### PR TITLE
Add extension schemas to landing

### DIFF
--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
@@ -1,4 +1,6 @@
 """context extension."""
+from typing import List, Optional
+
 import attr
 from fastapi import FastAPI
 
@@ -14,6 +16,13 @@ class ContextExtension(ApiExtension):
 
     https://github.com/radiantearth/stac-api-spec/blob/master/item-search/README.md#context
     """
+
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.3/item-search/#context"]
+    )
+    schema_href: Optional[str] = attr.ib(
+        default="https://raw.githubusercontent.com/radiantearth/stac-api-spec/v1.0.0-beta.3/fragments/context/json-schema/schema.json"
+    )
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields.py
@@ -1,5 +1,5 @@
 """fields extension."""
-from typing import Set
+from typing import List, Optional, Set
 
 import attr
 from fastapi import FastAPI
@@ -23,6 +23,10 @@ class FieldsExtension(ApiExtension):
 
     """
 
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.3/item-search/#fields"]
+    )
+    schema_href: Optional[str] = attr.ib(default=None)
     default_includes: Set[str] = attr.ib(
         default=attr.Factory(
             lambda: {

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/query.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/query.py
@@ -1,4 +1,6 @@
 """query extension."""
+from typing import List, Optional
+
 import attr
 from fastapi import FastAPI
 
@@ -14,6 +16,11 @@ class QueryExtension(ApiExtension):
 
     https://github.com/radiantearth/stac-api-spec/blob/master/item-search/README.md#query
     """
+
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.3/item-search/#query"]
+    )
+    schema_href: Optional[str] = attr.ib(default=None)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/sort.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/sort.py
@@ -1,4 +1,6 @@
 """sort extension."""
+from typing import List, Optional
+
 import attr
 from fastapi import FastAPI
 
@@ -14,6 +16,11 @@ class SortExtension(ApiExtension):
 
     https://github.com/radiantearth/stac-api-spec/blob/master/item-search/README.md#sort
     """
+
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.3/item-search/#sort"]
+    )
+    schema_href: Optional[str] = attr.ib(default=None)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -1,5 +1,5 @@
 """transaction extension."""
-from typing import Callable, List, Type, Union
+from typing import Callable, List, Optional, Type, Union
 
 import attr
 from fastapi import APIRouter, FastAPI
@@ -36,9 +36,15 @@ class TransactionExtension(ApiExtension):
 
     client: Union[AsyncBaseTransactionsClient, BaseTransactionsClient] = attr.ib()
     settings: ApiSettings = attr.ib()
+    conformance_classes: List[str] = attr.ib(
+        factory=lambda: [
+            "https://api.stacspec.org/v1.0.0-beta.3/ogcapi-features/extensions/transaction/",
+            "http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/simpletx",
+        ]
+    )
+    schema_href: Optional[str] = attr.ib(default=None)
     router: APIRouter = attr.ib(factory=APIRouter)
     response_class: Type[Response] = attr.ib(default=JSONResponse)
-    conformance_classes: List[str] = attr.ib(default=list())
 
     def _create_endpoint(
         self,

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -61,6 +61,7 @@ class BulkTransactionExtension(ApiExtension):
 
     client: BaseBulkTransactionsClient = attr.ib()
     conformance_classes: List[str] = attr.ib(default=list())
+    schema_href: Optional[str] = attr.ib(default=None)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/tiles.py
@@ -172,6 +172,7 @@ class TilesExtension(ApiExtension):
     client: BaseTilesClient = attr.ib()
     route_prefix: str = attr.ib(default="/titiler")
     conformance_classes: List[str] = attr.ib(default=list())
+    schema_href: Optional[str] = attr.ib(default=None)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -766,7 +766,9 @@ def test_conformance_classes_configurable():
     """Test conformance class configurability"""
     landing = LandingPageMixin()
     landing_page = landing._landing_page(
-        base_url="http://test/test", conformance_classes=["this is a test"]
+        base_url="http://test/test",
+        conformance_classes=["this is a test"],
+        extension_schemas=[],
     )
     assert landing_page["conformsTo"][0] == "this is a test"
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -232,7 +232,10 @@ class LandingPageMixin(abc.ABC):
     description: str = attr.ib(default="stac-fastapi")
 
     def _landing_page(
-        self, base_url: str, conformance_classes: List[str]
+        self,
+        base_url: str,
+        conformance_classes: List[str],
+        extension_schemas: List[str],
     ) -> stac_types.LandingPage:
         landing_page = stac_types.LandingPage(
             type="Catalog",
@@ -271,7 +274,7 @@ class LandingPageMixin(abc.ABC):
                     "href": urljoin(base_url, "search"),
                 },
             ],
-            stac_extensions=[],
+            stac_extensions=extension_schemas,
         )
         return landing_page
 
@@ -319,8 +322,13 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
             API landing page, serving as an entry point to the API.
         """
         base_url = str(kwargs["request"].base_url)
+        extension_schemas = [
+            schema.schema_href for schema in self.extensions if schema.schema_href
+        ]
         landing_page = self._landing_page(
-            base_url=base_url, conformance_classes=self.conformance_classes()
+            base_url=base_url,
+            conformance_classes=self.conformance_classes(),
+            extension_schemas=extension_schemas,
         )
         collections = self.all_collections(request=kwargs["request"])
         for collection in collections:
@@ -485,8 +493,13 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
             API landing page, serving as an entry point to the API.
         """
         base_url = str(kwargs["request"].base_url)
+        extension_schemas = [
+            schema.schema_href for schema in self.extensions if schema.schema_href
+        ]
         landing_page = self._landing_page(
-            base_url=base_url, conformance_classes=self.conformance_classes()
+            base_url=base_url,
+            conformance_classes=self.conformance_classes(),
+            extension_schemas=extension_schemas,
         )
         collections = await self.all_collections(request=kwargs["request"])
         for collection in collections:

--- a/stac_fastapi/types/stac_fastapi/types/extension.py
+++ b/stac_fastapi/types/stac_fastapi/types/extension.py
@@ -1,6 +1,6 @@
 """base api extension."""
 import abc
-from typing import List
+from typing import List, Optional
 
 import attr
 from fastapi import FastAPI
@@ -11,6 +11,7 @@ class ApiExtension(abc.ABC):
     """Abstract base class for defining API extensions."""
 
     conformance_classes: List[str] = attr.ib(factory=list)
+    schema_href: Optional[str] = attr.ib(default=None)
 
     @abc.abstractmethod
     def register(self, app: FastAPI) -> None:


### PR DESCRIPTION
STAC extensions should be advertised on the landing page. This PR adds a `schema_href` attribute to `ApiExtension` which can is used to generate a list of JSON schemas.