### PR TITLE
use setup.cfg metadata to set package version

### DIFF
--- a/stac_fastapi/api/setup.cfg
+++ b/stac_fastapi/api/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: stac_fastapi.api.version.__version__

--- a/stac_fastapi/api/setup.py
+++ b/stac_fastapi/api/setup.py
@@ -1,17 +1,9 @@
-"""arturo-stac-api."""
-import os
-from imp import load_source
+"""stac_fastapi: api module."""
 
 from setuptools import find_namespace_packages, setup
 
 with open("README.md") as f:
     desc = f.read()
-
-# Get version from stac-fastapi-api
-__version__ = load_source(
-    "stac_fastapi.api.version",
-    os.path.join(os.path.dirname(__file__), "stac_fastapi/api/version.py"),
-).__version__  # type:ignore
 
 install_requires = [
     "fastapi",
@@ -31,7 +23,6 @@ setup(
     description="An implementation of STAC API based on the FastAPI framework.",
     long_description=desc,
     long_description_content_type="text/markdown",
-    version=__version__,
     python_requires=">=3.8",
     classifiers=[
         "Intended Audience :: Developers",

--- a/stac_fastapi/extensions/setup.cfg
+++ b/stac_fastapi/extensions/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: stac_fastapi.extensions.version.__version__

--- a/stac_fastapi/extensions/setup.py
+++ b/stac_fastapi/extensions/setup.py
@@ -1,17 +1,9 @@
-"""arturo-stac-api."""
-import os
-from imp import load_source
+"""stac_fastapi: extensions module."""
 
 from setuptools import find_namespace_packages, setup
 
 with open("README.md") as f:
     desc = f.read()
-
-# Get version from stac-fastapi-api
-__version__ = load_source(
-    "stac_fastapi.extensions.version",
-    os.path.join(os.path.dirname(__file__), "stac_fastapi/extensions/version.py"),
-).__version__  # type:ignore
 
 install_requires = [
     "fastapi",
@@ -34,7 +26,6 @@ setup(
     description="An implementation of STAC API based on the FastAPI framework.",
     long_description=desc,
     long_description_content_type="text/markdown",
-    version=__version__,
     python_requires=">=3.8",
     classifiers=[
         "Intended Audience :: Developers",

--- a/stac_fastapi/pgstac/setup.cfg
+++ b/stac_fastapi/pgstac/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: stac_fastapi.pgstac.version.__version__

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -1,17 +1,9 @@
-"""arturo-stac-api."""
-import os
-from imp import load_source
+"""stac_fastapi: pgstac module."""
 
 from setuptools import find_namespace_packages, setup
 
 with open("README.md") as f:
     desc = f.read()
-
-# Get version from stac-fastapi-api
-__version__ = load_source(
-    "stac_fastapi.pgstac.version",
-    os.path.join(os.path.dirname(__file__), "stac_fastapi/pgstac/version.py"),
-).__version__  # type:ignore
 
 install_requires = [
     "fastapi",
@@ -49,7 +41,6 @@ setup(
     description="An implementation of STAC API based on the FastAPI framework and using the pgstac backend.",
     long_description=desc,
     long_description_content_type="text/markdown",
-    version=__version__,
     python_requires=">=3.8",
     classifiers=[
         "Intended Audience :: Developers",

--- a/stac_fastapi/sqlalchemy/setup.cfg
+++ b/stac_fastapi/sqlalchemy/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: stac_fastapi.sqlalchemy.version.__version__

--- a/stac_fastapi/sqlalchemy/setup.py
+++ b/stac_fastapi/sqlalchemy/setup.py
@@ -1,17 +1,9 @@
-"""arturo-stac-api."""
-import os
-from imp import load_source
+"""stac_fastapi: sqlalchemy module."""
 
 from setuptools import find_namespace_packages, setup
 
 with open("README.md") as f:
     desc = f.read()
-
-# Get version from stac-fastapi-api
-__version__ = load_source(
-    "stac_fastapi.sqlalchemy.version",
-    os.path.join(os.path.dirname(__file__), "stac_fastapi/sqlalchemy/version.py"),
-).__version__  # type:ignore
 
 install_requires = [
     "fastapi",
@@ -42,7 +34,6 @@ setup(
     description="An implementation of STAC API based on the FastAPI framework.",
     long_description=desc,
     long_description_content_type="text/markdown",
-    version=__version__,
     python_requires=">=3.8",
     classifiers=[
         "Intended Audience :: Developers",

--- a/stac_fastapi/types/setup.cfg
+++ b/stac_fastapi/types/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: stac_fastapi.types.version.__version__

--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -1,17 +1,9 @@
-"""arturo-stac-api."""
-import os
-from imp import load_source
+"""stac_fastapi: types module."""
 
 from setuptools import find_namespace_packages, setup
 
 with open("README.md") as f:
     desc = f.read()
-
-# Get version from stac-fastapi-api
-__version__ = load_source(
-    "stac_fastapi.types.version",
-    os.path.join(os.path.dirname(__file__), "stac_fastapi/types/version.py"),
-).__version__  # type:ignore
 
 install_requires = [
     "fastapi",
@@ -31,7 +23,6 @@ setup(
     description="An implementation of STAC API based on the FastAPI framework.",
     long_description=desc,
     long_description_content_type="text/markdown",
-    version=__version__,
     python_requires=">=3.8",
     classifiers=[
         "Intended Audience :: Developers",


### PR DESCRIPTION
This PR removes the code in the setup.py which grab the `version` form the code and use setup.cfg metadata notation

This is a personal opinion so feel free to ignore. (I also had difficulties trying to install the package using GitHub url, but not 💯 it was related to this) 