### PR TITLE
Avoid use of leading slash for urljoins

### DIFF
--- a/scripts/ingest_joplin.py
+++ b/scripts/ingest_joplin.py
@@ -15,7 +15,7 @@ def ingest_joplin_data(data_dir=Path.cwd() / "tests" / "data" / "joplin"):
     with open(data_dir / "collection.json") as f:
         collection = json.load(f)
 
-    r = requests.post(urljoin(app_host, "/collections"), json=collection)
+    r = requests.post(urljoin(app_host, "collections"), json=collection)
     if r.status_code not in (200, 409):
         r.raise_for_status()
 
@@ -25,7 +25,7 @@ def ingest_joplin_data(data_dir=Path.cwd() / "tests" / "data" / "joplin"):
     for feat in index["features"]:
         del feat["stac_extensions"]
         r = requests.post(
-            urljoin(app_host, f"/collections/{collection['id']}/items"), json=feat
+            urljoin(app_host, f"collections/{collection['id']}/items"), json=feat
         )
         if r.status_code == 409:
             continue

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
@@ -45,7 +45,7 @@ class TileLinks:
         """Post init handler."""
         self.item_uri = urljoin(
             self.base_url,
-            f"/collections/{self.collection_id}/items/{self.item_id}",
+            f"collections/{self.collection_id}/items/{self.item_id}",
         )
 
     def tiles(self) -> OGCTileLink:

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -66,19 +66,19 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     rel=Relations.docs,
                     type=MimeTypes.html,
                     title="OpenAPI docs",
-                    href=urljoin(str(kwargs["request"].base_url), "/docs"),
+                    href=urljoin(str(kwargs["request"].base_url), "docs"),
                 ),
                 Link(
                     rel=Relations.conformance,
                     type=MimeTypes.json,
                     title="STAC/WFS3 conformance classes implemented by this server",
-                    href=urljoin(str(kwargs["request"].base_url), "/conformance"),
+                    href=urljoin(str(kwargs["request"].base_url), "conformance"),
                 ),
                 Link(
                     rel=Relations.search,
                     type=MimeTypes.geojson,
                     title="STAC search",
-                    href=urljoin(str(kwargs["request"].base_url), "/search"),
+                    href=urljoin(str(kwargs["request"].base_url), "search"),
                 ),
             ],
         )

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/links.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/links.py
@@ -26,7 +26,7 @@ class BaseLinks:
     def root(self) -> Link:
         """Return the catalog root."""
         return Link(
-            rel=Relations.root, type=MimeTypes.json, href=urljoin(self.base_url, "/")
+            rel=Relations.root, type=MimeTypes.json, href=self.base_url
         )
 
 
@@ -39,13 +39,13 @@ class CollectionLinks(BaseLinks):
         return Link(
             rel=Relations.self,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"/collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
         )
 
     def parent(self) -> Link:
         """Create the `parent` link."""
         return Link(
-            rel=Relations.parent, type=MimeTypes.json, href=urljoin(self.base_url, "/")
+            rel=Relations.parent, type=MimeTypes.json, href=self.base_url
         )
 
     def item(self) -> Link:
@@ -53,7 +53,7 @@ class CollectionLinks(BaseLinks):
         return Link(
             rel=Relations.item,
             type=MimeTypes.geojson,
-            href=urljoin(self.base_url, f"/collections/{self.collection_id}/items"),
+            href=urljoin(self.base_url, f"collections/{self.collection_id}/items"),
         )
 
     def create_links(self) -> List[Link]:
@@ -73,7 +73,7 @@ class ItemLinks(BaseLinks):
             rel=Relations.self,
             type=MimeTypes.geojson,
             href=urljoin(
-                self.base_url, f"/collections/{self.collection_id}/items/{self.item_id}"
+                self.base_url, f"collections/{self.collection_id}/items/{self.item_id}"
             ),
         )
 
@@ -82,7 +82,7 @@ class ItemLinks(BaseLinks):
         return Link(
             rel=Relations.parent,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"/collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
         )
 
     def collection(self) -> Link:
@@ -90,7 +90,7 @@ class ItemLinks(BaseLinks):
         return Link(
             rel=Relations.collection,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"/collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
         )
 
     def tiles(self) -> Link:
@@ -101,7 +101,7 @@ class ItemLinks(BaseLinks):
             title="tiles",
             href=urljoin(
                 self.base_url,
-                f"/collections/{self.collection_id}/items/{self.item_id}/tiles",
+                f"collections/{self.collection_id}/items/{self.item_id}/tiles",
             ),
         )
 

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/links.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/links.py
@@ -25,9 +25,7 @@ class BaseLinks:
 
     def root(self) -> Link:
         """Return the catalog root."""
-        return Link(
-            rel=Relations.root, type=MimeTypes.json, href=self.base_url
-        )
+        return Link(rel=Relations.root, type=MimeTypes.json, href=self.base_url)
 
 
 @attr.s
@@ -44,9 +42,7 @@ class CollectionLinks(BaseLinks):
 
     def parent(self) -> Link:
         """Create the `parent` link."""
-        return Link(
-            rel=Relations.parent, type=MimeTypes.json, href=self.base_url
-        )
+        return Link(rel=Relations.parent, type=MimeTypes.json, href=self.base_url)
 
     def item(self) -> Link:
         """Create the `item` link."""


### PR DESCRIPTION
This PR removes all leading slashes from uses of `urljoin`, thus allowing users to specify a `root_path` without it being ignored in the process of joining


Closes #142