### PR TITLE
Prototype model customization

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -1,9 +1,10 @@
 """fastapi app creation."""
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Union
 
 import attr
 from fastapi import APIRouter, FastAPI
 from fastapi.openapi.utils import get_openapi
+from starlette.responses import JSONResponse
 from stac_pydantic import Collection, Item, ItemCollection
 from stac_pydantic.api import ConformanceClasses, LandingPage
 
@@ -92,12 +93,25 @@ class StacApi:
         Returns:
             None
         """
+
+        # Registering the custom pydantic models
+        if hasattr(settings, "custom_models"):
+            item_class = settings.custom_models["pydantic"]["item"] if settings.custom_models["pydantic"]["item"] else Item
+        else:
+            item_class = Item
+
+        if hasattr(settings, "custom_models"):
+            collection_class = settings.custom_models["pydantic"]["collection"] if settings.custom_models["pydantic"]["collection"] else Collection
+        else:
+            collection_class = Collection
+
         search_request_model = _create_request_model(STACSearch)
         fields_ext = self.get_extension(FieldsExtension)
         router = APIRouter()
         router.add_api_route(
             name="Landing Page",
             path="/",
+            response_class=JSONResponse,
             response_model=LandingPage,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
@@ -109,6 +123,7 @@ class StacApi:
         router.add_api_route(
             name="Conformance Classes",
             path="/conformance",
+            response_class=JSONResponse,
             response_model=ConformanceClasses,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
@@ -120,7 +135,8 @@ class StacApi:
         router.add_api_route(
             name="Get Item",
             path="/collections/{collectionId}/items/{itemId}",
-            response_model=Item,
+            response_class=JSONResponse,
+            response_model=item_class,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
@@ -129,6 +145,7 @@ class StacApi:
         router.add_api_route(
             name="Search",
             path="/search",
+            response_class=JSONResponse,
             response_model=ItemCollection if not fields_ext else None,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
@@ -140,6 +157,7 @@ class StacApi:
         router.add_api_route(
             name="Search",
             path="/search",
+            response_class=JSONResponse,
             response_model=ItemCollection if not fields_ext else None,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
@@ -151,7 +169,8 @@ class StacApi:
         router.add_api_route(
             name="Get Collections",
             path="/collections",
-            response_model=List[Collection],
+            response_class=JSONResponse,
+            response_model=List[collection_class],
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
@@ -162,7 +181,8 @@ class StacApi:
         router.add_api_route(
             name="Get Collection",
             path="/collections/{collectionId}",
-            response_model=Collection,
+            response_class=JSONResponse,
+            response_model=collection_class,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
@@ -173,6 +193,7 @@ class StacApi:
         router.add_api_route(
             name="Get ItemCollection",
             path="/collections/{collectionId}/items",
+            response_class=JSONResponse,
             response_model=ItemCollection,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -95,13 +95,13 @@ class StacApi:
         """
 
         # Registering the custom pydantic models
-        if hasattr(settings, "custom_models"):
-            item_class = settings.custom_models["pydantic"]["item"] if settings.custom_models["pydantic"]["item"] else Item
+        if hasattr(self.settings, "custom_models"):
+            item_class = self.settings.custom_models["pydantic"]["item"] if self.settings.custom_models["pydantic"]["item"] else Item
         else:
             item_class = Item
 
-        if hasattr(settings, "custom_models"):
-            collection_class = settings.custom_models["pydantic"]["collection"] if settings.custom_models["pydantic"]["collection"] else Collection
+        if hasattr(self.settings, "custom_models"):
+            collection_class = self.settings.custom_models["pydantic"]["collection"] if self.settings.custom_models["pydantic"]["collection"] else Collection
         else:
             collection_class = Collection
 

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -70,7 +70,7 @@ class ItemUri(CollectionUri):
 
     def kwargs(self) -> Dict:
         """kwargs."""
-        return {"id": self.itemId}
+        return {"collection_id": self.collectionId, "item_id": self.itemId}
 
 
 @attr.s

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -47,7 +47,7 @@ def create_endpoint_from_model(
     ):
         """Endpoint."""
         resp = func(request_data, request=request)
-        return response_class()(resp.dict(by_alias=True))
+        return response_class()(resp.dict(by_alias=True, exclude_none=True))
 
     return _endpoint
 
@@ -78,6 +78,6 @@ def create_endpoint_with_depends(
         resp = func(
             request=request, **request_data.kwargs()  # type:ignore
         )
-        return response_class()(resp.dict(by_alias=True))
+        return response_class()(resp.dict(by_alias=True, exclude_none=True))
 
     return _endpoint

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -47,7 +47,7 @@ def create_endpoint_from_model(
     ):
         """Endpoint."""
         resp = func(request_data, request=request)
-        return response_class()(resp.dict())
+        return response_class()(resp.dict(by_alias=True))
 
     return _endpoint
 
@@ -78,6 +78,6 @@ def create_endpoint_with_depends(
         resp = func(
             request=request, **request_data.kwargs()  # type:ignore
         )
-        return response_class()(resp.dict())
+        return response_class()(resp.dict(by_alias=True))
 
     return _endpoint

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/app.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/app.py
@@ -19,16 +19,25 @@ from stac_fastapi.sqlalchemy.models import database, schemas
 import sqlalchemy as sa
 
 
+def triple_underscore_to_colon(string: str) -> str:
+    return string.replace("___", ":")
+
 # Pydantic model extensions (which define responses and documentation)
 class ScientificCitationItem(schemas.Item):
-    sci_doi: str = "default_doi"
-    sci_citation: str = "default_citation"
-    sci_publications: str = "publication1, publication2, publication3"
+    sci___doi: str = "default_doi"
+    sci___citation: str = "default_citation"
+    sci___publications: str = "publication1, publication2, publication3"
+
+    class Config:
+        alias_generator = triple_underscore_to_colon
 
 class ScientificCitationCollection(schemas.Collection):
-    sci_doi: str = "default_doi"
-    sci_citation: str = "default_citation"
-    sci_publications: str = "publication1, publication2, publication3"
+    sci___doi: str = "default_doi"
+    sci___citation: str = "default_citation"
+    sci___publications: str = "publication1, publication2, publication3"
+
+    class Config:
+        alias_generator = triple_underscore_to_colon
 
 """SqlAlchemy model extensions (which define database interactions)
     These classes are currently not used, as they result in errors without

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/app.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/app.py
@@ -15,7 +15,48 @@ from stac_fastapi.sqlalchemy.transactions import (
     TransactionsClient,
 )
 
-settings = SqlalchemySettings()
+from stac_fastapi.sqlalchemy.models import database, schemas
+import sqlalchemy as sa
+
+
+# Pydantic model extensions (which define responses and documentation)
+class ScientificCitationItem(schemas.Item):
+    sci_doi: str = "default_doi"
+    sci_citation: str = "default_citation"
+    sci_publications: str = "publication1, publication2, publication3"
+
+class ScientificCitationCollection(schemas.Collection):
+    sci_doi: str = "default_doi"
+    sci_citation: str = "default_citation"
+    sci_publications: str = "publication1, publication2, publication3"
+
+"""SqlAlchemy model extensions (which define database interactions)
+    These classes are currently not used, as they result in errors without
+    modifications to the database and joplin ingest; provided here as
+    demonstration of a possible customization strategy for this backend
+"""
+class ScientificCitationItemDB(database.Item):
+    sci_doi = sa.Column(sa.VARCHAR(300))
+    sci_citation = sa.Column(sa.VARCHAR(300))
+    sci_publications = sa.Column(sa.VARCHAR(300))
+
+class ScientificCitationCollectionDB(database.Collection):
+    sci_doi = sa.Column(sa.VARCHAR(300))
+    sci_citation = sa.Column(sa.VARCHAR(300))
+    sci_publications = sa.Column(sa.VARCHAR(300))
+
+custom_models = {
+    "pydantic": {
+        "item": ScientificCitationItem,
+        "collection": ScientificCitationCollection
+    },
+    "sqlalchemy": {
+        "item": ScientificCitationItemDB,
+        "collection": ScientificCitationCollectionDB
+    }
+}
+
+settings = SqlalchemySettings(custom_models=custom_models)
 session = Session.create_from_settings(settings)
 api = StacApi(
     settings=settings,
@@ -26,6 +67,6 @@ api = StacApi(
         QueryExtension(),
         SortExtension(),
     ],
-    client=CoreCrudClient(session=session),
+    client=CoreCrudClient(session=session)
 )
 app = api.app

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/config.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/config.py
@@ -1,5 +1,5 @@
 """Postgres API configuration."""
-from typing import Set
+from typing import Set, Dict, Any
 
 from stac_fastapi.types.config import ApiSettings
 
@@ -22,6 +22,8 @@ class SqlalchemySettings(ApiSettings):
     postgres_host_writer: str
     postgres_port: str
     postgres_dbname: str
+
+    custom_models: Dict[str, Any]
 
     # Fields which are defined by STAC but not included in the database model
     forbidden_fields: Set[str] = {"type"}

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -42,8 +42,6 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
     item_table: Type[database.Item] = attr.ib(default=database.Item)
     collection_table: Type[database.Collection] = attr.ib(default=database.Collection)
 
-
-
     @staticmethod
     def _lookup_id(
         id: str, table: Type[database.BaseModel], session: SqlSession


### PR DESCRIPTION
This draft PR is not meant for merger but to provide an example of what would be necessary under the current `SqlAlchemy` backend to support model customization. This draft is relevant for further investigating a solution to #58 and #121.

At issue is the fact that some properties in STAC `Item`s and `Collection`s are meant to live at the top level of said `Item`s and `Collection`s - full-fledged STAC extensions but also the grey area of custom models which are technically not fully implemented as STAC extensions. Providing top level support of this kind means subclassing the Pydantic models used by `stac-fastapi` to provide type information for `fastapi`'s automatic documentation generation. Unfortunately, this concession doesn't neatly fit for a few reasons. These limitations are discussed below. First, some example output from the collections endpoint as instantiated by `Docker Compose`:

```json
{
  "id":"joplin",
  "description":"This imagery was acquired by the NOAA Remote Sensing Division to support NOAA national security and emergency response requirements. In addition, it will be used for ongoing research efforts for testing and developing standards for airborne digital imagery. Individual images have been combined into a larger mosaic and tiled for distribution. The approximate ground sample distance (GSD) for each pixel is 35 cm (1.14 feet).",
  "stac_version":"1.0.0-beta.2",
  "links":[
    {
      "href":"http://localhost:8081/collections/joplin",
      "rel":"self",
      "type":"application/json",
      "title":null,
      "label":null
    },
    {
      "href":"http://localhost:8081/",
      "rel":"parent",
      "type":"application/json",
      "title":null,
      "label":null
    },
    {
      "href":"http://localhost:8081/collections/joplin/items",
      "rel":"item",
      "type":"application/geo+json",
      "title":null,
      "label":null
    },
    {
      "href":"http://localhost:8081/",
      "rel":"root",
      "type":"application/json",
      "title":null,
      "label":null
    }
  ],
  "stac_extensions":[
    
  ],
  "title":null,
  "license":"public-domain",
  "extent":{
    "spatial":{
      "bbox":[
        [
          -94.6911621,
          37.0332547,
          -94.402771,
          37.1077651
        ]
      ]
    },
    "temporal":{
      "interval":[
        [
          "2000-02-01T00:00:00Z",
          "2000-02-12T00:00:00Z"
        ]
      ]
    }
  },
  "keywords":null,
  "providers":null,
  "summaries":null,
  "sci_doi":"default_doi",
  "sci_citation":"default_citation",
  "sci_publications":"publication1, publication2, publication3"
}
```

## Pressing Issues (both of these have been resolved as discussed in the comments below)

### Type information determines response fields (outdated)

This issue is avoided with `exclude_none` as pointed out by @kylebarron. `exclude_unset`, which I had previously tried appears not to be the answer.

In the above JSON, a host of `null` values are apparent which are not normally provided and which are not desirable. These are seen here because of a change introduced in `router.py` to ensure that fields unique to subclasses of `Collection` and `Item` are returned in responses. Without first turning pydantic instances into dictionaries, only fields provided on `Item` and `Collection` are found in the response. Perhaps a `pretty_dict` method could be required up the inheritance chain to avoid this ugliness.

### Incorrect field names (outdated)

This issue can be avoided with aliases, though [the solution](https://pydantic-docs.helpmanual.io/usage/model_config/#alias-generator) might introduce some difficulties in complex cases.

The STAC scientific extension uses ":" instead of "_" to separate "sci" from "doi", "citation", and "publications". As pydantic models are simply python classes, field names can't include ":". To accommodate python, field names containing ":" will need to be systematically rewritten. Dictionaries can avoid this limitation but they do so at the cost of losing valuable type information. A solution to this problem which preserves use of pydantic is not apparent beyond users specifying transformations of field names inside the previously mentioned, speculative `pretty_dict` method.