### PR TITLE
Fix test-* make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ run_docker = docker-compose run --rm \
 				-e APP_PORT=${APP_PORT} \
 				app-sqlalchemy
 
+run_pgstac = docker-compose run --rm \
+				-p ${EXTERNAL_APP_PORT}:${APP_PORT} \
+				-e APP_HOST=${APP_HOST} \
+				-e APP_PORT=${APP_PORT} \
+				app-pgstac
+
 .PHONY: image
 image:
 	docker-compose build
@@ -25,8 +31,8 @@ test-sqlalchemy:
 	$(run_docker) /bin/bash -c 'export && cd /app/stac_fastapi/sqlalchemy/tests/ && pytest'
 
 .PHONY: test-pgstac
-test-pgstac: pgstac-install
-	$(run_docker) /bin/bash -c 'export && cd /app/stac_fastapi/pgstac/tests/ && pytest'
+test-pgstac:
+	$(run_pgstac) /bin/bash -c 'export && cd /app/stac_fastapi/pgstac/tests/ && pytest'
 
 .PHONY: run-database
 run-database:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ docker-shell:
 	$(run_docker) /bin/bash
 
 .PHONY: test-sqlalchemy
-test-sqlalchemy:
+test-sqlalchemy: run-joplin-sqlalchemy
 	$(run_docker) /bin/bash -c 'export && cd /app/stac_fastapi/sqlalchemy/tests/ && pytest'
 
 .PHONY: test-pgstac
@@ -37,6 +37,10 @@ test-pgstac:
 .PHONY: run-database
 run-database:
 	docker-compose run --rm database
+
+.PHONY: run-joplin-sqlalchemy
+run-joplin-sqlalchemy:
+	docker-compose run --rm loadjoplin-sqlalchemy
 
 .PHONY: test
 test: test-sqlalchemy test-pgstac

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ test-sqlalchemy:
 test-pgstac: pgstac-install
 	$(run_docker) /bin/bash -c 'export && cd /app/stac_fastapi/pgstac/tests/ && pytest'
 
+.PHONY: run-database
+run-database:
+	docker-compose run --rm database
+
 .PHONY: test
 test: test-sqlalchemy test-pgstac
 


### PR DESCRIPTION
**Changes:**
- Adds a `run-database` make target to run just the `database` service for testing
   This was purely for convenience

- Uses `app-pgstac` instead of `app-sqlalchemy` in `test-pgstac` target
- Removes `test-pgstac` dependency on `pgstac-install` target
   This was causing problems when installing `rasterio` in my environment and we don't appear to need it since we are running the tests inside the `stac-fastapi-pgstac` container.
- **UPDATE:** Adds `run-joplin-sqlalchemy` make target and adds it as a dependency to `test-sqlalchemy` to ensure test data is loaded prior to running unit tests.

Again, could be some user error here, so let me know if I'm off-base.