### PR TITLE
Update version to 2.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## UNRELEASED
 
+## 2.0.0 (2021-07)
+
+* Refactor stac-fastapi into submodules (https://github.com/stac-utils/stac-fastapi/pull/106)
+* Add pgstac backend (https://github.com/stac-utils/stac-fastapi/pull/126)
 * Upgrade to stac-pydantic 2.0.0 and stac-spec 1.0.0 (https://github.com/stac-utils/stac-fastapi/pull/181)
 
 ## 1.1.0 (2021-01-28)

--- a/scripts/publish
+++ b/scripts/publish
@@ -8,11 +8,11 @@ fi
 
 # Import shared variables
 SUBPACKAGE_DIRS=(
-    "stac_fastapi_types"
-    "stac_fastapi_extensions"
-    "stac_fastapi_api"
-    "stac_fastapi_postgres"
-    "stac_fastapi_server"
+    "stac_fastapi/types"
+    "stac_fastapi/extensions"
+    "stac_fastapi/api"
+    "stac_fastapi/sqlalchemy"
+    "stac_fastapi/pgstac"
 )
 
 function usage() {
@@ -69,8 +69,4 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         popd
 
     done
-
-    rm -rf dist
-    python setup.py sdist bdist_wheel
-    twine upload ${TEST_PYPI} dist/*
 fi

--- a/stac_fastapi/api/stac_fastapi/api/version.py
+++ b/stac_fastapi/api/stac_fastapi/api/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "1.1.0"
+__version__ = "2.0.0"

--- a/stac_fastapi/extensions/stac_fastapi/extensions/version.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "1.1.0"
+__version__ = "2.0.0"

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/version.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "0.1.0"
+__version__ = "2.0.0"

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/version.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "1.1.0"
+__version__ = "2.0.0"

--- a/stac_fastapi/types/stac_fastapi/types/version.py
+++ b/stac_fastapi/types/stac_fastapi/types/version.py
@@ -1,2 +1,2 @@
 """library version."""
-__version__ = "1.1.0"
+__version__ = "2.0.0"


### PR DESCRIPTION
This PR prepares for a 2.0.0 by setting the version numbers and updating the changelog.

Fixed the publishing script to work with the repo reorganization. Tested pushing to test.pypi. Also added some changelog entries that were missing; there are some PRs not accounted for but captured the highlights; feel free to add other entries.

Next steps after this PR gets merged, we should be able to tag off of master, push up, and create a GitHub release. The "publish" GitHub Actions workflow will pick up the tag and publish to pypi