### PR TITLE
Preserve relative paths on link generation

### DIFF
--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
@@ -239,7 +239,7 @@ class TileLinks:
         """Post init handler."""
         self.item_uri = urljoin(
             self.base_url,
-            f"/collections/{self.collection_id}/items/{self.item_id}",
+            f"collections/{self.collection_id}/items/{self.item_id}",
         )
 
     def link_tiles(self) -> Dict:
@@ -247,7 +247,7 @@ class TileLinks:
         return dict(
             href=urljoin(
                 self.base_url,
-                f"/titiler/tiles/{{z}}/{{x}}/{{y}}.png?url={self.item_uri}",
+                f"titiler/tiles/{{z}}/{{x}}/{{y}}.png?url={self.item_uri}",
             ),
             rel=Relations.item.value,
             title="tiles",
@@ -258,7 +258,7 @@ class TileLinks:
     def link_viewer(self) -> Dict:
         """Create viewer link."""
         return dict(
-            href=urljoin(self.base_url, f"/titiler/viewer?url={self.item_uri}"),
+            href=urljoin(self.base_url, f"titiler/viewer?url={self.item_uri}"),
             rel=Relations.alternate.value,
             type=MimeTypes.html.value,
             title="viewer",
@@ -267,7 +267,7 @@ class TileLinks:
     def link_tilejson(self) -> Dict:
         """Create tilejson link."""
         return dict(
-            href=urljoin(self.base_url, f"/titiler/tilejson.json?url={self.item_uri}"),
+            href=urljoin(self.base_url, f"titiler/tilejson.json?url={self.item_uri}"),
             rel=Relations.alternate.value,
             type=MimeTypes.json.value,
             title="tilejson",
@@ -278,7 +278,7 @@ class TileLinks:
         return dict(
             href=urljoin(
                 self.base_url,
-                f"/titiler/WMTSCapabilities.xml?url={self.item_uri}",
+                f"titiler/WMTSCapabilities.xml?url={self.item_uri}",
             ),
             rel=Relations.alternate.value,
             type=MimeTypes.xml.value,

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
@@ -204,9 +204,7 @@ class ItemLinks(CollectionLinksBase):
         return dict(
             rel=Relations.self.value,
             type=MimeTypes.geojson.value,
-            href=self.resolve(
-                f"collections/{self.collection_id}/items/{self.item_id}"
-            ),
+            href=self.resolve(f"collections/{self.collection_id}/items/{self.item_id}"),
         )
 
     def link_parent(self) -> Dict:

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
@@ -164,7 +164,7 @@ class CollectionLinksBase(BaseLinks):
         return dict(
             rel=rel,
             type=MimeTypes.json.value,
-            href=self.resolve(f"/collections/{self.collection_id}"),
+            href=self.resolve(f"collections/{self.collection_id}"),
         )
 
 
@@ -189,7 +189,7 @@ class CollectionLinks(CollectionLinksBase):
         return dict(
             rel="items",
             type=MimeTypes.geojson.value,
-            href=self.resolve(f"/collections/{self.collection_id}/items"),
+            href=self.resolve(f"collections/{self.collection_id}/items"),
         )
 
 
@@ -205,7 +205,7 @@ class ItemLinks(CollectionLinksBase):
             rel=Relations.self.value,
             type=MimeTypes.geojson.value,
             href=self.resolve(
-                f"/collections/{self.collection_id}/items/{self.item_id}"
+                f"collections/{self.collection_id}/items/{self.item_id}"
             ),
         )
 
@@ -224,7 +224,7 @@ class ItemLinks(CollectionLinksBase):
             type=MimeTypes.json.value,
             title="tiles",
             href=self.resolve(
-                f"/collections/{self.collection_id}/items/{self.item_id}/tiles",
+                f"collections/{self.collection_id}/items/{self.item_id}/tiles",
             ),
         )
 

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -913,20 +913,18 @@ async def test_search_invalid_query_field(app_client):
 
 
 @pytest.mark.asyncio
-async def test_relative_link_construction(load_test_data, altered_root_app_client):
-
+async def test_relative_link_construction():
     req = Request(
         scope={
-            'type': 'http',
-            'scheme': 'http',
-            'method': 'PUT',
-            'root_path': 'http://test/stac',
-            'path': '/',
-            'raw_path': b'/tab/abc',
-            'query_string': b'',
-            'headers': {}
+            "type": "http",
+            "scheme": "http",
+            "method": "PUT",
+            "root_path": "http://test/stac",
+            "path": "/",
+            "raw_path": b"/tab/abc",
+            "query_string": b"",
+            "headers": {},
         }
     )
     links = CollectionLinks(collection_id="naip", request=req)
-
-    assert links.link_items()['href'] == "http://test/stac/collections/naip/items"
+    assert links.link_items()["href"] == "http://test/stac/collections/naip/items"

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from ..conftest import MockStarletteRequest
 
+
 STAC_CORE_ROUTES = [
     "GET /",
     "GET /collections",

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from ..conftest import MockStarletteRequest
 
-
 STAC_CORE_ROUTES = [
     "GET /",
     "GET /collections",

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -229,6 +229,7 @@ class LandingPageMixin:
     landing_page_id: str = attr.ib(default="stac-fastapi")
     title: str = attr.ib(default="stac-fastapi")
     description: str = attr.ib(default="stac-fastapi")
+    conformance_classes: List[str] = attr.ib()
 
     def _landing_page(self, base_url: str) -> stac_types.LandingPage:
         landing_page = stac_types.LandingPage(
@@ -237,10 +238,7 @@ class LandingPageMixin:
             title=self.title,
             description=self.description,
             stac_version=self.stac_version,
-            conformsTo=[
-                "https://stacspec.org/STAC-api.html",
-                "http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#ats_geojson",
-            ],
+            conformsTo=self.conformance_classes,
             links=[
                 {
                     "rel": Relations.self.value,
@@ -262,7 +260,7 @@ class LandingPageMixin:
                     "rel": Relations.conformance.value,
                     "type": MimeTypes.json,
                     "title": "STAC/WFS3 conformance classes implemented by this server",
-                    "href": base_url,
+                    "href": urljoin(base_url, "conformance"),
                 },
                 {
                     "rel": Relations.search.value,
@@ -285,6 +283,12 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
     """
 
     extensions: List[ApiExtension] = attr.ib(default=attr.Factory(list))
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: [
+            "https://stacspec.org/STAC-api.html",
+            "http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#ats_geojson",
+        ]
+    )
 
     def extension_is_enabled(self, extension: Type[ApiExtension]) -> bool:
         """Check if an api extension is enabled."""
@@ -312,7 +316,6 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
             )
         return landing_page
 
-    @abc.abstractmethod
     def conformance(self, **kwargs) -> stac_types.Conformance:
         """Conformance classes.
 
@@ -321,7 +324,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         Returns:
             Conformance classes which the server conforms to.
         """
-        ...
+        stac_types.Conformance(conformsTo=self.conformance_classes)
 
     @abc.abstractmethod
     def post_search(
@@ -430,6 +433,12 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
     """
 
     extensions: List[ApiExtension] = attr.ib(default=attr.Factory(list))
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: [
+            "https://stacspec.org/STAC-api.html",
+            "http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#ats_geojson",
+        ]
+    )
 
     def extension_is_enabled(self, extension: Type[ApiExtension]) -> bool:
         """Check if an api extension is enabled."""
@@ -457,7 +466,6 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
             )
         return landing_page
 
-    @abc.abstractmethod
     async def conformance(self, **kwargs) -> stac_types.Conformance:
         """Conformance classes.
 
@@ -466,7 +474,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         Returns:
             Conformance classes which the server conforms to.
         """
-        ...
+        stac_types.Conformance(conformsTo=self.conformance_classes)
 
     @abc.abstractmethod
     async def post_search(

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -225,11 +225,11 @@ class AsyncBaseTransactionsClient(abc.ABC):
 class LandingPageMixin:
     """Create a STAC landing page (GET /)."""
 
+    conformance_classes: List[str] = attr.ib()
     stac_version: str = attr.ib(default=STAC_VERSION)
     landing_page_id: str = attr.ib(default="stac-fastapi")
     title: str = attr.ib(default="stac-fastapi")
     description: str = attr.ib(default="stac-fastapi")
-    conformance_classes: List[str] = attr.ib()
 
     def _landing_page(self, base_url: str) -> stac_types.LandingPage:
         landing_page = stac_types.LandingPage(


### PR DESCRIPTION
This PR addresses a couple of small issues introduced with the recent stac-pydantic 2.0 and model customization updates. First, `urljoin`s now build links preserving relative paths. Second, conformance classes are now on `CoreCrudClient` and its async variant, enabling users to customize these values when instantiating a client