### PR TITLE
Include collection ID in ItemURI

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -70,7 +70,7 @@ class ItemUri(CollectionUri):
 
     def kwargs(self) -> Dict:
         """kwargs."""
-        return {"id": self.itemId}
+        return {"collection_id": self.collectionId, "item_id": self.itemId}
 
 
 @attr.s

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
@@ -108,7 +108,7 @@ class BaseTilesClient(abc.ABC):
 
     @abc.abstractmethod
     def get_item_tiles(
-        self, id: str, **kwargs
+        self, item_id: str, collection_id: str, **kwargs
     ) -> Union[RedirectResponse, TileSetResource]:
         """Get OGC TileSet resource for a stac item.
 
@@ -135,7 +135,7 @@ class TilesClient(BaseTilesClient):
     route_prefix: str = attr.ib(default="/titiler")
 
     def get_item_tiles(
-        self, id: str, **kwargs
+        self, item_id: str, collection_id: str, **kwargs
     ) -> Union[RedirectResponse, TileSetResource]:
         """Get OGC TileSet resource for a stac item."""
         item = self.client.get_item(id, **kwargs)

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
@@ -138,7 +138,7 @@ class TilesClient(BaseTilesClient):
         self, item_id: str, collection_id: str, **kwargs
     ) -> Union[RedirectResponse, TileSetResource]:
         """Get OGC TileSet resource for a stac item."""
-        item = self.client.get_item(id, **kwargs)
+        item = self.client.get_item(item_id, collection_id, **kwargs)
         resource = TileSetResource(
             extent=SpatialExtent(bbox=[list(item.bbox)]),
             title=f"Tiled layer of {item.collection}/{item.id}",

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -186,10 +186,10 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                 links=links,
             )
 
-    def get_item(self, id: str, **kwargs) -> schemas.Item:
+    def get_item(self, item_id: str, **kwargs) -> schemas.Item:
         """Get item by id."""
         with self.session.reader.context_session() as session:
-            item = self._lookup_id(id, self.item_table, session)
+            item = self._lookup_id(item_id, self.item_table, session)
             item.base_url = str(kwargs["request"].base_url)
             return schemas.Item.from_orm(item)
 

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -186,7 +186,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                 links=links,
             )
 
-    def get_item(self, item_id: str, **kwargs) -> schemas.Item:
+    def get_item(self, item_id: str, collection_id: str, **kwargs) -> schemas.Item:
         """Get item by id."""
         with self.session.reader.context_session() as session:
             item = self._lookup_id(item_id, self.item_table, session)

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
@@ -78,10 +78,10 @@ class TransactionsClient(BaseTransactionsClient):
             query.update(data)
         return model
 
-    def delete_item(self, id: str, **kwargs) -> schemas.Item:
+    def delete_item(self, item_id: str, collection_id: str, **kwargs) -> schemas.Item:
         """Delete item."""
         with self.session.writer.context_session() as session:
-            query = session.query(self.item_table).filter(self.item_table.id == id)
+            query = session.query(self.item_table).filter(self.item_table.id == item_id)
             data = query.first()
             if not data:
                 raise NotFoundError(f"Item {id} not found")

--- a/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
+++ b/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
@@ -111,7 +111,9 @@ def test_create_item(
     postgres_transactions.create_collection(coll, request=MockStarletteRequest)
     item = Item.parse_obj(load_test_data("test_item.json"))
     postgres_transactions.create_item(item, request=MockStarletteRequest)
-    resp = postgres_core.get_item(item.id, request=MockStarletteRequest)
+    resp = postgres_core.get_item(
+        item.id, item.collection, request=MockStarletteRequest
+    )
     assert item.dict(
         exclude={"links": ..., "properties": {"created", "updated"}}
     ) == resp.dict(exclude={"links": ..., "properties": {"created", "updated"}})
@@ -146,7 +148,9 @@ def test_update_item(
     item.properties.foo = "bar"
     postgres_transactions.update_item(item, request=MockStarletteRequest)
 
-    updated_item = postgres_core.get_item(item.id, request=MockStarletteRequest)
+    updated_item = postgres_core.get_item(
+        item.id, item.collection, request=MockStarletteRequest
+    )
     assert updated_item.properties.foo == "bar"
 
 
@@ -161,10 +165,12 @@ def test_delete_item(
     item = Item.parse_obj(load_test_data("test_item.json"))
     postgres_transactions.create_item(item, request=MockStarletteRequest)
 
-    postgres_transactions.delete_item(item.id, request=MockStarletteRequest)
+    postgres_transactions.delete_item(
+        item.id, item.collection, request=MockStarletteRequest
+    )
 
     with pytest.raises(NotFoundError):
-        postgres_core.get_item(item.id, request=MockStarletteRequest)
+        postgres_core.get_item(item.id, item.collection, request=MockStarletteRequest)
 
 
 def test_bulk_item_insert(
@@ -186,7 +192,9 @@ def test_bulk_item_insert(
     postgres_bulk_transactions.bulk_item_insert(Items(items=items))
 
     for item in items:
-        postgres_transactions.delete_item(item["id"], request=MockStarletteRequest)
+        postgres_transactions.delete_item(
+            item["id"], item["collection"], request=MockStarletteRequest
+        )
 
 
 def test_bulk_item_insert_chunked(
@@ -208,4 +216,6 @@ def test_bulk_item_insert_chunked(
     postgres_bulk_transactions.bulk_item_insert(Items(items=items), chunk_size=2)
 
     for item in items:
-        postgres_transactions.delete_item(item["id"], request=MockStarletteRequest)
+        postgres_transactions.delete_item(
+            item["id"], item["collection"], request=MockStarletteRequest
+        )

--- a/stac_fastapi/sqlalchemy/tests/conftest.py
+++ b/stac_fastapi/sqlalchemy/tests/conftest.py
@@ -47,7 +47,9 @@ def cleanup(postgres_core: CoreCrudClient, postgres_transactions: TransactionsCl
                 coll.id, limit=100, request=MockStarletteRequest
             )
             for feat in items.features:
-                postgres_transactions.delete_item(feat.id, request=MockStarletteRequest)
+                postgres_transactions.delete_item(
+                    feat.id, feat.collection, request=MockStarletteRequest
+                )
 
             # Delete the collection
             postgres_transactions.delete_collection(

--- a/stac_fastapi/sqlalchemy/tests/features/test_tiles_extension.py
+++ b/stac_fastapi/sqlalchemy/tests/features/test_tiles_extension.py
@@ -30,7 +30,9 @@ def tiles_extension_app(postgres_core, postgres_transactions, load_test_data):
         yield test_app
 
     # Cleanup test data
-    postgres_transactions.delete_item(item.id, request=MockStarletteRequest)
+    postgres_transactions.delete_item(
+        item.id, item.collection, request=MockStarletteRequest
+    )
     postgres_transactions.delete_collection(coll.id, request=MockStarletteRequest)
 
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -48,7 +48,7 @@ class BaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def delete_item(self, id: str, **kwargs) -> Item:
+    def delete_item(self, item_id: str, collection_id: str, **kwargs) -> Item:
         """Delete an item from a collection.
 
         Called with `DELETE /collections/{collectionId}/items/{itemId}`
@@ -180,7 +180,7 @@ class BaseCoreClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_item(self, id: str, **kwargs) -> Item:
+    def get_item(self, item_id: str, collection_id: str, **kwargs) -> Item:
         """Get item by id.
 
         Called with `GET /collections/{collectionId}/items/{itemId}`.


### PR DESCRIPTION
This PR ensures all URL parameters provided to get a STAC item are available for implementing `get_item` methods. Previously, only the item id was available.

Closes #135