### PR TITLE
bump pgstac version to 0.2.7 and fix lt/lte gt/gte

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -24,8 +24,8 @@ jobs:
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-timeout 10s
+          --health-retries 10
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       db_service:
-        image: bitner/pgstac:0.1.7
+        image: bitner/pgstac:0.2.7
         env:
           POSTGRES_USER: username
           POSTGRES_PASSWORD: password

--- a/stac_fastapi/pgstac/README.md
+++ b/stac_fastapi/pgstac/README.md
@@ -76,6 +76,6 @@ For Stac FastAPI development, a docker image (which is pulled as part of the doc
 There is also a python utility as part of PGStac (pypgstac) that includes a migration utility. The pgstac version required by stac-fastapi/pgstac is pinned by using the pinned version of pypgstac in the [setup](setup.py) file.
 
 In order to migrate database versions you can use the migration utility:
-```
+```bash
 pypgstac migrate
 ```

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -35,7 +35,7 @@ extra_reqs = {
         "pytest-asyncio",
         "pre-commit",
         "requests",
-        "pypgstac==0.2.4",
+        "pypgstac==0.2.7",
         "httpx",
     ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
@@ -22,9 +22,9 @@ class Operator(str, AutoValueEnum):
     eq = auto()
     ne = auto()
     lt = auto()
-    le = auto()
+    lte = auto()
     gt = auto()
-    ge = auto()
+    gte = auto()
     # TODO: These are defined in the spec but aren't currently implemented by the api
     # startsWith = auto()
     # endsWith = auto()


### PR DESCRIPTION
Bumps pgstac version to 0.2.7 and changes le and ge to lte/gte per the spec for the pgstac backend (#171 ) 