### PR TITLE
rebuild docs on changes to python files

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -5,10 +5,11 @@ on:
     branches:
       - master
     paths:
-      # Only rebuild website when docs have changed
+      # Rebuild website when docs have changed or code has changed
       - 'README.md'
       - 'docs/**'
       - 'mkdocs.yml'
+      - '**.py'
 
 jobs:
   build:


### PR DESCRIPTION
We are autogenerating an API reference from function docstrings, so we should re-publish docs whenever there are changes to a python file.  Adds a new path filter to the github action to do this.

closes #131 
