### PR TITLE
Fix/add landing page links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ run-database:
 run-joplin-sqlalchemy:
 	docker-compose run --rm loadjoplin-sqlalchemy
 
+.PHONY: run-joplin-sqlalchemy
+run-joplin-sqlalchemy:
+	docker-compose run --rm loadjoplin-sqlalchemy
+
 .PHONY: test
 test: test-sqlalchemy test-pgstac
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -62,7 +62,11 @@ class StacApi:
     exceptions: Dict[Type[Exception], int] = attr.ib(
         default=attr.Factory(lambda: DEFAULT_STATUS_CODES)
     )
-    app: FastAPI = attr.ib(default=attr.Factory(FastAPI))
+    app: FastAPI = attr.ib(
+        default=attr.Factory(
+            lambda self: FastAPI(openapi_url=self.settings.openapi_url), takes_self=True
+        )
+    )
     router: APIRouter = attr.ib(default=attr.Factory(APIRouter))
     title: str = attr.ib(default="stac-fastapi")
     api_version: str = attr.ib(default="0.1")

--- a/stac_fastapi/pgstac/tests/clients/test_postgres.py
+++ b/stac_fastapi/pgstac/tests/clients/test_postgres.py
@@ -80,7 +80,7 @@ async def test_update_item(app_client, load_test_collection, load_test_item):
 
     item.properties.description = "Update Test"
 
-    resp = await app_client.put(f"/collections/{coll.id}/items", data=item.json())
+    resp = await app_client.put(f"/collections/{coll.id}/items", content=item.json())
     assert resp.status_code == 200
 
     resp = await app_client.get(f"/collections/{coll.id}/items/{item.id}")
@@ -113,7 +113,7 @@ async def test_get_collection_items(app_client, load_test_collection, load_test_
         item.id = str(uuid.uuid4())
         resp = await app_client.post(
             f"/collections/{coll.id}/items",
-            data=item.json(),
+            content=item.json(),
         )
         assert resp.status_code == 200
 

--- a/stac_fastapi/pgstac/tests/conftest.py
+++ b/stac_fastapi/pgstac/tests/conftest.py
@@ -111,7 +111,7 @@ async def app(api_client):
 
 
 @pytest.mark.asyncio
-@pytest.fixture()
+@pytest.fixture(scope="session")
 async def app_client(app):
     async with AsyncClient(app=app, base_url="http://test") as c:
         yield c

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -39,9 +39,14 @@ async def test_search_link(response_json):
 
 @pytest.mark.asyncio
 async def test_conformance_link(response_json, app_client):
-    # Make sure conformance classes are linked
-    conf = get_link(response_json, "conformance")["href"]
-    resp = await app_client.get(conf)
+    conformance_link = get_link(response_json, "conformance")
+
+    assert conformance_link.get("type") == "application/json"
+
+    conformance_path = urllib.parse.urlsplit(conformance_link.get("href")).path
+    assert conformance_path == "/conformance"
+
+    resp = await app_client.get(conformance_path)
     assert resp.status_code == 200
 
 

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -34,7 +34,7 @@ link_tests = [
     ("root", "application/json", "/"),
     ("conformance", "application/json", "/conformance"),
     ("docs", "application/json", "/docs"),
-    ("service-desc", "application/vnd.oai.openapi+json;version=3.0", "/openapi.json"),
+    ("service-desc", "application/vnd.oai.openapi+json;version=3.0", "/api"),
 ]
 
 

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -17,24 +17,26 @@ def get_link(landing_page, rel_type):
     return next(filter(lambda link: link["rel"] == rel_type, landing_page["links"]))
 
 
-@pytest.mark.asyncio
-async def test_landing_page_health(response):
+def test_landing_page_health(response):
     """Test landing page"""
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
 
 
-@pytest.mark.asyncio
-async def test_search_link(response_json):
+def test_search_link(response_json):
     search_link = get_link(response_json, "search")
     assert search_link.get("type") == "application/geo+json"
+
+    search_path = urllib.parse.urlsplit(search_link.get("href")).path
+    assert search_path == "/search"
 
     # This endpoint currently returns a 404 for empty result sets, but testing for this response
     # code here seems meaningless since it would be the same as if the endpoint did not exist. Until
     # https://github.com/stac-utils/stac-fastapi/pull/227 has been merged, we simply test that the
     # path is correct.
-    search_path = urllib.parse.urlsplit(search_link.get("href")).path
-    assert search_path == "/search"
+    #
+    # resp = await app_client.get(search_path)
+    # assert resp.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -25,7 +25,13 @@ def test_landing_page_health(response):
     assert response.headers["content-type"] == "application/json"
 
 
+# Parameters for test_landing_page_links test below.
+# Each tuple has the following values (in this order):
+#  - Rel type of link to test
+#  - Expected MIME/Media Type
+#  - Expected relative path
 link_tests = [
+    ("root", "application/json", "/"),
     ("conformance", "application/json", "/conformance"),
     ("docs", "application/json", "/docs"),
     ("service-desc", "application/vnd.oai.openapi+json;version=3.0", "/openapi.json"),

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -1,21 +1,54 @@
+import urllib.parse
+
 import pytest
 
 
+@pytest.fixture(scope="module")
+async def response(app_client):
+    return await app_client.get("/")
+
+
+@pytest.fixture(scope="module")
+async def response_json(response):
+    return response.json()
+
+
+def get_link(landing_page, rel_type):
+    return next(filter(lambda link: link["rel"] == rel_type, landing_page["links"]))
+
+
 @pytest.mark.asyncio
-async def test_landing_page(app_client):
+async def test_landing_page_health(response):
     """Test landing page"""
-    resp = await app_client.get("/")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_search_link(response_json):
+    search_link = get_link(response_json, "search")
+    assert search_link.get("type") == "application/geo+json"
+
+    # This endpoint currently returns a 404 for empty result sets, but testing for this response
+    # code here seems meaningless since it would be the same as if the endpoint did not exist. Until
+    # https://github.com/stac-utils/stac-fastapi/pull/227 has been merged, we simply test that the
+    # path is correct.
+    search_path = urllib.parse.urlsplit(search_link.get("href")).path
+    assert search_path == "/search"
+
+
+@pytest.mark.asyncio
+async def test_conformance_link(response_json, app_client):
+    # Make sure conformance classes are linked
+    conf = get_link(response_json, "conformance")["href"]
+    resp = await app_client.get(conf)
     assert resp.status_code == 200
-    resp_json = resp.json()
+
+
+@pytest.mark.asyncio
+async def test_docs_link(response_json, app_client):
 
     # Make sure OpenAPI docs are linked
-    docs = next(filter(lambda link: link["rel"] == "docs", resp_json["links"]))["href"]
+    docs = get_link(response_json, "docs")["href"]
     resp = await app_client.get(docs)
-    assert resp.status_code == 200
-
-    # Make sure conformance classes are linked
-    conf = next(filter(lambda link: link["rel"] == "conformance", resp_json["links"]))[
-        "href"
-    ]
-    resp = await app_client.get(conf)
     assert resp.status_code == 200

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -120,7 +120,7 @@ async def test_update_item(
 
     item.properties.description = "Update Test"
 
-    resp = await app_client.put(f"/collections/{coll.id}/items", data=item.json())
+    resp = await app_client.put(f"/collections/{coll.id}/items", content=item.json())
     assert resp.status_code == 200
 
     resp = await app_client.get(f"/collections/{coll.id}/items/{item.id}")
@@ -155,7 +155,7 @@ async def test_get_collection_items(app_client, load_test_collection, load_test_
         item.id = str(uuid.uuid4())
         resp = await app_client.post(
             f"/collections/{coll.id}/items",
-            data=item.json(),
+            content=item.json(),
         )
         assert resp.status_code == 200
 
@@ -225,7 +225,7 @@ async def test_update_new_item(
     item = load_test_item
     item.id = "test-updatenewitem"
 
-    resp = await app_client.put(f"/collections/{coll.id}/items", data=item.json())
+    resp = await app_client.put(f"/collections/{coll.id}/items", content=item.json())
     assert resp.status_code == 404
 
 
@@ -237,7 +237,7 @@ async def test_update_item_missing_collection(
     item = load_test_item
     item.collection = None
 
-    resp = await app_client.put(f"/collections/{coll.id}/items", data=item.json())
+    resp = await app_client.put(f"/collections/{coll.id}/items", content=item.json())
     assert resp.status_code == 424
 
 

--- a/stac_fastapi/sqlalchemy/tests/resources/test_conformance.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_conformance.py
@@ -1,17 +1,68 @@
-def test_landing_page(app_client):
+import urllib.parse
+
+import pytest
+
+
+@pytest.fixture
+def response(app_client):
+    return app_client.get("/")
+
+
+@pytest.fixture
+def response_json(response):
+    return response.json()
+
+
+def get_link(landing_page, rel_type):
+    return next(
+        filter(lambda link: link["rel"] == rel_type, landing_page["links"]), None
+    )
+
+
+def test_landing_page_health(response):
     """Test landing page"""
-    resp = app_client.get("/")
-    assert resp.status_code == 200
-    resp_json = resp.json()
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
 
-    # Make sure OpenAPI docs are linked
-    docs = next(filter(lambda link: link["rel"] == "docs", resp_json["links"]))["href"]
-    resp = app_client.get(docs)
+
+# Parameters for test_landing_page_links test below.
+# Each tuple has the following values (in this order):
+#  - Rel type of link to test
+#  - Expected MIME/Media Type
+#  - Expected relative path
+link_tests = [
+    ("root", "application/json", "/"),
+    ("conformance", "application/json", "/conformance"),
+    ("docs", "application/json", "/docs"),
+    ("service-desc", "application/vnd.oai.openapi+json;version=3.0", "/openapi.json"),
+]
+
+
+@pytest.mark.parametrize("rel_type,expected_media_type,expected_path", link_tests)
+def test_landing_page_links(
+    response_json, app_client, rel_type, expected_media_type, expected_path
+):
+    link = get_link(response_json, rel_type)
+
+    assert link is not None, f"Missing {rel_type} link in landing page"
+    assert link.get("type") == expected_media_type
+
+    link_path = urllib.parse.urlsplit(link.get("href")).path
+    assert link_path == expected_path
+
+    resp = app_client.get(link_path)
     assert resp.status_code == 200
 
-    # Make sure conformance classes are linked
-    conf = next(filter(lambda link: link["rel"] == "conformance", resp_json["links"]))[
-        "href"
-    ]
-    resp = app_client.get(conf)
-    assert resp.status_code == 200
+
+# This endpoint currently returns a 404 for empty result sets, but testing for this response
+# code here seems meaningless since it would be the same as if the endpoint did not exist. Once
+# https://github.com/stac-utils/stac-fastapi/pull/227 has been merged we can add this to the
+# parameterized tests above.
+def test_search_link(response_json):
+    search_link = get_link(response_json, "search")
+
+    assert search_link is not None
+    assert search_link.get("type") == "application/geo+json"
+
+    search_path = urllib.parse.urlsplit(search_link.get("href")).path
+    assert search_path == "/search"

--- a/stac_fastapi/sqlalchemy/tests/resources/test_conformance.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_conformance.py
@@ -34,7 +34,7 @@ link_tests = [
     ("root", "application/json", "/"),
     ("conformance", "application/json", "/conformance"),
     ("docs", "application/json", "/docs"),
-    ("service-desc", "application/vnd.oai.openapi+json;version=3.0", "/openapi.json"),
+    ("service-desc", "application/vnd.oai.openapi+json;version=3.0", "/api"),
 ]
 
 

--- a/stac_fastapi/types/stac_fastapi/types/config.py
+++ b/stac_fastapi/types/stac_fastapi/types/config.py
@@ -26,6 +26,8 @@ class ApiSettings(BaseSettings):
     reload: bool = True
     enable_response_models: bool = False
 
+    openapi_url: str = "/api"
+
     class Config:
         """model config (https://pydantic-docs.helpmanual.io/usage/model_config/)."""
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -248,6 +248,11 @@ class LandingPageMixin(abc.ABC):
                     "href": base_url,
                 },
                 {
+                    "rel": Relations.root.value,
+                    "type": MimeTypes.json,
+                    "href": base_url,
+                },
+                {
                     "rel": "data",
                     "type": MimeTypes.json,
                     "href": urljoin(base_url, "collections"),

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -259,6 +259,12 @@ class LandingPageMixin(abc.ABC):
                     "href": urljoin(base_url, "docs"),
                 },
                 {
+                    "rel": "service-desc",
+                    "type": "application/vnd.oai.openapi+json;version=3.0",
+                    "title": "OpenAPI service description",
+                    "href": urljoin(base_url, "openapi.json"),
+                },
+                {
                     "rel": Relations.conformance.value,
                     "type": MimeTypes.json,
                     "title": "STAC/WFS3 conformance classes implemented by this server",

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 from urllib.parse import urljoin
 
 import attr
+from fastapi import Request
 from stac_pydantic.api import Search
 from stac_pydantic.links import Relations
 from stac_pydantic.shared import MimeTypes
@@ -264,12 +265,6 @@ class LandingPageMixin(abc.ABC):
                     "href": urljoin(base_url, "docs"),
                 },
                 {
-                    "rel": "service-desc",
-                    "type": "application/vnd.oai.openapi+json;version=3.0",
-                    "title": "OpenAPI service description",
-                    "href": urljoin(base_url, "openapi.json"),
-                },
-                {
                     "rel": Relations.conformance.value,
                     "type": MimeTypes.json,
                     "title": "STAC/WFS3 conformance classes implemented by this server",
@@ -329,10 +324,13 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         Returns:
             API landing page, serving as an entry point to the API.
         """
-        base_url = str(kwargs["request"].base_url)
+        request: Request = kwargs["request"]
+        base_url = str(request.base_url)
         landing_page = self._landing_page(
             base_url=base_url, conformance_classes=self.conformance_classes()
         )
+
+        # Add Collections links
         collections = self.all_collections(request=kwargs["request"])
         for collection in collections:
             landing_page["links"].append(
@@ -343,6 +341,16 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
                     "href": urljoin(base_url, f"collections/{collection['id']}"),
                 }
             )
+
+        # Add OpenAPI URL
+        landing_page["links"].append(
+            {
+                "rel": "service-desc",
+                "type": "application/vnd.oai.openapi+json;version=3.0",
+                "title": "OpenAPI service description",
+                "href": urljoin(base_url, request.app.openapi_url.lstrip("/")),
+            }
+        )
         return landing_page
 
     def conformance(self, **kwargs) -> stac_types.Conformance:
@@ -495,7 +503,8 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         Returns:
             API landing page, serving as an entry point to the API.
         """
-        base_url = str(kwargs["request"].base_url)
+        request: Request = kwargs["request"]
+        base_url = str(request.base_url)
         landing_page = self._landing_page(
             base_url=base_url, conformance_classes=self.conformance_classes()
         )
@@ -509,6 +518,17 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
                     "href": urljoin(base_url, f"collections/{collection['id']}"),
                 }
             )
+
+        # Add OpenAPI URL
+        landing_page["links"].append(
+            {
+                "rel": "service-desc",
+                "type": "application/vnd.oai.openapi+json;version=3.0",
+                "title": "OpenAPI service description",
+                "href": urljoin(base_url, request.app.openapi_url.lstrip("/")),
+            }
+        )
+
         return landing_page
 
     async def conformance(self, **kwargs) -> stac_types.Conformance:

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -266,7 +266,7 @@ class LandingPageMixin(abc.ABC):
                 },
                 {
                     "rel": Relations.search.value,
-                    "type": MimeTypes.json,
+                    "type": MimeTypes.geojson,
                     "title": "STAC search",
                     "href": urljoin(base_url, "search"),
                 },


### PR DESCRIPTION
**Related Issues:**

- #219 
- #218 
- #217 
- #216 

**Summary of Changes:**

- Uses a module-scoped fixture to fetch the landing page within `test_conformance` so that we only fetch it once
- Adds parameterized tests for links related to the above issues
- Adds `root` and `service-desc` links to landing page
- Changes `type` of `search` link to `"application/geo+json"`

**Questions:**

- [x] Should the `"service-desc"` rel type be added to `stac-pydantic.links`?
- [x] Should the `"application/vnd.oai.openapi+json;version=3.0"` MIME type be added to `stac_pydantic.shared`?
   Opened stac-utils/stac-pydantic#101 for both of these changes.
- [x] Should we [change the default OpenAPI endpoint](https://fastapi.tiangolo.com/advanced/conditional-openapi/?h=openapi#conditional-openapi-from-settings-and-env-vars) to be `/api` to be in line with the [recommendation in the STAC API spec](https://github.com/radiantearth/stac-api-spec/tree/master/core#link-relations)?
   This is configurable in `ApiSettings.openapi_url` and defaults to `/api`
- [ ] ~**UPDATE:** Should I also include a fix to the `/search` endpoint `"Content-Type"` header for #220?~ I'll do this in a separate PR since it seems like it might be a bit involved.

~I plan to add the equivalent changes to the `sqlalchemy` app but was having some trouble getting those tests to run and I thought I'd get feedback on this first.~ I got these working and added the equivalent tests.

cc: @philvarner