### PR TITLE
Set default landing page ID

### DIFF
--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -42,7 +42,6 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
     item_table: Type[database.Item] = attr.ib(default=database.Item)
     collection_table: Type[database.Collection] = attr.ib(default=database.Collection)
 
-
     @staticmethod
     def _lookup_id(
         id: str, table: Type[database.BaseModel], session: SqlSession

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -37,9 +37,11 @@ NumType = Union[float, int]
 class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
     """Client for core endpoints defined by stac."""
 
+    landing_page_id: str = attr.ib(default="stac-api")
     session: Session = attr.ib(default=attr.Factory(Session.create_from_env))
     item_table: Type[database.Item] = attr.ib(default=database.Item)
     collection_table: Type[database.Collection] = attr.ib(default=database.Collection)
+
 
     @staticmethod
     def _lookup_id(
@@ -54,6 +56,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
     def landing_page(self, **kwargs) -> LandingPage:
         """Landing page."""
         landing_page = LandingPage(
+            id=self.landing_page_id,
             title="Arturo STAC API",
             description="Arturo raster datastore",
             links=[


### PR DESCRIPTION
`LandingPage` instances are supposed to have an `id` field; this PR fills that in for the `sqlalchemy` project