### PR TITLE
Update to stac-pydantic 2.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## UNRELEASED
+
+* Upgrade to stac-pydantic 2.0.0 and stac-spec 1.0.0 (https://github.com/stac-utils/stac-fastapi/pull/181)
 
 ## 1.1.0 (2021-01-28)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - ./stac_fastapi:/app/stac_fastapi
       - ./scripts:/app/scripts
     command: >
-      bash -c "sleep 10 && cd stac_fastapi/sqlalchemy && alembic upgrade head && python /app/scripts/ingest_joplin.py http://app-sqlalchemy:8081"
+      bash -c "./scripts/wait-for-it.sh app-sqlalchemy:8081 && cd stac_fastapi/sqlalchemy && alembic upgrade head && python /app/scripts/ingest_joplin.py http://app-sqlalchemy:8081"
     depends_on:
       - database
       - app-sqlalchemy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
 
   database:
     container_name: stac-db
-    image: bitner/pgstac:0.2.4
+    image: bitner/pgstac:0.2.7
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/scripts/ingest_joplin.py
+++ b/scripts/ingest_joplin.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from urllib.parse import urljoin
 
+from stac_pydantic import Collection
+
 import requests
 
 workingdir = Path(__file__).parent.absolute()

--- a/scripts/ingest_joplin.py
+++ b/scripts/ingest_joplin.py
@@ -4,8 +4,6 @@ import sys
 from pathlib import Path
 from urllib.parse import urljoin
 
-from stac_pydantic import Collection
-
 import requests
 
 workingdir = Path(__file__).parent.absolute()

--- a/stac_fastapi/api/setup.py
+++ b/stac_fastapi/api/setup.py
@@ -17,11 +17,17 @@ install_requires = [
     "fastapi",
     "attrs",
     "pydantic[dotenv]",
-    "stac_pydantic==1.3.8",
+    "stac_pydantic==2.0.0",
 ]
 
 extra_reqs = {
-    "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "requests"],
+    "dev": [
+        "pytest",
+        "pytest-cov",
+        "pytest-asyncio",
+        "pre-commit",
+        "requests",
+    ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],
 }
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.openapi.utils import get_openapi
 from stac_pydantic import Collection, Item, ItemCollection
 from stac_pydantic.api import ConformanceClasses, LandingPage
+from stac_pydantic.api.collections import Collections
 from stac_pydantic.version import STAC_VERSION
 
 from stac_fastapi.api.errors import DEFAULT_STATUS_CODES, add_exception_handlers
@@ -148,7 +149,7 @@ class StacApi:
         router.add_api_route(
             name="Get Collections",
             path="/collections",
-            response_model=List[Collection],
+            response_model=Collections,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],

--- a/stac_fastapi/api/stac_fastapi/api/config.py
+++ b/stac_fastapi/api/stac_fastapi/api/config.py
@@ -2,20 +2,6 @@
 import enum
 
 
-# TODO: Move to stac-pydantic
-class ApiExtensions(enum.Enum):
-    """Enumeration of available stac api extensions.
-
-    Ref: https://github.com/radiantearth/stac-api-spec/tree/master/extensions
-    """
-
-    context = "context"
-    fields = "fields"
-    query = "query"
-    sort = "sort"
-    transaction = "transaction"
-
-
 class AddOns(enum.Enum):
     """Enumeration of available third party add ons."""
 

--- a/stac_fastapi/api/stac_fastapi/api/config.py
+++ b/stac_fastapi/api/stac_fastapi/api/config.py
@@ -6,6 +6,7 @@ import enum
 # Does that make sense now? The shift to json schema rather than a well-known enumeration makes that less obvious.
 class ApiExtensions(enum.Enum):
     """Enumeration of available stac api extensions.
+
     Ref: https://github.com/radiantearth/stac-api-spec/tree/master/extensions
     """
 

--- a/stac_fastapi/api/stac_fastapi/api/config.py
+++ b/stac_fastapi/api/stac_fastapi/api/config.py
@@ -2,6 +2,20 @@
 import enum
 
 
+# TODO: Move to stac-pydantic
+# Does that make sense now? The shift to json schema rather than a well-known enumeration makes that less obvious.
+class ApiExtensions(enum.Enum):
+    """Enumeration of available stac api extensions.
+    Ref: https://github.com/radiantearth/stac-api-spec/tree/master/extensions
+    """
+
+    context = "context"
+    fields = "fields"
+    query = "query"
+    sort = "sort"
+    transaction = "transaction"
+
+
 class AddOns(enum.Enum):
     """Enumeration of available third party add ons."""
 

--- a/stac_fastapi/api/stac_fastapi/api/errors.py
+++ b/stac_fastapi/api/stac_fastapi/api/errors.py
@@ -67,7 +67,8 @@ def add_exception_handlers(
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
         return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST, content={"detail": exc.errors()}
+            status_code=status.HTTP_400_BAD_REQUEST,
+            content={"detail": exc.errors()},
         )
 
     app.add_exception_handler(

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -91,7 +91,11 @@ class ItemCollectionUri(CollectionUri):
 
     def kwargs(self) -> Dict:
         """kwargs."""
-        return {"id": self.collectionId, "limit": self.limit, "token": self.token}
+        return {
+            "id": self.collectionId,
+            "limit": self.limit,
+            "token": self.token,
+        }
 
 
 @attr.s

--- a/stac_fastapi/api/stac_fastapi/api/openapi.py
+++ b/stac_fastapi/api/stac_fastapi/api/openapi.py
@@ -2,7 +2,6 @@
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 
-from stac_fastapi.api.config import ApiExtensions
 from stac_fastapi.types.config import ApiSettings
 
 
@@ -17,14 +16,6 @@ def config_openapi(app: FastAPI, settings: ApiSettings):
         openapi_schema = get_openapi(
             title="Arturo STAC API", version="0.1", routes=app.routes
         )
-
-        if settings.api_extension_is_enabled(ApiExtensions.fields):
-            openapi_schema["paths"]["/search"]["get"]["responses"]["200"]["content"][
-                "application/json"
-            ]["schema"] = {"$ref": "#/components/schemas/ItemCollection"}
-            openapi_schema["paths"]["/search"]["post"]["responses"]["200"]["content"][
-                "application/json"
-            ]["schema"] = {"$ref": "#/components/schemas/ItemCollection"}
 
         app.openapi_schema = openapi_schema
         return app.openapi_schema

--- a/stac_fastapi/api/stac_fastapi/api/openapi.py
+++ b/stac_fastapi/api/stac_fastapi/api/openapi.py
@@ -2,6 +2,7 @@
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 
+from stac_fastapi.api.config import ApiExtensions
 from stac_fastapi.types.config import ApiSettings
 
 
@@ -16,6 +17,14 @@ def config_openapi(app: FastAPI, settings: ApiSettings):
         openapi_schema = get_openapi(
             title="Arturo STAC API", version="0.1", routes=app.routes
         )
+
+        if settings.api_extension_is_enabled(ApiExtensions.fields):
+            openapi_schema["paths"]["/search"]["get"]["responses"]["200"]["content"][
+                "application/json"
+            ]["schema"] = {"$ref": "#/components/schemas/ItemCollection"}
+            openapi_schema["paths"]["/search"]["post"]["responses"]["200"]["content"][
+                "application/json"
+            ]["schema"] = {"$ref": "#/components/schemas/ItemCollection"}
 
         app.openapi_schema = openapi_schema
         return app.openapi_schema

--- a/stac_fastapi/extensions/setup.py
+++ b/stac_fastapi/extensions/setup.py
@@ -17,13 +17,19 @@ install_requires = [
     "fastapi",
     "attrs",
     "pydantic[dotenv]",
-    "stac_pydantic==1.3.8",
+    "stac_pydantic==2.0.0",
     "stac-fastapi.types",
     "stac-fastapi.api",
 ]
 
 extra_reqs = {
-    "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "requests"],
+    "dev": [
+        "pytest",
+        "pytest-cov",
+        "pytest-asyncio",
+        "pre-commit",
+        "requests",
+    ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],
     "tiles": ["titiler==0.2.*"],
 }

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
@@ -7,7 +7,8 @@ import attr
 from fastapi import FastAPI
 from pydantic import BaseModel
 from stac_pydantic.collection import SpatialExtent
-from stac_pydantic.shared import Link, MimeTypes, Relations
+from stac_pydantic.links import Link, Relations
+from stac_pydantic.shared import MimeTypes
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse
 

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "attrs",
     "orjson",
     "pydantic[dotenv]",
-    "stac_pydantic==1.3.8",
+    "stac_pydantic==2.0.0",
     "stac-fastapi.types",
     "stac-fastapi.api",
     "stac-fastapi.extensions",

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -26,6 +26,16 @@ NumType = Union[float, int]
 class CoreCrudClient(BaseCoreClient):
     """Client for core endpoints defined by stac."""
 
+    landing_page_id: str = attr.ib(default="stac-api")
+    title: str = attr.ib(default="Arturo STAC API")
+    description: str = attr.ib(default="Arturo raster datastore")
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: [
+            "https://stacspec.org/STAC-api.html",
+            "http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#ats_geojson",
+        ]
+    )
+
     async def landing_page(self, **kwargs) -> ORJSONResponse:
         """Landing page.
 
@@ -37,8 +47,10 @@ class CoreCrudClient(BaseCoreClient):
         request = kwargs["request"]
         base_url = str(request.base_url)
         landing_page = LandingPage(
-            title="Arturo STAC API",
-            description="Arturo raster datastore",
+            id=self.landing_page_id,
+            title=self.title,
+            description=self.description,
+            conformsTo=self.conformance_classes,
             links=[
                 Link(
                     rel=Relations.self,
@@ -49,24 +61,24 @@ class CoreCrudClient(BaseCoreClient):
                     rel=Relations.docs,
                     type=MimeTypes.html,
                     title="OpenAPI docs",
-                    href=urljoin(base_url, "/docs"),
+                    href=urljoin(base_url, "docs"),
                 ),
                 Link(
                     rel=Relations.conformance,
                     type=MimeTypes.json,
                     title="STAC/WFS3 conformance classes implemented by this server",
-                    href=urljoin(base_url, "/conformance"),
+                    href=urljoin(base_url, "conformance"),
                 ),
                 Link(
                     rel=Relations.search,
                     type=MimeTypes.geojson,
                     title="STAC search",
-                    href=urljoin(base_url, "/search"),
+                    href=urljoin(base_url, "search"),
                 ),
                 Link(
                     rel="data",
                     type=MimeTypes.json,
-                    href=urljoin(base_url, "/collections"),
+                    href=urljoin(base_url, "collections"),
                 ),
             ],
         )
@@ -83,12 +95,7 @@ class CoreCrudClient(BaseCoreClient):
 
     async def conformance(self, **kwargs) -> ConformanceClasses:
         """Conformance classes."""
-        return ConformanceClasses(
-            conformsTo=[
-                "https://stacspec.org/STAC-api.html",
-                "http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#ats_geojson",
-            ]
-        )
+        return ConformanceClasses(conformsTo=self.conformance_classes)
 
     async def _all_collections_func(self, **kwargs) -> List[Collection]:
         """Read all collections from the database."""

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -130,12 +130,14 @@ class CoreCrudClient(BaseCoreClient):
             Link(rel=Relations.root, type=MimeTypes.json, href=base_url),
         ]
         if collections is None:
-            return ORJSONResponse(Collections(collections=[], links=links))
+            return ORJSONResponse(
+                Collections(collections=[], links=links).dict(exclude_none=True)
+            )
         return ORJSONResponse(
             Collections(
                 collections=[c.dict(exclude_none=True) for c in collections],
                 links=links,
-            )
+            ).dict(exclude_none=True)
         )
 
     async def get_collection(self, id: str, **kwargs) -> ORJSONResponse:

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
@@ -5,7 +5,8 @@ from urllib.parse import ParseResult, parse_qs, unquote, urlencode, urljoin, url
 
 import attr
 from stac_pydantic.api.extensions.paging import PaginationLink
-from stac_pydantic.shared import Link, MimeTypes, Relations
+from stac_pydantic.links import Link, Relations
+from stac_pydantic.shared import MimeTypes
 from starlette.requests import Request
 
 from stac_fastapi.extensions.third_party.tiles import OGCTileLink

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
@@ -4,8 +4,7 @@ from typing import Dict, List, Union
 from urllib.parse import ParseResult, parse_qs, unquote, urlencode, urljoin, urlparse
 
 import attr
-from stac_pydantic.api.extensions.paging import PaginationLink
-from stac_pydantic.links import Link, Relations
+from stac_pydantic.links import Link, Relations, PaginationLink
 from stac_pydantic.shared import MimeTypes
 from starlette.requests import Request
 

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Union
 from urllib.parse import ParseResult, parse_qs, unquote, urlencode, urljoin, urlparse
 
 import attr
-from stac_pydantic.links import Link, Relations, PaginationLink
+from stac_pydantic.links import Link, PaginationLink, Relations
 from stac_pydantic.shared import MimeTypes
 from starlette.requests import Request
 

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/schemas.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/schemas.py
@@ -7,8 +7,8 @@ from geojson_pydantic.geometries import Polygon
 from pydantic import BaseModel
 from stac_pydantic import Collection as CollectionBase
 from stac_pydantic import Item as ItemBase
-from stac_pydantic.api.search import DATETIME_RFC339
-from stac_pydantic.shared import Link
+from stac_pydantic.links import Link
+from stac_pydantic.shared import DATETIME_RFC339
 
 # Be careful: https://github.com/samuelcolvin/pydantic/issues/1423#issuecomment-642797287
 NumType = Union[float, int]

--- a/stac_fastapi/pgstac/tests/clients/test_postgres.py
+++ b/stac_fastapi/pgstac/tests/clients/test_postgres.py
@@ -80,7 +80,7 @@ async def test_update_item(app_client, load_test_collection, load_test_item):
 
     item.properties.description = "Update Test"
 
-    resp = await app_client.put(f"/collections/{coll.id}/items", json=item.dict())
+    resp = await app_client.put(f"/collections/{coll.id}/items", data=item.json())
     assert resp.status_code == 200
 
     resp = await app_client.get(f"/collections/{coll.id}/items/{item.id}")
@@ -113,7 +113,7 @@ async def test_get_collection_items(app_client, load_test_collection, load_test_
         item.id = str(uuid.uuid4())
         resp = await app_client.post(
             f"/collections/{coll.id}/items",
-            json=item.dict(),
+            data=item.json(),
         )
         assert resp.status_code == 200
 

--- a/stac_fastapi/pgstac/tests/data/joplin/collection.json
+++ b/stac_fastapi/pgstac/tests/data/joplin/collection.json
@@ -1,9 +1,10 @@
 {
     "id": "joplin",
     "description": "This imagery was acquired by the NOAA Remote Sensing Division to support NOAA national security and emergency response requirements. In addition, it will be used for ongoing research efforts for testing and developing standards for airborne digital imagery. Individual images have been combined into a larger mosaic and tiled for distribution. The approximate ground sample distance (GSD) for each pixel is 35 cm (1.14 feet).",
-    "stac_version": "1.0.0-beta.2",
+    "stac_version": "1.0.0",
     "license": "public-domain",
     "links": [],
+    "type": "collection",
     "extent": {
         "spatial": {
             "bbox": [

--- a/stac_fastapi/pgstac/tests/data/joplin/index.geojson
+++ b/stac_fastapi/pgstac/tests/data/joplin/index.geojson
@@ -55,10 +55,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "a7e125ba-565d-4aa2-bbf3-c57a9087c2e3",
@@ -114,10 +114,10 @@
                 37.0814756
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "f7f164c9-cfdf-436d-a3f0-69864c38ba2a",
@@ -173,10 +173,10 @@
                 37.1033841
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "ea0fddf4-56f9-4a16-8a0b-f6b0b123b7cf",
@@ -232,10 +232,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "c811e716-ab07-4d80-ac95-6670f8713bc4",
@@ -291,10 +291,10 @@
                 37.0814756
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "d4eccfa2-7d77-4624-9e2a-3f59102285bb",
@@ -350,10 +350,10 @@
                 37.1033841
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "fe916452-ba6f-4631-9154-c249924a122d",
@@ -409,10 +409,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "85f923a5-a81f-4acd-bc7f-96c7c915f357",
@@ -468,10 +468,10 @@
                 37.0814756
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "29c53e17-d7d1-4394-a80f-36763c8f42dc",
@@ -527,10 +527,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "e0a02e4e-aa0c-412e-8f63-6f5344f829df",
@@ -586,10 +586,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "047ab5f0-dce1-4166-a00d-425a3dbefe02",
@@ -645,10 +645,10 @@
                 37.0814756
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "57f88dd2-e4e0-48e6-a2b6-7282d4ab8ea4",
@@ -704,10 +704,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "68f2c2b2-4bce-4c40-9a0d-782c1be1f4f2",
@@ -763,10 +763,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "d8461d8c-3d2b-4e4e-a931-7ae61ca06dbf",
@@ -822,10 +822,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "aeedef30-cbdd-4364-8781-dbb42d148c99",
@@ -881,10 +881,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "9ef4279f-386c-40c7-ad71-8de5d9543aa4",
@@ -940,10 +940,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "70cc6c05-9fe0-436a-a264-a52515f3f242",
@@ -999,10 +999,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "d191a6fd-7881-4421-805c-e246371e5cc4",
@@ -1058,10 +1058,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "d144adde-df4a-45e8-bed9-f085f91486a2",
@@ -1117,10 +1117,10 @@
                 37.0617526
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "a4c32abd-9791-422b-87ab-b0f3fa36f053",
@@ -1176,10 +1176,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "4610c58e-39f4-4d9d-94ba-ceddbf9ac570",
@@ -1235,10 +1235,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "145fa700-16d4-4d34-98e0-7540d5c0885f",
@@ -1294,10 +1294,10 @@
                 37.0617526
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "a89dc7b8-a580-435b-8176-d8e4386d620c",
@@ -1353,10 +1353,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "386dfa13-c2b4-4ce6-8e6f-fcac73f4e64e",
@@ -1412,10 +1412,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "4d8a8e40-d089-4ca7-92c8-27d810ee07bf",
@@ -1471,10 +1471,10 @@
                 37.0617526
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "f734401c-2df0-4694-a353-cdd3ea760cdc",
@@ -1530,10 +1530,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "da6ef938-c58f-4bab-9d4e-89f6ae667da2",
@@ -1589,10 +1589,10 @@
                 37.1077651
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "ad420ced-b005-472b-a6df-3838c2b74504",
@@ -1648,10 +1648,10 @@
                 37.0617526
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "f490b7af-0019-45e2-854b-3854d07fd063",
@@ -1707,10 +1707,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "b853f353-4b72-44d5-aa44-c07dfd307138",
@@ -1766,10 +1766,10 @@
                 37.1077651
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         }
     ]
 }

--- a/stac_fastapi/pgstac/tests/data/test_collection.json
+++ b/stac_fastapi/pgstac/tests/data/test_collection.json
@@ -1,8 +1,9 @@
 {
   "id": "test-collection",
   "stac_extensions": [],
+  "type": "collection",
   "description": "Landat 8 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
-  "stac_version": "1.0.0-beta.2",
+  "stac_version": "1.0.0",
   "license": "PDDL-1.0",
   "summaries": {
     "platform": ["landsat-8"],

--- a/stac_fastapi/pgstac/tests/data/test_item.json
+++ b/stac_fastapi/pgstac/tests/data/test_item.json
@@ -2,8 +2,8 @@
   "type": "Feature",
   "id": "test-item",
   "stac_extensions": [
-    "eo",
-    "view"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
   ],
   "geometry": {
     "coordinates": [

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -87,7 +87,7 @@ async def test_update_item(
 
     item.properties.description = "Update Test"
 
-    resp = await app_client.put(f"/collections/{coll.id}/items", json=item.dict())
+    resp = await app_client.put(f"/collections/{coll.id}/items", data=item.json())
     assert resp.status_code == 200
 
     resp = await app_client.get(f"/collections/{coll.id}/items/{item.id}")
@@ -122,7 +122,7 @@ async def test_get_collection_items(app_client, load_test_collection, load_test_
         item.id = str(uuid.uuid4())
         resp = await app_client.post(
             f"/collections/{coll.id}/items",
-            json=item.dict(),
+            data=item.json(),
         )
         assert resp.status_code == 200
 
@@ -192,7 +192,7 @@ async def test_update_new_item(
     item = load_test_item
     item.id = "test-updatenewitem"
 
-    resp = await app_client.put(f"/collections/{coll.id}/items", json=item.dict())
+    resp = await app_client.put(f"/collections/{coll.id}/items", data=item.json())
     assert resp.status_code == 404
 
 
@@ -204,7 +204,7 @@ async def test_update_item_missing_collection(
     item = load_test_item
     item.collection = None
 
-    resp = await app_client.put(f"/collections/{coll.id}/items", json=item.dict())
+    resp = await app_client.put(f"/collections/{coll.id}/items", data=item.json())
     assert resp.status_code == 424
 
 

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -7,7 +7,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from shapely.geometry import Polygon
 from stac_pydantic import Collection, Item
-from stac_pydantic.api.search import DATETIME_RFC339
+from stac_pydantic.shared import DATETIME_RFC339
 
 
 @pytest.mark.asyncio

--- a/stac_fastapi/sqlalchemy/alembic/versions/407037cb1636_add_stac_1_0_0_fields.py
+++ b/stac_fastapi/sqlalchemy/alembic/versions/407037cb1636_add_stac_1_0_0_fields.py
@@ -1,0 +1,24 @@
+"""add-stac-1.0.0-fields
+
+Revision ID: 407037cb1636
+Revises: 77c019af60bf
+Create Date: 2021-07-07 16:10:03.196942
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '407037cb1636'
+down_revision = '77c019af60bf'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("collections", sa.Column("type", sa.VARCHAR(300), default="collection", nullable=False), schema="data")
+
+
+def downgrade():
+    op.drop_column("collections", "type")

--- a/stac_fastapi/sqlalchemy/alembic/versions/407037cb1636_add_stac_1_0_0_fields.py
+++ b/stac_fastapi/sqlalchemy/alembic/versions/407037cb1636_add_stac_1_0_0_fields.py
@@ -5,19 +5,22 @@ Revises: 77c019af60bf
 Create Date: 2021-07-07 16:10:03.196942
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = '407037cb1636'
-down_revision = '77c019af60bf'
+revision = "407037cb1636"
+down_revision = "77c019af60bf"
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column("collections", sa.Column("type", sa.VARCHAR(300), default="collection", nullable=False), schema="data")
+    op.add_column(
+        "collections",
+        sa.Column("type", sa.VARCHAR(300), default="collection", nullable=False),
+        schema="data",
+    )
 
 
 def downgrade():

--- a/stac_fastapi/sqlalchemy/setup.py
+++ b/stac_fastapi/sqlalchemy/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     "fastapi",
     "attrs",
     "pydantic[dotenv]",
-    "stac_pydantic==1.3.8",
+    "stac_pydantic==2.0.0",
     "stac-fastapi.types",
     "stac-fastapi.api",
     "stac-fastapi.extensions",
@@ -31,7 +31,13 @@ install_requires = [
 ]
 
 extra_reqs = {
-    "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "requests"],
+    "dev": [
+        "pytest",
+        "pytest-cov",
+        "pytest-asyncio",
+        "pre-commit",
+        "requests",
+    ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],
     "server": ["uvicorn[standard]>=0.12.0,<0.14.0"],
 }

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -301,8 +301,9 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                 if search_request.datetime:
                     # Two tailed query (between)
                     if ".." not in search_request.datetime:
+                        dts = search_request.datetime.split("/")
                         query = query.filter(
-                            self.item_table.datetime.between(*search_request.datetime)
+                            self.item_table.datetime.between(*dts)
                         )
                     # All items after the start date
                     if search_request.datetime[0] != "..":

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -302,19 +302,13 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     # Two tailed query (between)
                     dts = search_request.datetime.split("/")
                     if ".." not in search_request.datetime:
-                        query = query.filter(
-                            self.item_table.datetime.between(*dts)
-                        )
+                        query = query.filter(self.item_table.datetime.between(*dts))
                     # All items after the start date
                     if dts[0] != "..":
-                        query = query.filter(
-                            self.item_table.datetime >= dts[0]
-                        )
+                        query = query.filter(self.item_table.datetime >= dts[0])
                     # All items before the end date
                     if dts[1] != "..":
-                        query = query.filter(
-                            self.item_table.datetime <= dts[1]
-                        )
+                        query = query.filter(self.item_table.datetime <= dts[1])
 
                 # Query fields
                 if search_request.query:

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -15,8 +15,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session as SqlSession
 from stac_pydantic import ItemCollection
 from stac_pydantic.api import ConformanceClasses
-from stac_pydantic.api.extensions.paging import PaginationLink
-from stac_pydantic.shared import Relations
+from stac_pydantic.links import PaginationLink, Relations
 
 from stac_fastapi.extensions.core import ContextExtension, FieldsExtension
 from stac_fastapi.sqlalchemy.models import database, schemas
@@ -135,7 +134,11 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
 
             context_obj = None
             if self.extension_is_enabled(ContextExtension):
-                context_obj = {"returned": len(page), "limit": limit, "matched": count}
+                context_obj = {
+                    "returned": len(page),
+                    "limit": limit,
+                    "matched": count,
+                }
 
             return ItemCollection(
                 type="FeatureCollection",
@@ -247,7 +250,8 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
             if search_request.sortby:
                 sort_fields = [
                     getattr(
-                        self.item_table.get_field(sort.field), sort.direction.value
+                        self.item_table.get_field(sort.field),
+                        sort.direction.value,
                     )()
                     for sort in search_request.sortby
                 ]

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -300,20 +300,20 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                 # Temporal query
                 if search_request.datetime:
                     # Two tailed query (between)
+                    dts = search_request.datetime.split("/")
                     if ".." not in search_request.datetime:
-                        dts = search_request.datetime.split("/")
                         query = query.filter(
                             self.item_table.datetime.between(*dts)
                         )
                     # All items after the start date
-                    if search_request.datetime[0] != "..":
+                    if dts[0] != "..":
                         query = query.filter(
-                            self.item_table.datetime >= search_request.datetime[0]
+                            self.item_table.datetime >= dts[0]
                         )
                     # All items before the end date
-                    if search_request.datetime[1] != "..":
+                    if dts[1] != "..":
                         query = query.filter(
-                            self.item_table.datetime <= search_request.datetime[1]
+                            self.item_table.datetime <= dts[1]
                         )
 
                 # Query fields

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
@@ -98,7 +98,7 @@ class Item(BaseModel):  # type:ignore
             # Use getattr to accommodate extension namespaces
             field_value = getattr(schema.properties, field)
             if field == "datetime" and not isinstance(field_value, datetime):
-                    field_value = datetime.strptime(field_value, DATETIME_RFC339)
+                field_value = datetime.strptime(field_value, DATETIME_RFC339)
             indexed_fields[field.split(":")[-1]] = field_value
 
         # Exclude indexed fields from the properties jsonb field

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
@@ -106,6 +106,12 @@ class Item(BaseModel):  # type:ignore
         now = datetime.utcnow().strftime(DATETIME_RFC339)
         if not properties["created"]:
             properties["created"] = now
+        else:
+            # If there isn't a created field initially it is already included in the pydantic model.
+            # Which means its typed as a datetime.datetime object, but sqlalchemy needs this to be a string.
+            # Probably don't need the isinstance check here but it's a little safer.
+            if isinstance(properties["created"], datetime):
+                properties["created"] = properties["created"].strftime(DATETIME_RFC339)
         properties["updated"] = now
 
         return dict(

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
@@ -97,9 +97,8 @@ class Item(BaseModel):  # type:ignore
         for field in Settings.get().indexed_fields:
             # Use getattr to accommodate extension namespaces
             field_value = getattr(schema.properties, field)
-            print(field, field_value)
-            if field == "datetime":
-                field_value = datetime.strptime(field_value, DATETIME_RFC339)
+            if field == "datetime" and not isinstance(field_value, datetime):
+                    field_value = datetime.strptime(field_value, DATETIME_RFC339)
             indexed_fields[field.split(":")[-1]] = field_value
 
         # Exclude indexed fields from the properties jsonb field

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
@@ -49,7 +49,7 @@ class Collection(BaseModel):  # type:ignore
     stac_extensions = sa.Column(sa.ARRAY(sa.VARCHAR(300)), nullable=True)
     title = sa.Column(sa.VARCHAR(1024))
     description = sa.Column(sa.VARCHAR(1024), nullable=False)
-    keywords = sa.Column(sa.VARCHAR(300))
+    keywords = sa.Column(sa.ARRAY(sa.VARCHAR(300)))
     version = sa.Column(sa.VARCHAR(300))
     license = sa.Column(sa.VARCHAR(300), nullable=False)
     providers = sa.Column(JSONB)
@@ -57,6 +57,7 @@ class Collection(BaseModel):  # type:ignore
     extent = sa.Column(JSONB)
     links = sa.Column(JSONB)
     children = sa.orm.relationship("Item", lazy="dynamic")
+    type = sa.Column(sa.VARCHAR(300), nullable=False)
 
     @classmethod
     def get_database_model(cls, schema: schemas.Collection) -> dict:
@@ -96,6 +97,7 @@ class Item(BaseModel):  # type:ignore
         for field in Settings.get().indexed_fields:
             # Use getattr to accommodate extension namespaces
             field_value = getattr(schema.properties, field)
+            print(field, field_value)
             if field == "datetime":
                 field_value = datetime.strptime(field_value, DATETIME_RFC339)
             indexed_fields[field.split(":")[-1]] = field_value

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/decompose.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/decompose.py
@@ -108,6 +108,6 @@ class CollectionGetter(GetterDict):
             summaries=obj.summaries,
             extent=obj.extent,
             links=collection_links,
-            type="collection"
+            type="collection",
         )
         super().__init__(db_model)

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/decompose.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/decompose.py
@@ -108,5 +108,6 @@ class CollectionGetter(GetterDict):
             summaries=obj.summaries,
             extent=obj.extent,
             links=collection_links,
+            type="collection"
         )
         super().__init__(db_model)

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/decompose.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/decompose.py
@@ -55,7 +55,9 @@ class ItemGetter(GetterDict):
             properties[field] = field_value
         # Create inferred links
         item_links = ItemLinks(
-            collection_id=obj.collection_id, base_url=obj.base_url, item_id=obj.id
+            collection_id=obj.collection_id,
+            base_url=obj.base_url,
+            item_id=obj.id,
         ).create_links()
         # Resolve existing links
         if obj.links:

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/schemas.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/schemas.py
@@ -7,8 +7,8 @@ from geojson_pydantic.geometries import Polygon
 from pydantic import BaseModel
 from stac_pydantic import Collection as CollectionBase
 from stac_pydantic import Item as ItemBase
-from stac_pydantic.api.search import DATETIME_RFC339
-from stac_pydantic.shared import Link
+from stac_pydantic.links import Link
+from stac_pydantic.shared import DATETIME_RFC339
 
 from stac_fastapi.sqlalchemy.models.decompose import CollectionGetter, ItemGetter
 

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
@@ -39,6 +39,7 @@ class TransactionsClient(BaseTransactionsClient):
     ) -> schemas.Collection:
         """Create collection."""
         data = self.collection_table.from_schema(model)
+        data.type = "collection"
         with self.session.writer.context_session() as session:
             session.add(data)
             data.base_url = str(kwargs["request"].base_url)

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
@@ -39,7 +39,6 @@ class TransactionsClient(BaseTransactionsClient):
     ) -> schemas.Collection:
         """Create collection."""
         data = self.collection_table.from_schema(model)
-        data.type = "collection"
         with self.session.writer.context_session() as session:
             session.add(data)
             data.base_url = str(kwargs["request"].base_url)

--- a/stac_fastapi/sqlalchemy/tests/data/test_collection.json
+++ b/stac_fastapi/sqlalchemy/tests/data/test_collection.json
@@ -1,8 +1,9 @@
 {
   "id": "test-collection",
   "stac_extensions": [],
+  "type": "collection",
   "description": "Landat 8 imagery radiometrically calibrated and orthorectified using gound points and Digital Elevation Model (DEM) data to correct relief displacement.",
-  "stac_version": "1.0.0-beta.2",
+  "stac_version": "1.0.0",
   "license": "PDDL-1.0",
   "summaries": {
     "platform": ["landsat-8"],

--- a/stac_fastapi/sqlalchemy/tests/data/test_item.json
+++ b/stac_fastapi/sqlalchemy/tests/data/test_item.json
@@ -2,8 +2,8 @@
   "type": "Feature",
   "id": "test-item",
   "stac_extensions": [
-    "eo",
-    "view"
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
   ],
   "geometry": {
     "coordinates": [

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -532,7 +532,8 @@ def test_pagination_item_collection(app_client, load_test_data):
             break
         query_params = parse_qs(urlparse(next_link[0]["href"]).query)
         page = app_client.get(
-            f"/collections/{test_item['collection']}/items", params=query_params
+            f"/collections/{test_item['collection']}/items",
+            params=query_params,
         )
 
     # Our limit is 1 so we expect len(ids) number of requests before we run out of pages

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -7,7 +7,7 @@ from random import randint
 from urllib.parse import parse_qs, urlparse, urlsplit
 
 from shapely.geometry import Polygon
-from stac_pydantic.api.search import DATETIME_RFC339
+from stac_pydantic.shared import DATETIME_RFC339
 
 
 def test_create_and_delete_item(app_client, load_test_data):

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -240,7 +240,7 @@ def test_item_search_temporal_query_post(app_client, load_test_data):
     params = {
         "collections": [test_item["collection"]],
         "intersects": test_item["geometry"],
-        "datetime": item_date.strftime(DATETIME_RFC339),
+        "datetime": f"../{item_date.strftime(DATETIME_RFC339)}",
     }
     resp = app_client.post("/search", json=params)
     resp_json = resp.json()

--- a/stac_fastapi/testdata/joplin/collection.json
+++ b/stac_fastapi/testdata/joplin/collection.json
@@ -1,9 +1,10 @@
 {
     "id": "joplin",
     "description": "This imagery was acquired by the NOAA Remote Sensing Division to support NOAA national security and emergency response requirements. In addition, it will be used for ongoing research efforts for testing and developing standards for airborne digital imagery. Individual images have been combined into a larger mosaic and tiled for distribution. The approximate ground sample distance (GSD) for each pixel is 35 cm (1.14 feet).",
-    "stac_version": "1.0.0-beta.2",
+    "stac_version": "1.0.0",
     "license": "public-domain",
     "links": [],
+    "type": "collection",
     "extent": {
         "spatial": {
             "bbox": [

--- a/stac_fastapi/testdata/joplin/index.geojson
+++ b/stac_fastapi/testdata/joplin/index.geojson
@@ -55,10 +55,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "a7e125ba-565d-4aa2-bbf3-c57a9087c2e3",
@@ -114,10 +114,10 @@
                 37.0814756
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "f7f164c9-cfdf-436d-a3f0-69864c38ba2a",
@@ -173,10 +173,10 @@
                 37.1033841
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "ea0fddf4-56f9-4a16-8a0b-f6b0b123b7cf",
@@ -232,10 +232,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "c811e716-ab07-4d80-ac95-6670f8713bc4",
@@ -291,10 +291,10 @@
                 37.0814756
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "d4eccfa2-7d77-4624-9e2a-3f59102285bb",
@@ -350,10 +350,10 @@
                 37.1033841
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "fe916452-ba6f-4631-9154-c249924a122d",
@@ -409,10 +409,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "85f923a5-a81f-4acd-bc7f-96c7c915f357",
@@ -468,10 +468,10 @@
                 37.0814756
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "29c53e17-d7d1-4394-a80f-36763c8f42dc",
@@ -527,10 +527,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "e0a02e4e-aa0c-412e-8f63-6f5344f829df",
@@ -586,10 +586,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "047ab5f0-dce1-4166-a00d-425a3dbefe02",
@@ -645,10 +645,10 @@
                 37.0814756
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "57f88dd2-e4e0-48e6-a2b6-7282d4ab8ea4",
@@ -704,10 +704,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "68f2c2b2-4bce-4c40-9a0d-782c1be1f4f2",
@@ -763,10 +763,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "d8461d8c-3d2b-4e4e-a931-7ae61ca06dbf",
@@ -822,10 +822,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "aeedef30-cbdd-4364-8781-dbb42d148c99",
@@ -881,10 +881,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "9ef4279f-386c-40c7-ad71-8de5d9543aa4",
@@ -940,10 +940,10 @@
                 37.0595608
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "70cc6c05-9fe0-436a-a264-a52515f3f242",
@@ -999,10 +999,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "d191a6fd-7881-4421-805c-e246371e5cc4",
@@ -1058,10 +1058,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "d144adde-df4a-45e8-bed9-f085f91486a2",
@@ -1117,10 +1117,10 @@
                 37.0617526
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "a4c32abd-9791-422b-87ab-b0f3fa36f053",
@@ -1176,10 +1176,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "4610c58e-39f4-4d9d-94ba-ceddbf9ac570",
@@ -1235,10 +1235,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "145fa700-16d4-4d34-98e0-7540d5c0885f",
@@ -1294,10 +1294,10 @@
                 37.0617526
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "a89dc7b8-a580-435b-8176-d8e4386d620c",
@@ -1353,10 +1353,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "386dfa13-c2b4-4ce6-8e6f-fcac73f4e64e",
@@ -1412,10 +1412,10 @@
                 37.1055746
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "4d8a8e40-d089-4ca7-92c8-27d810ee07bf",
@@ -1471,10 +1471,10 @@
                 37.0617526
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "f734401c-2df0-4694-a353-cdd3ea760cdc",
@@ -1530,10 +1530,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "da6ef938-c58f-4bab-9d4e-89f6ae667da2",
@@ -1589,10 +1589,10 @@
                 37.1077651
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "ad420ced-b005-472b-a6df-3838c2b74504",
@@ -1648,10 +1648,10 @@
                 37.0617526
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "f490b7af-0019-45e2-854b-3854d07fd063",
@@ -1707,10 +1707,10 @@
                 37.0836668
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         },
         {
             "id": "b853f353-4b72-44d5-aa44-c07dfd307138",
@@ -1766,10 +1766,10 @@
                 37.1077651
             ],
             "stac_extensions": [
-                "eo",
-                "proj"
+                "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+                "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
             ],
-            "stac_version": "1.0.0-beta.2"
+            "stac_version": "1.0.0"
         }
     ]
 }

--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -17,11 +17,17 @@ install_requires = [
     "fastapi",
     "attrs",
     "pydantic[dotenv]",
-    "stac_pydantic==1.3.8",
+    "stac_pydantic==2.0.0",
 ]
 
 extra_reqs = {
-    "dev": ["pytest", "pytest-cov", "pytest-asyncio", "pre-commit", "requests"],
+    "dev": [
+        "pytest",
+        "pytest-cov",
+        "pytest-asyncio",
+        "pre-commit",
+        "requests",
+    ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],
 }
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -142,7 +142,7 @@ class BaseCoreClient(abc.ABC):
             id=self.landing_page_id,
             title=self.title,
             description=self.description,
-            conformsTo= [
+            conformsTo=[
                 "https://stacspec.org/STAC-api.html",
                 "http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#ats_geojson",
             ],

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -7,7 +7,8 @@ from urllib.parse import urljoin
 import attr
 from stac_pydantic import Collection, Item, ItemCollection
 from stac_pydantic.api import ConformanceClasses, LandingPage, Search
-from stac_pydantic.shared import Link, MimeTypes, Relations
+from stac_pydantic.links import Link, Relations
+from stac_pydantic.shared import MimeTypes
 from stac_pydantic.version import STAC_VERSION
 
 from stac_fastapi.types.extension import ApiExtension

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -142,6 +142,10 @@ class BaseCoreClient(abc.ABC):
             id=self.landing_page_id,
             title=self.title,
             description=self.description,
+            conformsTo= [
+                "https://stacspec.org/STAC-api.html",
+                "http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#ats_geojson",
+            ],
             stac_version=self.stac_version,
             links=[
                 Link(

--- a/stac_fastapi/types/stac_fastapi/types/links.py
+++ b/stac_fastapi/types/stac_fastapi/types/links.py
@@ -4,7 +4,8 @@ from typing import Dict, List
 from urllib.parse import urljoin
 
 import attr
-from stac_pydantic.shared import Link, MimeTypes, Relations
+from stac_pydantic.links import Link, Relations
+from stac_pydantic.shared import MimeTypes
 
 # These can be inferred from the item/collection so they aren't included in the database
 # Instead they are dynamically generated when querying the database using the classes defined below
@@ -69,7 +70,8 @@ class ItemLinks(BaseLinks):
             rel=Relations.self,
             type=MimeTypes.geojson,
             href=urljoin(
-                self.base_url, f"collections/{self.collection_id}/items/{self.item_id}"
+                self.base_url,
+                f"collections/{self.collection_id}/items/{self.item_id}",
             ),
         )
 


### PR DESCRIPTION
This PR upgrades the version of `stac-pydantic` to 2.0.0 so that the library can use stac-spec 1.0.0. Mostly, the changes are import updates, though collections are now represented as `stac-pydantic`'s `Collections` type rather than a `List[Collection]`