### PR TITLE
Include unset (default) fields on landing page response

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -99,7 +99,7 @@ class StacApi:
             name="Landing Page",
             path="/",
             response_model=LandingPage,
-            response_model_exclude_unset=True,
+            response_model_exclude_unset=False,
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=create_endpoint_with_depends(


### PR DESCRIPTION
This PR ensures that `stac_version` is returned in the `LandingPage` response. As a default argument, it is (according to pydantic) unset; thus, we unset fields should not be excluded.

```json
{
  "description":"Arturo raster datastore",
  "title":"Arturo STAC API",
  "stac_version":"1.0.0-beta.2",
  "links":[
    {
      "href":"http://localhost:8081/",
      "rel":"self",
      "type":"application/json"
    },
    {
      "href":"http://localhost:8081/docs",
      "rel":"docs",
      "type":"text/html",
      "title":"OpenAPI docs"
    },
    {
      "href":"http://localhost:8081/conformance",
      "rel":"conformance",
      "type":"application/json",
      "title":"STAC/WFS3 conformance classes implemented by this server"
    },
    {
      "href":"http://localhost:8081/search",
      "rel":"search",
      "type":"application/geo+json",
      "title":"STAC search"
    },
    {
      "href":"http://localhost:8081/collections/joplin",
      "rel":"child",
      "type":"application/json"
    }
  ]
}
```

Closes #137