### PR TITLE
add PGStac in the available namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,17 @@ packages:
 
 - **stac_fastapi.api**: An API layer which enforces the [stac-api-spec](https://github.com/radiantearth/stac-api-spec).
 - **stac_fastapi.extensions**: Abstract base classes for [STAC API extensions](https://github.com/radiantearth/stac-api-spec/blob/master/extensions.md) and third-party extensions.
-- **stac_fastapi.server**: Standalone FastAPI server for the application.
-- **stac_fastapi.sqlalchemy**: Postgres backend implementation with sqlalchemy.
 - **stac_fastapi.types**: Shared types and abstract base classes used by the library.
+
+#### Backends
+- **stac_fastapi.sqlalchemy**: Postgres backend implementation with sqlalchemy.
+- **stac_fastapi.pgstac**: Postgres backend implementation with [PGStac](https://github.com/stac-utils/pgstac).
 
 `stac-fastapi` was initially developed by [arturo-ai](https://github.com/arturo-ai).
 
 ## Installation
 
-```
+```bash
 pip install stac-fastapi
 
 # or from sources
@@ -45,8 +47,12 @@ cd stac-fastapi
 pip install -e \
     stac_fastapi/api \
     stac_fastapi/types \
-    stac_fastapi/extensions \
-    stac_fastapi/sqlalchemy
+    stac_fastapi/extensions
+
+# Install a backend
+pip install -e stac_fastapi/sqlalchemy
+# or
+pip install -e stac_fastapi/pgstac
 ```
 
 ## Local Development
@@ -54,13 +60,17 @@ Use docker-compose to deploy the application, migrate the database, and ingest s
 ```bash
 docker-compose build
 docker-compose up
+
+# You can also launch specific application
+docker-compose up app-sqlalchemy  # or sqlalchemy-loadjoplin
+# or
+docker-compose up app-pgstac  # or pgstac-loadjoplin
 ```
 
 For local development it is often more convenient to run the application outside of docker-compose:
 ```bash
 make docker-run
 ```
-
 
 ### Testing
 The database container provided by the docker-compose stack must be running.  Run all tests:

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ Use docker-compose to deploy the application, migrate the database, and ingest s
 docker-compose build
 docker-compose up
 
-# You can also launch specific application
-docker-compose up app-sqlalchemy  # or sqlalchemy-loadjoplin
+# You can also launch application with specific backend (PGSTac or sqlalchemy)
+docker-compose up app-sqlalchemy
 # or
-docker-compose up app-pgstac  # or pgstac-loadjoplin
+docker-compose up app-pgstac
 ```
 
 For local development it is often more convenient to run the application outside of docker-compose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,8 @@ services:
       - "5439:5432"
     command: postgres -N 500
 
-  sqlalchemy-loadjoplin:
+  # Load joplin demo dataset into the SQLAlchemy Application
+  loadjoplin-sqlalchemy:
     image: stac-utils/stac-fastapi
     environment:
       - ENVIRONMENT=development
@@ -96,7 +97,8 @@ services:
       - database
       - app-sqlalchemy
 
-  pgstac-loadjoplin:
+  # Load joplin demo dataset into the PGStac Application
+  loadjoplin-pgstac:
     image: stac-utils/stac-fastapi
     environment:
       - ENVIRONMENT=development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - "5439:5432"
     command: postgres -N 500
 
-  sqlalchemy-migration:
+  sqlalchemy-loadjoplin:
     image: stac-utils/stac-fastapi
     environment:
       - ENVIRONMENT=development


### PR DESCRIPTION
This PR does several Readme fixes:

- remove `stac_fastapi.server` namespace package
- add `stac_fastapi.pgstac` packages 
- rename `sqlalchemy-migration` to `sqlalchemy-loadjoplin` in docker-compose to match with `pgstac-loadjoplin` 

I've also introduced a subsection in the namespaces list to split core and backends packages. 
