### PR TITLE
Return empty item collection instead of error when searching

### DIFF
--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -75,7 +75,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             )
             collection = await conn.fetchval(q, *p)
         if collection is None:
-            raise NotFoundError
+            raise NotFoundError(f"Collection {id} does not exist.")
         links = await CollectionLinks(collection_id=id, request=request).get_links()
         collection["links"] = links
         return Collection(**collection)

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -113,8 +113,6 @@ class CoreCrudClient(AsyncBaseCoreClient):
         prev: Optional[str] = items.pop("prev", None)
         collection = ItemCollection(**items)
         cleaned_features: List[Item] = []
-        if collection["features"] is None or len(collection["features"]) == 0:
-            raise NotFoundError("No features found")
 
         for feature in collection["features"]:
             feature = Item(**feature)

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -160,27 +160,16 @@ class CoreCrudClient(AsyncBaseCoreClient):
             An ItemCollection.
         """
 
-        # If collection doesn't exist, raise NotFoundError
-        request: Request = kwargs["request"]
-        pool = request.app.state.readpool
-        async with pool.acquire() as conn:
-            q, p = render(
-                """
-                SELECT * FROM get_collection(:id::text);
-                """,
-                id=id,
-            )
-            collection = await conn.fetchval(q, *p)
-        if collection is None:
-            raise NotFoundError(f"Collection {id} does not exist.")
+        # If collection does not exist, NotFoundError wil be raised
+        collection = await self.get_collection(id, **kwargs)
 
         req = PgstacSearch(collections=[id], limit=limit, token=token)
-        collection = await self._search_base(req, **kwargs)
+        item_collection = await self._search_base(req, **kwargs)
         links = await CollectionLinks(
             collection_id=id, request=kwargs["request"]
-        ).get_links(extra_links=collection["links"])
-        collection["links"] = links
-        return collection
+        ).get_links(extra_links=item_collection["links"])
+        item_collection["links"] = links
+        return item_collection
 
     async def get_item(self, item_id: str, collection_id: str, **kwargs) -> Item:
         """Get item by id.
@@ -193,12 +182,15 @@ class CoreCrudClient(AsyncBaseCoreClient):
         Returns:
             Item.
         """
-        req = PgstacSearch(ids=[item_id], limit=1)
-        collection = await self._search_base(req, **kwargs)
-        if not collection["features"]:
-            raise NotFoundError
+        # If collection does not exist, NotFoundError wil be raised
+        collection = await self.get_collection(collection_id, **kwargs)
 
-        return Item(**collection["features"][0])
+        req = PgstacSearch(ids=[item_id], limit=1)
+        item_collection = await self._search_base(req, **kwargs)
+        if not item_collection["features"]:
+            raise NotFoundError(f"Collection {collection_id} does not exist.")
+
+        return Item(**item_collection["features"][0])
 
     async def post_search(
         self, search_request: PgstacSearch, **kwargs

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -159,9 +159,8 @@ class CoreCrudClient(AsyncBaseCoreClient):
         Returns:
             An ItemCollection.
         """
-
         # If collection does not exist, NotFoundError wil be raised
-        collection = await self.get_collection(id, **kwargs)
+        await self.get_collection(id, **kwargs)
 
         req = PgstacSearch(collections=[id], limit=limit, token=token)
         item_collection = await self._search_base(req, **kwargs)
@@ -183,7 +182,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             Item.
         """
         # If collection does not exist, NotFoundError wil be raised
-        collection = await self.get_collection(collection_id, **kwargs)
+        await self.get_collection(collection_id, **kwargs)
 
         req = PgstacSearch(ids=[item_id], limit=1)
         item_collection = await self._search_base(req, **kwargs)

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -180,6 +180,9 @@ class CoreCrudClient(AsyncBaseCoreClient):
         """
         req = PgstacSearch(ids=[item_id], limit=1)
         collection = await self._search_base(req, **kwargs)
+        if not collection["features"]:
+            raise NotFoundError
+
         return Item(**collection["features"][0])
 
     async def post_search(

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -338,18 +338,18 @@ async def test_item_search_by_id_post(app_client, load_test_data, load_test_coll
     assert set([feat["id"] for feat in resp_json["features"]]) == set(ids)
 
 
-# @pytest.mark.asyncio
-# async def test_item_search_by_id_no_results_post(app_client, load_test_data, load_test_collection):
-#     """Test POST search by item id (core) when there are no results"""
-#     test_item = load_test_data("test_item.json")
-#
-#     search_ids = ["nonexistent_id"]
-#
-#     params = {"collections": [test_item["collection"]], "ids": search_ids}
-#     resp = await app_client.post("/search", json=params)
-#     assert resp.status_code == 200
-#     resp_json = resp.json()
-#     assert len(resp_json["features"]) == 0
+@pytest.mark.asyncio
+async def test_item_search_by_id_no_results_post(app_client, load_test_data, load_test_collection):
+    """Test POST search by item id (core) when there are no results"""
+    test_item = load_test_data("test_item.json")
+
+    search_ids = ["nonexistent_id"]
+
+    params = {"collections": [test_item["collection"]], "ids": search_ids}
+    resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 0
 
 @pytest.mark.asyncio
 async def test_item_search_spatial_query_post(

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -49,7 +49,7 @@ async def test_update_collection(app_client, load_test_data, load_test_collectio
 
 @pytest.mark.asyncio
 async def test_delete_collection(
-        app_client, load_test_data: Callable, load_test_collection
+    app_client, load_test_data: Callable, load_test_collection
 ):
     in_coll = load_test_collection
 
@@ -84,7 +84,7 @@ async def test_create_item(app_client, load_test_data: Callable, load_test_colle
 
 @pytest.mark.asyncio
 async def test_fetches_valid_item(
-        app_client, load_test_data: Callable, load_test_collection
+    app_client, load_test_data: Callable, load_test_collection
 ):
     coll = load_test_collection
 
@@ -113,7 +113,7 @@ async def test_fetches_valid_item(
 
 @pytest.mark.asyncio
 async def test_update_item(
-        app_client, load_test_data: Callable, load_test_collection, load_test_item
+    app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -133,7 +133,7 @@ async def test_update_item(
 
 @pytest.mark.asyncio
 async def test_delete_item(
-        app_client, load_test_data: Callable, load_test_collection, load_test_item
+    app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -170,7 +170,7 @@ async def test_get_collection_items(app_client, load_test_collection, load_test_
 
 @pytest.mark.asyncio
 async def test_create_item_conflict(
-        app_client, load_test_data: Callable, load_test_collection
+    app_client, load_test_data: Callable, load_test_collection
 ):
     pass
 
@@ -191,7 +191,7 @@ async def test_create_item_conflict(
 
 @pytest.mark.asyncio
 async def test_delete_missing_item(
-        app_client, load_test_data: Callable, load_test_collection, load_test_item
+    app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -207,7 +207,7 @@ async def test_delete_missing_item(
 
 @pytest.mark.asyncio
 async def test_create_item_missing_collection(
-        app_client, load_test_data: Callable, load_test_collection
+    app_client, load_test_data: Callable, load_test_collection
 ):
     coll = load_test_collection
     item = load_test_data("test_item.json")
@@ -219,7 +219,7 @@ async def test_create_item_missing_collection(
 
 @pytest.mark.asyncio
 async def test_update_new_item(
-        app_client, load_test_data: Callable, load_test_collection, load_test_item
+    app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -231,7 +231,7 @@ async def test_update_new_item(
 
 @pytest.mark.asyncio
 async def test_update_item_missing_collection(
-        app_client, load_test_data: Callable, load_test_collection, load_test_item
+    app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -354,7 +354,7 @@ async def test_item_search_by_id_no_results_post(app_client, load_test_data, loa
 
 @pytest.mark.asyncio
 async def test_item_search_spatial_query_post(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test POST search with spatial query (core)"""
     test_item = load_test_data("test_item.json")
@@ -375,7 +375,7 @@ async def test_item_search_spatial_query_post(
 
 @pytest.mark.asyncio
 async def test_item_search_temporal_query_post(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test POST search with single-tailed spatio-temporal query (core)"""
     test_item = load_test_data("test_item.json")
@@ -402,7 +402,7 @@ async def test_item_search_temporal_query_post(
 
 @pytest.mark.asyncio
 async def test_item_search_temporal_window_post(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test POST search with two-tailed spatio-temporal query (core)"""
     test_item = load_test_data("test_item.json")
@@ -427,7 +427,7 @@ async def test_item_search_temporal_window_post(
 
 @pytest.mark.asyncio
 async def test_item_search_temporal_open_window(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test POST search with open spatio-temporal query (core)"""
     test_item = load_test_data("test_item.json")
@@ -517,7 +517,7 @@ async def test_item_search_bbox_get(app_client, load_test_data, load_test_collec
 
 @pytest.mark.asyncio
 async def test_item_search_get_without_collections(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test GET search without specifying collections"""
     test_item = load_test_data("test_item.json")
@@ -537,7 +537,7 @@ async def test_item_search_get_without_collections(
 
 @pytest.mark.asyncio
 async def test_item_search_temporal_window_get(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test GET search with spatio-temporal query (core)"""
     test_item = load_test_data("test_item.json")
@@ -588,7 +588,7 @@ async def test_item_search_sort_get(app_client, load_test_data, load_test_collec
 
 @pytest.mark.asyncio
 async def test_item_search_post_without_collection(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test POST search without specifying a collection"""
     test_item = load_test_data("test_item.json")
@@ -608,7 +608,7 @@ async def test_item_search_post_without_collection(
 
 @pytest.mark.asyncio
 async def test_item_search_properties_jsonb(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test POST search with JSONB query (query extension)"""
     test_item = load_test_data("test_item.json")
@@ -628,7 +628,7 @@ async def test_item_search_properties_jsonb(
 
 @pytest.mark.asyncio
 async def test_item_search_properties_field(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test POST search indexed field with query (query extension)"""
     test_item = load_test_data("test_item.json")
@@ -647,7 +647,7 @@ async def test_item_search_properties_field(
 
 @pytest.mark.asyncio
 async def test_item_search_get_query_extension(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test GET search with JSONB query (query extension)"""
     test_item = load_test_data("test_item.json")
@@ -696,7 +696,7 @@ async def test_get_item_from_missing_item_collection(app_client):
 
 @pytest.mark.asyncio
 async def test_pagination_item_collection(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test item collection pagination links (paging extension)"""
     test_item = load_test_data("test_item.json")
@@ -785,7 +785,7 @@ async def test_pagination_post(app_client, load_test_data, load_test_collection)
 
 @pytest.mark.asyncio
 async def test_pagination_token_idempotent(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test that pagination tokens are idempotent (paging extension)"""
     test_item = load_test_data("test_item.json")
@@ -870,7 +870,7 @@ async def test_field_extension_post(app_client, load_test_data, load_test_collec
 
 @pytest.mark.asyncio
 async def test_field_extension_exclude_and_include(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test POST search including/excluding same field (fields extension)"""
     test_item = load_test_data("test_item.json")
@@ -893,7 +893,7 @@ async def test_field_extension_exclude_and_include(
 
 @pytest.mark.asyncio
 async def test_field_extension_exclude_default_includes(
-        app_client, load_test_data, load_test_collection
+    app_client, load_test_data, load_test_collection
 ):
     """Test POST search excluding a forbidden field (fields extension)"""
     test_item = load_test_data("test_item.json")

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -689,7 +689,7 @@ async def test_get_missing_item_collection(app_client):
 
 @pytest.mark.asyncio
 async def test_get_item_from_missing_item_collection(app_client):
-    """Test reading a collection which does not exist"""
+    """Test reading an item from a collection which does not exist"""
     resp = await app_client.get("/collections/invalid-collection/items/some-item")
     assert resp.status_code == 404
 

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -338,6 +338,19 @@ async def test_item_search_by_id_post(app_client, load_test_data, load_test_coll
     assert set([feat["id"] for feat in resp_json["features"]]) == set(ids)
 
 
+# @pytest.mark.asyncio
+# async def test_item_search_by_id_no_results_post(app_client, load_test_data, load_test_collection):
+#     """Test POST search by item id (core) when there are no results"""
+#     test_item = load_test_data("test_item.json")
+#
+#     search_ids = ["nonexistent_id"]
+#
+#     params = {"collections": [test_item["collection"]], "ids": search_ids}
+#     resp = await app_client.post("/search", json=params)
+#     assert resp.status_code == 200
+#     resp_json = resp.json()
+#     assert len(resp_json["features"]) == 0
+
 @pytest.mark.asyncio
 async def test_item_search_spatial_query_post(
     app_client, load_test_data, load_test_collection
@@ -650,7 +663,9 @@ async def test_item_search_get_query_extension(
         ),
     }
     resp = await app_client.get("/search", params=params)
-    assert resp.status_code == 404
+    # No items found should still return a 200 but with an empty list of features
+    assert resp.status_code == 200
+    assert len(resp.json()["features"]) == 0
 
     params["query"] = json.dumps(
         {"proj:epsg": {"eq": test_item["properties"]["proj:epsg"]}}

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -339,7 +339,9 @@ async def test_item_search_by_id_post(app_client, load_test_data, load_test_coll
 
 
 @pytest.mark.asyncio
-async def test_item_search_by_id_no_results_post(app_client, load_test_data, load_test_collection):
+async def test_item_search_by_id_no_results_post(
+    app_client, load_test_data, load_test_collection
+):
     """Test POST search by item id (core) when there are no results"""
     test_item = load_test_data("test_item.json")
 
@@ -675,8 +677,8 @@ async def test_item_search_get_query_extension(
     resp_json = resp.json()
     assert len(resp.json()["features"]) == 1
     assert (
-            resp_json["features"][0]["properties"]["proj:epsg"]
-            == test_item["properties"]["proj:epsg"]
+        resp_json["features"][0]["properties"]["proj:epsg"]
+        == test_item["properties"]["proj:epsg"]
     )
 
 

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -49,7 +49,7 @@ async def test_update_collection(app_client, load_test_data, load_test_collectio
 
 @pytest.mark.asyncio
 async def test_delete_collection(
-    app_client, load_test_data: Callable, load_test_collection
+        app_client, load_test_data: Callable, load_test_collection
 ):
     in_coll = load_test_collection
 
@@ -84,7 +84,7 @@ async def test_create_item(app_client, load_test_data: Callable, load_test_colle
 
 @pytest.mark.asyncio
 async def test_fetches_valid_item(
-    app_client, load_test_data: Callable, load_test_collection
+        app_client, load_test_data: Callable, load_test_collection
 ):
     coll = load_test_collection
 
@@ -113,7 +113,7 @@ async def test_fetches_valid_item(
 
 @pytest.mark.asyncio
 async def test_update_item(
-    app_client, load_test_data: Callable, load_test_collection, load_test_item
+        app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -133,7 +133,7 @@ async def test_update_item(
 
 @pytest.mark.asyncio
 async def test_delete_item(
-    app_client, load_test_data: Callable, load_test_collection, load_test_item
+        app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -170,7 +170,7 @@ async def test_get_collection_items(app_client, load_test_collection, load_test_
 
 @pytest.mark.asyncio
 async def test_create_item_conflict(
-    app_client, load_test_data: Callable, load_test_collection
+        app_client, load_test_data: Callable, load_test_collection
 ):
     pass
 
@@ -191,7 +191,7 @@ async def test_create_item_conflict(
 
 @pytest.mark.asyncio
 async def test_delete_missing_item(
-    app_client, load_test_data: Callable, load_test_collection, load_test_item
+        app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -207,7 +207,7 @@ async def test_delete_missing_item(
 
 @pytest.mark.asyncio
 async def test_create_item_missing_collection(
-    app_client, load_test_data: Callable, load_test_collection
+        app_client, load_test_data: Callable, load_test_collection
 ):
     coll = load_test_collection
     item = load_test_data("test_item.json")
@@ -219,7 +219,7 @@ async def test_create_item_missing_collection(
 
 @pytest.mark.asyncio
 async def test_update_new_item(
-    app_client, load_test_data: Callable, load_test_collection, load_test_item
+        app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -231,7 +231,7 @@ async def test_update_new_item(
 
 @pytest.mark.asyncio
 async def test_update_item_missing_collection(
-    app_client, load_test_data: Callable, load_test_collection, load_test_item
+        app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
     coll = load_test_collection
     item = load_test_item
@@ -351,9 +351,10 @@ async def test_item_search_by_id_no_results_post(app_client, load_test_data, loa
     resp_json = resp.json()
     assert len(resp_json["features"]) == 0
 
+
 @pytest.mark.asyncio
 async def test_item_search_spatial_query_post(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test POST search with spatial query (core)"""
     test_item = load_test_data("test_item.json")
@@ -374,7 +375,7 @@ async def test_item_search_spatial_query_post(
 
 @pytest.mark.asyncio
 async def test_item_search_temporal_query_post(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test POST search with single-tailed spatio-temporal query (core)"""
     test_item = load_test_data("test_item.json")
@@ -401,7 +402,7 @@ async def test_item_search_temporal_query_post(
 
 @pytest.mark.asyncio
 async def test_item_search_temporal_window_post(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test POST search with two-tailed spatio-temporal query (core)"""
     test_item = load_test_data("test_item.json")
@@ -426,7 +427,7 @@ async def test_item_search_temporal_window_post(
 
 @pytest.mark.asyncio
 async def test_item_search_temporal_open_window(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test POST search with open spatio-temporal query (core)"""
     test_item = load_test_data("test_item.json")
@@ -516,7 +517,7 @@ async def test_item_search_bbox_get(app_client, load_test_data, load_test_collec
 
 @pytest.mark.asyncio
 async def test_item_search_get_without_collections(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test GET search without specifying collections"""
     test_item = load_test_data("test_item.json")
@@ -536,7 +537,7 @@ async def test_item_search_get_without_collections(
 
 @pytest.mark.asyncio
 async def test_item_search_temporal_window_get(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test GET search with spatio-temporal query (core)"""
     test_item = load_test_data("test_item.json")
@@ -587,7 +588,7 @@ async def test_item_search_sort_get(app_client, load_test_data, load_test_collec
 
 @pytest.mark.asyncio
 async def test_item_search_post_without_collection(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test POST search without specifying a collection"""
     test_item = load_test_data("test_item.json")
@@ -607,7 +608,7 @@ async def test_item_search_post_without_collection(
 
 @pytest.mark.asyncio
 async def test_item_search_properties_jsonb(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test POST search with JSONB query (query extension)"""
     test_item = load_test_data("test_item.json")
@@ -627,7 +628,7 @@ async def test_item_search_properties_jsonb(
 
 @pytest.mark.asyncio
 async def test_item_search_properties_field(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test POST search indexed field with query (query extension)"""
     test_item = load_test_data("test_item.json")
@@ -646,7 +647,7 @@ async def test_item_search_properties_field(
 
 @pytest.mark.asyncio
 async def test_item_search_get_query_extension(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test GET search with JSONB query (query extension)"""
     test_item = load_test_data("test_item.json")
@@ -674,8 +675,8 @@ async def test_item_search_get_query_extension(
     resp_json = resp.json()
     assert len(resp.json()["features"]) == 1
     assert (
-        resp_json["features"][0]["properties"]["proj:epsg"]
-        == test_item["properties"]["proj:epsg"]
+            resp_json["features"][0]["properties"]["proj:epsg"]
+            == test_item["properties"]["proj:epsg"]
     )
 
 
@@ -687,8 +688,15 @@ async def test_get_missing_item_collection(app_client):
 
 
 @pytest.mark.asyncio
+async def test_get_item_from_missing_item_collection(app_client):
+    """Test reading a collection which does not exist"""
+    resp = await app_client.get("/collections/invalid-collection/items/some-item")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_pagination_item_collection(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test item collection pagination links (paging extension)"""
     test_item = load_test_data("test_item.json")
@@ -777,7 +785,7 @@ async def test_pagination_post(app_client, load_test_data, load_test_collection)
 
 @pytest.mark.asyncio
 async def test_pagination_token_idempotent(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test that pagination tokens are idempotent (paging extension)"""
     test_item = load_test_data("test_item.json")
@@ -862,7 +870,7 @@ async def test_field_extension_post(app_client, load_test_data, load_test_collec
 
 @pytest.mark.asyncio
 async def test_field_extension_exclude_and_include(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test POST search including/excluding same field (fields extension)"""
     test_item = load_test_data("test_item.json")
@@ -885,7 +893,7 @@ async def test_field_extension_exclude_and_include(
 
 @pytest.mark.asyncio
 async def test_field_extension_exclude_default_includes(
-    app_client, load_test_data, load_test_collection
+        app_client, load_test_data, load_test_collection
 ):
     """Test POST search excluding a forbidden field (fields extension)"""
     test_item = load_test_data("test_item.json")


### PR DESCRIPTION
This PR addresses issue https://github.com/stac-utils/stac-fastapi/issues/172. 
- A POST to `/search` that returns no items now returns an empty list of features rather than a 404 and `NotFoundError`;
- I kept the logic that a GET `/collections/{collectionId}/items` with an invalid collection ID still returns a 404 rather than a 200 with an empty features list 
- I added logic such that a GET to `/collections/{collectionId}/items/{itemId}` with an invalid collection ID returns a 404

Testing:
- Added a few unit tests and all unit tests are passing
- Ran locally and tested behavior as expected

cc: @moradology, @lossyrob 