### PR TITLE
Add Support for CQL JSON to Stac FastAPI PGStac Backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     depends_on:
       - database
     command:
-      python -m stac_fastapi.sqlalchemy.app
+      bash -c "./scripts/wait-for-it.sh database:5432 && python -m stac_fastapi.sqlalchemy.app"
 
   app-pgstac:
     container_name: stac-fastapi-pgstac
@@ -65,7 +65,7 @@ services:
     depends_on:
       - database
     command:
-      python -m stac_fastapi.pgstac.app
+      bash -c "./scripts/wait-for-it.sh database:5432 && python -m stac_fastapi.pgstac.app"
 
   database:
     container_name: stac-db

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
@@ -96,6 +96,7 @@ class PgstacSearch(Search):
     fields: FieldsExtension = Field(FieldsExtension())
     # Override query extension with supported operators
     query: Optional[Dict[str, Dict[Operator, Any]]]
+    filter: Optional[Dict]
     token: Optional[str] = None
     datetime: Optional[str] = None
     sortby: Any


### PR DESCRIPTION
Adds filter to PGStac Search to allow CQL filters to be passed to the PGStac backend to leverage the new CQL functionality in https://github.com/stac-utils/pgstac/pull/38