### PR TITLE
Add title configuration to service and core client

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -60,6 +60,8 @@ class StacApi:
         default=attr.Factory(lambda: DEFAULT_STATUS_CODES)
     )
     app: FastAPI = attr.ib(default=attr.Factory(FastAPI))
+    title: str = attr.ib(default="Arturo STAC API")
+    version: str = attr.ib(default="0.1")
 
     def get_extension(self, extension: Type[ApiExtension]) -> Optional[ApiExtension]:
         """Get an extension.
@@ -190,7 +192,7 @@ class StacApi:
 
         # TODO: parametrize
         openapi_schema = get_openapi(
-            title="Arturo STAC API", version="0.1", routes=self.app.routes
+            title=self.title, version=self.version, routes=self.app.routes
         )
 
         self.app.openapi_schema = openapi_schema

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -190,7 +190,6 @@ class StacApi:
         if self.app.openapi_schema:
             return self.app.openapi_schema
 
-        # TODO: parametrize
         openapi_schema = get_openapi(
             title=self.title, version=self.version, routes=self.app.routes
         )

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -36,7 +36,6 @@ NumType = Union[float, int]
 @attr.s
 class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
     """Client for core endpoints defined by stac."""
-
     landing_page_id: str = attr.ib(default="stac-api")
     title: str = attr.ib(default="Arturo STAC API")
     description: str = attr.ib(default="Arturo raster datastore")
@@ -58,8 +57,6 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
         """Landing page."""
         base_url = str(kwargs["request"].base_url)
         landing_page = LandingPage(
-            title=self.title,
-            description=self.description,
             id=self.landing_page_id,
             title=self.title,
             description=self.description,

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -37,6 +37,8 @@ NumType = Union[float, int]
 class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
     """Client for core endpoints defined by stac."""
 
+    title: str = attr.ib(default="Arturo STAC API")
+    description: str = attr.ib(default="Arturo raster datastore")
     session: Session = attr.ib(default=attr.Factory(Session.create_from_env))
     item_table: Type[database.Item] = attr.ib(default=database.Item)
     collection_table: Type[database.Collection] = attr.ib(default=database.Collection)
@@ -54,8 +56,8 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
     def landing_page(self, **kwargs) -> LandingPage:
         """Landing page."""
         landing_page = LandingPage(
-            title="Arturo STAC API",
-            description="Arturo raster datastore",
+            title=self.title,
+            description=self.description,
             links=[
                 Link(
                     rel=Relations.self,

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -36,6 +36,7 @@ NumType = Union[float, int]
 @attr.s
 class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
     """Client for core endpoints defined by stac."""
+
     landing_page_id: str = attr.ib(default="stac-api")
     title: str = attr.ib(default="Arturo STAC API")
     description: str = attr.ib(default="Arturo raster datastore")


### PR DESCRIPTION
This PR adds configurability for title, version, and description.

These changes are fairly straightforward but, as a result of the fact that `client` is a required (non-default) argument, it is not possible to thread a single title through from service to client. It might be more sensible to put title, version, and description on the settings object to avoid duplication. On the other hand, it might be useful to allow OpenAPI and the LandingPage to have different titles. Thoughts?

Closes #136