### PR TITLE
Wait for 5432 to be available before running apps in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     depends_on:
       - database
     command:
-      python -m stac_fastapi.sqlalchemy.app
+      bash -c "./scripts/wait-for-it.sh database:5432 && python -m stac_fastapi.sqlalchemy.app"
 
   app-pgstac:
     container_name: stac-fastapi-pgstac
@@ -65,7 +65,7 @@ services:
     depends_on:
       - database
     command:
-      python -m stac_fastapi.pgstac.app
+      bash -c "./scripts/wait-for-it.sh database:5432 && python -m stac_fastapi.pgstac.app"
 
   database:
     container_name: stac-db


### PR DESCRIPTION
Use wait-for-it.sh on port 5432 (Postgres) before starting the app in both sqlalchemy and pgstac backends on Docker.

I believe this is what was causing the issues in #205 and #206