### PR TITLE
Fix docker-compose usage of ingest_joplin.py.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     volumes:
       - ./:/app
     command: >
-      bash -c "sleep 10 && alembic upgrade head && python scripts/ingest_joplin.py"
+      bash -c "sleep 10 && alembic upgrade head && python /app/scripts/ingest_joplin.py"
     depends_on:
       - database
       - app

--- a/scripts/ingest_joplin.py
+++ b/scripts/ingest_joplin.py
@@ -1,6 +1,6 @@
 """Ingest sample data during docker-compose"""
 import json
-import os
+from pathlib import Path
 from urllib.parse import urljoin
 
 import requests
@@ -9,17 +9,17 @@ bucket = "arturo-stac-api-test-data"
 app_host = "http://app:8081"
 
 
-def ingest_joplin_data(data_dir="/app/tests/data/joplin"):
+def ingest_joplin_data(data_dir=Path.cwd() / "tests" / "data" / "joplin"):
     """ingest data."""
 
-    with open(os.path.join(data_dir, "collection.json")) as f:
+    with open(data_dir / "collection.json") as f:
         collection = json.load(f)
 
     r = requests.post(urljoin(app_host, "/collections"), json=collection)
     if r.status_code not in (200, 409):
         r.raise_for_status()
 
-    with open(os.path.join(data_dir, "index.geojson")) as f:
+    with open(data_dir / "index.geojson") as f:
         index = json.load(f)
 
     for feat in index["features"]:


### PR DESCRIPTION
Hey all! 👋🏽 

This PR fixes an issue I noticed with the local dev instructions in the Readme: While `make docker-run` works fine, the `docker-compose up` does not work, it fails on the migration script:

```
migration_1  | INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
migration_1  | INFO  [alembic.runtime.migration] Will assume transactional DDL.
migration_1  | INFO  [alembic.runtime.migration] Running upgrade  -> 131aab4d9e49, create initial schema
migration_1  | INFO  [alembic.runtime.migration] Running upgrade 131aab4d9e49 -> 77c019af60bf, use timestamptz rather than timestamp
migration_1  | python: can't open file 'scripts/ingest_joplin.py': [Errno 2] No such file or directory
stac-fastapi_migration_1 exited with code 2
```

With this PR changes, `docker-compose up` works again, and the log looks like :

```
…
stac-fastapi | INFO:     172.19.0.4:39196 - "POST /collections/joplin/items HTTP/1.1" 200 OK
stac-fastapi | INFO:     172.19.0.4:39198 - "POST /collections/joplin/items HTTP/1.1" 200 OK
stac-fastapi | INFO:     172.19.0.4:39200 - "POST /collections/joplin/items HTTP/1.1" 200 OK
stac-fastapi_migration_1 exited with code 0  
```