### PR TITLE
add in urljoin to complete conformance href

### DIFF
--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -262,7 +262,7 @@ class LandingPageMixin:
                     "rel": Relations.conformance.value,
                     "type": MimeTypes.json,
                     "title": "STAC/WFS3 conformance classes implemented by this server",
-                    "href": base_url,
+                    "href": urljoin(base_url, "conformance"),
                 },
                 {
                     "rel": Relations.search.value,


### PR DESCRIPTION
landing page fix to complete conformance href

before:
<img width="547" alt="before-conformance" src="https://user-images.githubusercontent.com/2285647/127351203-89c74ca9-d607-4add-9ccd-f47fa4afd3e6.png">

after conformance-url fix:
<img width="545" alt="after-conformance" src="https://user-images.githubusercontent.com/2285647/127351314-732393fb-65de-4386-ba66-8be1f3888603.png">
