### PR TITLE
return 400 status codes for bad requests instead of 422

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/errors.py
+++ b/stac_fastapi/api/stac_fastapi/api/errors.py
@@ -4,6 +4,7 @@ import logging
 from typing import Callable, Dict, Type
 
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
 from starlette import status
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -57,8 +58,19 @@ def add_exception_handlers(
     Returns:
         None
     """
-    # """
-    # Add exception handlers to the FastAPI app.
-    # """
     for (exc, code) in status_codes.items():
         app.add_exception_handler(exc, exception_handler_factory(code))
+
+    # By default FastAPI will return 422 status codes for invalid requests
+    # But the STAC api spec suggests returning a 400 in this case
+    def request_validation_exception_handler(
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        # change this as you like, including possibly the return type
+        return JSONResponse(
+            status_code=status.HTTP_400_BAD_REQUEST, content={"detail": exc.errors()}
+        )
+
+    app.add_exception_handler(
+        RequestValidationError, request_validation_exception_handler
+    )

--- a/stac_fastapi/api/stac_fastapi/api/errors.py
+++ b/stac_fastapi/api/stac_fastapi/api/errors.py
@@ -66,7 +66,6 @@ def add_exception_handlers(
     def request_validation_exception_handler(
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
-        # change this as you like, including possibly the return type
         return JSONResponse(
             status_code=status.HTTP_400_BAD_REQUEST, content={"detail": exc.errors()}
         )

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -859,7 +859,7 @@ async def test_search_intersects_and_bbox(app_client):
     geoj = Polygon.from_bounds(*bbox).__geo_interface__
     params = {"bbox": bbox, "intersects": geoj}
     resp = await app_client.post("/search", json=params)
-    assert resp.status_code == 422
+    assert resp.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -875,4 +875,4 @@ async def test_get_missing_item(app_client, load_test_data):
 async def test_search_invalid_query_field(app_client):
     body = {"query": {"gsd": {"lt": 100}, "invalid-field": {"eq": 50}}}
     resp = await app_client.post("/search", json=body)
-    assert resp.status_code == 422
+    assert resp.status_code == 400

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -695,7 +695,7 @@ def test_search_intersects_and_bbox(app_client):
     geoj = Polygon.from_bounds(*bbox).__geo_interface__
     params = {"bbox": bbox, "intersects": geoj}
     resp = app_client.post("/search", json=params)
-    assert resp.status_code == 422
+    assert resp.status_code == 400
 
 
 def test_get_missing_item(app_client, load_test_data):
@@ -708,4 +708,4 @@ def test_get_missing_item(app_client, load_test_data):
 def test_search_invalid_query_field(app_client):
     body = {"query": {"gsd": {"lt": 100}, "invalid-field": {"eq": 50}}}
     resp = app_client.post("/search", json=body)
-    assert resp.status_code == 422
+    assert resp.status_code == 400


### PR DESCRIPTION
Adds another exception handler which overrides fastapi's default behavior of returning 422 status codes on request validation errors.  The response body is exactly the same, we are just returning a 400 instead.

Closes #173 