### PR TITLE
support async endpoints

### DIFF
--- a/stac_fastapi_api/stac_fastapi/api/app.py
+++ b/stac_fastapi_api/stac_fastapi/api/app.py
@@ -16,10 +16,7 @@ from stac_fastapi.api.models import (
     SearchGetRequest,
     _create_request_model,
 )
-from stac_fastapi.api.routes import (
-    create_endpoint_from_model,
-    create_endpoint_with_depends,
-)
+from stac_fastapi.api.routes import create_endpoint
 
 # TODO: make this module not depend on `stac_fastapi.extensions`
 from stac_fastapi.extensions.core import FieldsExtension
@@ -102,9 +99,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint_with_depends(
-                self.client.landing_page, EmptyRequest
-            ),
+            endpoint=create_endpoint(self.client.landing_page, EmptyRequest),
         )
         router.add_api_route(
             name="Conformance Classes",
@@ -113,9 +108,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint_with_depends(
-                self.client.conformance, EmptyRequest
-            ),
+            endpoint=create_endpoint(self.client.conformance, EmptyRequest),
         )
         router.add_api_route(
             name="Get Item",
@@ -124,7 +117,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint_with_depends(self.client.get_item, ItemUri),
+            endpoint=create_endpoint(self.client.get_item, ItemUri),
         )
         router.add_api_route(
             name="Search",
@@ -133,9 +126,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["POST"],
-            endpoint=create_endpoint_from_model(
-                self.client.post_search, search_request_model
-            ),
+            endpoint=create_endpoint(self.client.post_search, search_request_model),
         ),
         router.add_api_route(
             name="Search",
@@ -144,9 +135,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint_with_depends(
-                self.client.get_search, SearchGetRequest
-            ),
+            endpoint=create_endpoint(self.client.get_search, SearchGetRequest),
         )
         router.add_api_route(
             name="Get Collections",
@@ -155,9 +144,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint_with_depends(
-                self.client.all_collections, EmptyRequest
-            ),
+            endpoint=create_endpoint(self.client.all_collections, EmptyRequest),
         )
         router.add_api_route(
             name="Get Collection",
@@ -166,9 +153,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint_with_depends(
-                self.client.get_collection, CollectionUri
-            ),
+            endpoint=create_endpoint(self.client.get_collection, CollectionUri),
         )
         router.add_api_route(
             name="Get ItemCollection",
@@ -177,9 +162,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint_with_depends(
-                self.client.item_collection, ItemCollectionUri
-            ),
+            endpoint=create_endpoint(self.client.item_collection, ItemCollectionUri),
         )
         self.app.include_router(router)
 

--- a/stac_fastapi_api/stac_fastapi/api/app.py
+++ b/stac_fastapi_api/stac_fastapi/api/app.py
@@ -1,5 +1,5 @@
 """fastapi app creation."""
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import attr
 from fastapi import APIRouter, FastAPI
@@ -57,6 +57,7 @@ class StacApi:
         default=attr.Factory(lambda: DEFAULT_STATUS_CODES)
     )
     app: FastAPI = attr.ib(default=attr.Factory(FastAPI))
+    endpoint_factory: Callable = attr.ib(default=create_endpoint)
 
     def get_extension(self, extension: Type[ApiExtension]) -> Optional[ApiExtension]:
         """Get an extension.
@@ -99,7 +100,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint(self.client.landing_page, EmptyRequest),
+            endpoint=self.endpoint_factory(self.client.landing_page, EmptyRequest),
         )
         router.add_api_route(
             name="Conformance Classes",
@@ -108,7 +109,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint(self.client.conformance, EmptyRequest),
+            endpoint=self.endpoint_factory(self.client.conformance, EmptyRequest),
         )
         router.add_api_route(
             name="Get Item",
@@ -117,7 +118,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint(self.client.get_item, ItemUri),
+            endpoint=self.endpoint_factory(self.client.get_item, ItemUri),
         )
         router.add_api_route(
             name="Search",
@@ -126,7 +127,9 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["POST"],
-            endpoint=create_endpoint(self.client.post_search, search_request_model),
+            endpoint=self.endpoint_factory(
+                self.client.post_search, search_request_model
+            ),
         ),
         router.add_api_route(
             name="Search",
@@ -135,7 +138,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint(self.client.get_search, SearchGetRequest),
+            endpoint=self.endpoint_factory(self.client.get_search, SearchGetRequest),
         )
         router.add_api_route(
             name="Get Collections",
@@ -144,7 +147,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint(self.client.all_collections, EmptyRequest),
+            endpoint=self.endpoint_factory(self.client.all_collections, EmptyRequest),
         )
         router.add_api_route(
             name="Get Collection",
@@ -153,7 +156,7 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint(self.client.get_collection, CollectionUri),
+            endpoint=self.endpoint_factory(self.client.get_collection, CollectionUri),
         )
         router.add_api_route(
             name="Get ItemCollection",
@@ -162,7 +165,9 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=create_endpoint(self.client.item_collection, ItemCollectionUri),
+            endpoint=self.endpoint_factory(
+                self.client.item_collection, ItemCollectionUri
+            ),
         )
         self.app.include_router(router)
 

--- a/stac_fastapi_api/stac_fastapi/api/routes.py
+++ b/stac_fastapi_api/stac_fastapi/api/routes.py
@@ -85,7 +85,7 @@ def create_async_endpoint(
             request_data: request_model = Depends(),  # type:ignore
         ):
             """Endpoint."""
-            resp = func(
+            resp = await func(
                 request=request, **request_data.kwargs()  # type:ignore
             )
             return resp
@@ -97,7 +97,7 @@ def create_async_endpoint(
             request_data: request_model,  # type:ignore
         ):
             """Endpoint."""
-            resp = func(request_data, request=request)
+            resp = await func(request_data, request=request)
             return resp
 
     return _endpoint

--- a/stac_fastapi_api/stac_fastapi/api/routes.py
+++ b/stac_fastapi_api/stac_fastapi/api/routes.py
@@ -31,7 +31,7 @@ def create_endpoint(
     Returns:
         callable: fastapi route which may be added to a router/application
     """
-    if isinstance(request_model, APIRequest):
+    if issubclass(request_model, APIRequest):
 
         def _endpoint(
             request: Request,
@@ -78,7 +78,7 @@ def create_async_endpoint(
     Returns:
         callable: fastapi route which may be added to a router/application
     """
-    if isinstance(request_model, APIRequest):
+    if issubclass(request_model, APIRequest):
 
         async def _endpoint(
             request: Request,

--- a/stac_fastapi_api/stac_fastapi/api/routes.py
+++ b/stac_fastapi_api/stac_fastapi/api/routes.py
@@ -9,7 +9,7 @@ from stac_fastapi.api.models import APIRequest
 
 
 def create_endpoint(
-    func: Callable, request_model: Type[Union[APIRequest, BaseModel]]
+    func: Callable, request_model: Union[Type[APIRequest], Type[BaseModel]]
 ) -> Callable:
     """Create a FastAPI endpoint.
 
@@ -57,7 +57,7 @@ def create_endpoint(
 
 
 def create_async_endpoint(
-    func: Callable, request_model: Type[Union[APIRequest, BaseModel]]
+    func: Callable, request_model: Union[Type[APIRequest], Type[BaseModel]]
 ) -> Callable:
     """Create a FastAPI endpoint.
 

--- a/stac_fastapi_api/stac_fastapi/api/routes.py
+++ b/stac_fastapi_api/stac_fastapi/api/routes.py
@@ -1,5 +1,5 @@
 """route factories."""
-from typing import Callable, Type
+from typing import Callable, Type, Union
 
 from fastapi import Depends
 from pydantic import BaseModel
@@ -8,61 +8,46 @@ from starlette.requests import Request
 from stac_fastapi.api.models import APIRequest
 
 
-# TODO: Only use one endpoint factory
-def create_endpoint_from_model(
-    func: Callable, request_model: Type[BaseModel]
+def create_endpoint(
+    func: Callable, request_model: Type[Union[APIRequest, BaseModel]]
 ) -> Callable:
-    """Create a FastAPI endpoint from pydantic model.
+    """Create a FastAPI endpoint.
 
-    Wrap a callable in a function which uses the desired request model.  It is expected
-    that the signature of the callable matches that of the request model.  This is best for validating
-    request bodies (ex. POST requests).
+    Accepts either an `stac_fastapi.api.models.APIRequest` or `pydantic.BaseModel`.
+
+    Pydantic models are good for validating request bodies (ex. POST requests), and expect the signature of the
+    callable matches that of the request model.
+
+    APIRequest is good for validating query/path parameters (ex. GET requests) and allows for FastAPI dependency
+    injection.  It is expected the that the return of `APIRequest.kwargs` matches that of the callable.
 
     Args:
         func: the wrapped function.
-        request_model: a pydantic model.
+        request_model: either `stac_fastapi.api.models.APIRequest` or `pydantic.BaseModel`.
 
     Returns:
         callable: fastapi route which may be added to a router/application
     """
+    if isinstance(request_model, APIRequest):
 
-    def _endpoint(
-        request: Request,
-        request_data: request_model,  # type:ignore
-    ):
-        """Endpoint."""
-        resp = func(request_data, request=request)
-        return resp
+        def _endpoint(
+            request: Request,
+            request_data: request_model = Depends(),  # type:ignore
+        ):
+            """Endpoint."""
+            resp = func(
+                request=request, **request_data.kwargs()  # type:ignore
+            )
+            return resp
 
-    return _endpoint
+    else:
 
-
-def create_endpoint_with_depends(
-    func: Callable,
-    request_model: Type[APIRequest],
-) -> Callable:
-    """Create a FastAPI endpoint from an `APIRequest` (dataclass).
-
-    Wrap a callable in a function which uses the desired `APIRequest` to define request parameters.  It is expected
-    that the return of `APIRequest.kwargs` matches that of the callable.  This works best for validating query/path
-    parameters (ex. GET request) and allows for dependency injection.
-
-    Args:
-        func: the wrapped function
-        request_model: subclass of `APIRequest`
-
-    Returns:
-        callable: fastapi route which may be added to a router/application
-    """
-
-    def _endpoint(
-        request: Request,
-        request_data: request_model = Depends(),  # type:ignore
-    ):
-        """Endpoint."""
-        resp = func(
-            request=request, **request_data.kwargs()  # type:ignore
-        )
-        return resp
+        def _endpoint(
+            request: Request,
+            request_data: request_model,  # type:ignore
+        ):
+            """Endpoint."""
+            resp = func(request_data, request=request)
+            return resp
 
     return _endpoint

--- a/stac_fastapi_api/stac_fastapi/api/routes.py
+++ b/stac_fastapi_api/stac_fastapi/api/routes.py
@@ -13,6 +13,9 @@ def create_endpoint(
 ) -> Callable:
     """Create a FastAPI endpoint.
 
+    This endpoint executes code in an external threadpool which is then awaited by the event loop.
+    https://fastapi.tiangolo.com/async/#path-operation-functions
+
     Accepts either an `stac_fastapi.api.models.APIRequest` or `pydantic.BaseModel`.
 
     Pydantic models are good for validating request bodies (ex. POST requests), and expect the signature of the
@@ -43,6 +46,53 @@ def create_endpoint(
     else:
 
         def _endpoint(
+            request: Request,
+            request_data: request_model,  # type:ignore
+        ):
+            """Endpoint."""
+            resp = func(request_data, request=request)
+            return resp
+
+    return _endpoint
+
+
+def create_async_endpoint(
+    func: Callable, request_model: Type[Union[APIRequest, BaseModel]]
+) -> Callable:
+    """Create a FastAPI endpoint.
+
+    This endpoint executes code using the event loop.
+
+    Accepts either an `stac_fastapi.api.models.APIRequest` or `pydantic.BaseModel`.
+
+    Pydantic models are good for validating request bodies (ex. POST requests), and expect the signature of the
+    callable matches that of the request model.
+
+    APIRequest is good for validating query/path parameters (ex. GET requests) and allows for FastAPI dependency
+    injection.  It is expected the that the return of `APIRequest.kwargs` matches that of the callable.
+
+    Args:
+        func: the wrapped function.
+        request_model: either `stac_fastapi.api.models.APIRequest` or `pydantic.BaseModel`.
+
+    Returns:
+        callable: fastapi route which may be added to a router/application
+    """
+    if isinstance(request_model, APIRequest):
+
+        async def _endpoint(
+            request: Request,
+            request_data: request_model = Depends(),  # type:ignore
+        ):
+            """Endpoint."""
+            resp = func(
+                request=request, **request_data.kwargs()  # type:ignore
+            )
+            return resp
+
+    else:
+
+        async def _endpoint(
             request: Request,
             request_data: request_model,  # type:ignore
         ):

--- a/stac_fastapi_extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi_extensions/stac_fastapi/extensions/core/transaction.py
@@ -1,13 +1,12 @@
 """transaction extension."""
+from typing import Callable
+
 import attr
 from fastapi import APIRouter, FastAPI
 from stac_pydantic import Collection, Item
 
 from stac_fastapi.api.models import CollectionUri, ItemUri, _create_request_model
-from stac_fastapi.api.routes import (
-    create_endpoint_from_model,
-    create_endpoint_with_depends,
-)
+from stac_fastapi.api.routes import create_endpoint
 from stac_fastapi.types.core import BaseTransactionsClient
 from stac_fastapi.types.extension import ApiExtension
 
@@ -32,6 +31,7 @@ class TransactionExtension(ApiExtension):
     """
 
     client: BaseTransactionsClient = attr.ib()
+    endpoint_factory: Callable = attr.ib(default=create_endpoint)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.
@@ -53,9 +53,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["POST"],
-            endpoint=create_endpoint_from_model(
-                self.client.create_item, item_request_model
-            ),
+            endpoint=self.endpoint_factory(self.client.create_item, item_request_model),
         )
         router.add_api_route(
             name="Update Item",
@@ -64,9 +62,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["PUT"],
-            endpoint=create_endpoint_from_model(
-                self.client.update_item, item_request_model
-            ),
+            endpoint=self.endpoint_factory(self.client.update_item, item_request_model),
         )
         router.add_api_route(
             name="Delete Item",
@@ -75,7 +71,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["DELETE"],
-            endpoint=create_endpoint_with_depends(self.client.delete_item, ItemUri),
+            endpoint=self.endpoint_factory(self.client.delete_item, ItemUri),
         )
         router.add_api_route(
             name="Create Collection",
@@ -84,7 +80,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["POST"],
-            endpoint=create_endpoint_from_model(
+            endpoint=self.endpoint_factory(
                 self.client.create_collection, collection_request_model
             ),
         )
@@ -95,7 +91,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["PUT"],
-            endpoint=create_endpoint_from_model(
+            endpoint=self.endpoint_factory(
                 self.client.update_collection, collection_request_model
             ),
         )
@@ -106,7 +102,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["DELETE"],
-            endpoint=create_endpoint_with_depends(
+            endpoint=self.endpoint_factory(
                 self.client.delete_collection, CollectionUri
             ),
         )

--- a/stac_fastapi_extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi_extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -1,6 +1,6 @@
 """bulk transactions extension."""
 import abc
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import attr
 from fastapi import APIRouter, FastAPI
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from stac_pydantic import Item
 
 from stac_fastapi.api.models import _create_request_model
-from stac_fastapi.api.routes import create_endpoint_from_model
+from stac_fastapi.api.routes import create_endpoint
 from stac_fastapi.types.extension import ApiExtension
 
 
@@ -57,6 +57,7 @@ class BulkTransactionExtension(ApiExtension):
     """
 
     client: BaseBulkTransactionsClient = attr.ib()
+    endpoint_factory: Callable = attr.ib(default=create_endpoint)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.
@@ -77,7 +78,7 @@ class BulkTransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["POST"],
-            endpoint=create_endpoint_from_model(
+            endpoint=self.endpoint_factory(
                 self.client.bulk_item_insert, items_request_model
             ),
         )

--- a/stac_fastapi_extensions/stac_fastapi/extensions/third_party/tiles.py
+++ b/stac_fastapi_extensions/stac_fastapi/extensions/third_party/tiles.py
@@ -1,6 +1,6 @@
 """tiles extension."""
 import abc
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Union
 from urllib.parse import urljoin
 
 import attr
@@ -12,7 +12,7 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse
 
 from stac_fastapi.api.models import ItemUri
-from stac_fastapi.api.routes import create_endpoint_with_depends
+from stac_fastapi.api.routes import create_endpoint
 from stac_fastapi.types.core import BaseCoreClient
 from stac_fastapi.types.extension import ApiExtension
 
@@ -165,6 +165,7 @@ class TilesExtension(ApiExtension):
 
     client: BaseTilesClient = attr.ib()
     route_prefix: str = attr.ib(default="/titiler")
+    endpoint_factory: Callable = attr.ib(default=create_endpoint)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.
@@ -202,6 +203,6 @@ class TilesExtension(ApiExtension):
             response_model_exclude_none=True,
             response_model_exclude_unset=True,
             methods=["GET"],
-            endpoint=create_endpoint_with_depends(self.client.get_item_tiles, ItemUri),
+            endpoint=self.endpoint_factory(self.client.get_item_tiles, ItemUri),
             tags=["OGC Tiles"],
         )


### PR DESCRIPTION
Adds support for async endpoints, required if the client code is async (ex. asyncpg).

This adds the `endpoint_factory` instance attribute everywhere we are creating routes (the main API, transactions/tiles/bulk_transactions extensions).  It allows the caller to specify their own endpoint factory.  Also added is the `create_async_endpoint` function uses `async def` route handlers.  The attribute defaults to using sync route handlers, but this may change if the sqlalchemy implementation is upgraded to 1.4 which does support async.

```python
from stac_fastapi.api.app import StacApi
from stac_fastapi.api.routes import create_async_endpoint

api = StacApi(
    ...,
    endpoint_factory=create_async_endpoint
)
app = api.app
```

cc @bitner 

Closes #116 #69 