### PR TITLE
Correct response codes for bad/unusable bboxes

### DIFF
--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 import attr
-from fastapi import HTTPException
 import orjson
 from buildpg import render
+from fastapi import HTTPException
 from starlette.requests import Request
 
 from stac_fastapi.pgstac.models.links import CollectionLinks, ItemLinks, PagingLinks
@@ -190,7 +190,10 @@ class CoreCrudClient(AsyncBaseCoreClient):
             ItemCollection containing items which match the search criteria.
         """
         if search_request.bbox and len(search_request.bbox) == 6:
-            raise HTTPException(status_code=501, detail="Support for 3D bounding boxes is not yet implemented")
+            raise HTTPException(
+                status_code=501,
+                detail="Support for 3D bounding boxes is not yet implemented",
+            )
         item_collection = await self._search_base(search_request, **kwargs)
         return ItemCollection(**item_collection)
 

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -7,6 +7,7 @@ import attr
 import orjson
 from buildpg import render
 from fastapi import HTTPException
+from pydantic import ValidationError
 from starlette.requests import Request
 
 from stac_fastapi.pgstac.models.links import CollectionLinks, ItemLinks, PagingLinks
@@ -258,6 +259,6 @@ class CoreCrudClient(AsyncBaseCoreClient):
         # Do the request
         try:
             search_request = PgstacSearch(**base_args)
-        except:
+        except ValidationError:
             raise HTTPException(status_code=400, detail="Invalid parameters provided")
         return await self.post_search(search_request, request=kwargs["request"])

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -190,11 +190,6 @@ class CoreCrudClient(AsyncBaseCoreClient):
         Returns:
             ItemCollection containing items which match the search criteria.
         """
-        if search_request.bbox and len(search_request.bbox) == 6:
-            raise HTTPException(
-                status_code=501,
-                detail="Support for 3D bounding boxes is not yet implemented",
-            )
         item_collection = await self._search_base(search_request, **kwargs)
         return ItemCollection(**item_collection)
 

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -928,3 +928,21 @@ async def test_relative_link_construction():
     )
     links = CollectionLinks(collection_id="naip", request=req)
     assert links.link_items()["href"] == "http://test/stac/collections/naip/items"
+
+@pytest.mark.asyncio
+async def test_search_bbox_errors(app_client):
+    body = {"query": { "bbox": [0]}}
+    resp = await app_client.post("/search", json=body)
+    assert resp.status_code == 400
+
+    body = {"query": { "bbox": [100.0, 0.0, 0.0, 105.0, 1.0, 1.0]}}
+    resp = await app_client.post("/search", json=body)
+    assert resp.status_code == 400
+
+    params = {"bbox": "0,0,0,1,1,1"}
+    resp = await app_client.get("/search", params=params)
+    assert resp.status_code == 501
+
+    params = {"bbox": "100.0,0.0,0.0,105.0"}
+    resp = await app_client.get("/search", params=params)
+    assert resp.status_code == 400

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -929,13 +929,14 @@ async def test_relative_link_construction():
     links = CollectionLinks(collection_id="naip", request=req)
     assert links.link_items()["href"] == "http://test/stac/collections/naip/items"
 
+
 @pytest.mark.asyncio
 async def test_search_bbox_errors(app_client):
-    body = {"query": { "bbox": [0]}}
+    body = {"query": {"bbox": [0]}}
     resp = await app_client.post("/search", json=body)
     assert resp.status_code == 400
 
-    body = {"query": { "bbox": [100.0, 0.0, 0.0, 105.0, 1.0, 1.0]}}
+    body = {"query": {"bbox": [100.0, 0.0, 0.0, 105.0, 1.0, 1.0]}}
     resp = await app_client.post("/search", json=body)
     assert resp.status_code == 400
 

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -940,10 +940,6 @@ async def test_search_bbox_errors(app_client):
     resp = await app_client.post("/search", json=body)
     assert resp.status_code == 400
 
-    params = {"bbox": "0,0,0,1,1,1"}
-    resp = await app_client.get("/search", params=params)
-    assert resp.status_code == 501
-
     params = {"bbox": "100.0,0.0,0.0,105.0"}
     resp = await app_client.get("/search", params=params)
     assert resp.status_code == 400

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -301,10 +301,14 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     if len(search_request.bbox) == 4:
                         poly = ShapelyPolygon.from_bounds(*search_request.bbox)
                     elif len(search_request.bbox) == 6:
-                        raise HTTPException(
-                            status_code=501,
-                            detail="Support for 3D bounding boxes is not yet implemented",
-                        )
+                        """Shapely doesn't support 3d bounding boxes we'll just use the 2d portion"""
+                        bbox_2d = [
+                            search_request.bbox[0],
+                            search_request.bbox[1],
+                            search_request.bbox[3],
+                            search_request.bbox[4],
+                        ]
+                        poly = ShapelyPolygon.from_bounds(*bbox_2d)
 
                 if poly:
                     filter_geom = ga.shape.from_shape(poly, srid=4326)

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -10,6 +10,7 @@ import geoalchemy2 as ga
 import sqlalchemy as sa
 import stac_pydantic
 from fastapi import HTTPException
+from pydantic import ValidationError
 from shapely.geometry import Polygon as ShapelyPolygon
 from shapely.geometry import shape
 from sqlakeyset import get_page
@@ -210,7 +211,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
         # Do the request
         try:
             search_request = SQLAlchemySTACSearch(**base_args)
-        except:
+        except ValidationError:
             raise HTTPException(status_code=400, detail="Invalid parameters provided")
         resp = self.post_search(search_request, request=kwargs["request"])
 

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -7,9 +7,9 @@ from urllib.parse import urlencode
 
 import attr
 import geoalchemy2 as ga
-from fastapi import HTTPException
 import sqlalchemy as sa
 import stac_pydantic
+from fastapi import HTTPException
 from shapely.geometry import Polygon as ShapelyPolygon
 from shapely.geometry import shape
 from sqlakeyset import get_page
@@ -300,8 +300,10 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     if len(search_request.bbox) == 4:
                         poly = ShapelyPolygon.from_bounds(*search_request.bbox)
                     elif len(search_request.bbox) == 6:
-                        raise HTTPException(status_code=501, detail="Support for 3D bounding boxes is not yet implemented")
-
+                        raise HTTPException(
+                            status_code=501,
+                            detail="Support for 3D bounding boxes is not yet implemented",
+                        )
 
                 if poly:
                     filter_geom = ga.shape.from_shape(poly, srid=4326)

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -771,10 +771,6 @@ def test_search_bbox_errors(app_client):
     resp = app_client.post("/search", json=body)
     assert resp.status_code == 400
 
-    params = {"bbox": "0,0,0,1,1,1"}
-    resp = app_client.get("/search", params=params)
-    assert resp.status_code == 501
-
     params = {"bbox": "100.0,0.0,0.0,105.0"}
     resp = app_client.get("/search", params=params)
     assert resp.status_code == 400

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -763,11 +763,11 @@ def test_search_invalid_query_field(app_client):
 
 
 def test_search_bbox_errors(app_client):
-    body = {"query": { "bbox": [0]}}
+    body = {"query": {"bbox": [0]}}
     resp = app_client.post("/search", json=body)
     assert resp.status_code == 400
 
-    body = {"query": { "bbox": [100.0, 0.0, 0.0, 105.0, 1.0, 1.0]}}
+    body = {"query": {"bbox": [100.0, 0.0, 0.0, 105.0, 1.0, 1.0]}}
     resp = app_client.post("/search", json=body)
     assert resp.status_code == 400
 

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -762,6 +762,24 @@ def test_search_invalid_query_field(app_client):
     assert resp.status_code == 400
 
 
+def test_search_bbox_errors(app_client):
+    body = {"query": { "bbox": [0]}}
+    resp = app_client.post("/search", json=body)
+    assert resp.status_code == 400
+
+    body = {"query": { "bbox": [100.0, 0.0, 0.0, 105.0, 1.0, 1.0]}}
+    resp = app_client.post("/search", json=body)
+    assert resp.status_code == 400
+
+    params = {"bbox": "0,0,0,1,1,1"}
+    resp = app_client.get("/search", params=params)
+    assert resp.status_code == 501
+
+    params = {"bbox": "100.0,0.0,0.0,105.0"}
+    resp = app_client.get("/search", params=params)
+    assert resp.status_code == 400
+
+
 def test_conformance_classes_configurable():
     """Test conformance class configurability"""
     landing = LandingPageMixin()


### PR DESCRIPTION
This PR prevents 500s from being sent back to the user when parameters (BBox in particular, but it should help with others) are misconfigured. 400s should now be returned if users attempt a search with invalid bounding boxes. 501s will be returned for 6-length (not yet supported, 3D) bounding boxes.

Closes #222