### PR TITLE
Update pgstac to return 400 on invalid date parameter.

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/errors.py
+++ b/stac_fastapi/api/stac_fastapi/api/errors.py
@@ -13,6 +13,7 @@ from stac_fastapi.types.errors import (
     ConflictError,
     DatabaseError,
     ForeignKeyError,
+    InvalidQueryParameter,
     NotFoundError,
 )
 
@@ -25,6 +26,7 @@ DEFAULT_STATUS_CODES = {
     ForeignKeyError: status.HTTP_422_UNPROCESSABLE_ENTITY,
     DatabaseError: status.HTTP_424_FAILED_DEPENDENCY,
     Exception: status.HTTP_500_INTERNAL_SERVER_ERROR,
+    InvalidQueryParameter: status.HTTP_400_BAD_REQUEST,
 }
 
 

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -104,3 +104,19 @@ async def test_app_sort_extension(load_test_data, app_client, load_test_collecti
     resp_json = resp.json()
     assert resp_json["features"][1]["id"] == first_item["id"]
     assert resp_json["features"][0]["id"] == second_item["id"]
+
+
+@pytest.mark.asyncio
+async def test_search_invalid_date(load_test_data, app_client, load_test_collection):
+    coll = load_test_collection
+    first_item = load_test_data("test_item.json")
+    resp = await app_client.post(f"/collections/{coll.id}/items", json=first_item)
+    assert resp.status_code == 200
+
+    params = {
+        "datetime": "2020-XX-01/2020-10-30",
+        "collections": [coll.id],
+    }
+
+    resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 400

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -127,6 +127,4 @@ def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
     }
 
     resp = app_client.post("/search", json=params)
-    import json
-
     assert resp.status_code == 400

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -101,3 +101,19 @@ def test_app_sort_extension(load_test_data, app_client, postgres_transactions):
     resp_json = resp.json()
     assert resp_json["features"][0]["id"] == first_item["id"]
     assert resp_json["features"][1]["id"] == second_item["id"]
+
+
+def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
+    item = load_test_data("test_item.json")
+    postgres_transactions.create_item(item, request=MockStarletteRequest)
+
+    params = {
+        "datetime": "2020-XX-01/2020-10-30",
+        "collections": [item["collection"]],
+    }
+
+    resp = app_client.post("/search", json=params)
+    import json
+
+    print(json.dumps(resp.json(), indent=2))
+    assert resp.status_code == 400

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -129,5 +129,4 @@ def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
     resp = app_client.post("/search", json=params)
     import json
 
-    print(json.dumps(resp.json(), indent=2))
     assert resp.status_code == 400

--- a/stac_fastapi/types/stac_fastapi/types/errors.py
+++ b/stac_fastapi/types/stac_fastapi/types/errors.py
@@ -29,3 +29,13 @@ class DatabaseError(StacApiError):
     """Generic database errors."""
 
     pass
+
+
+class InvalidQueryParameter(StacApiError):
+    """Error for unknown or invalid query parameters.
+
+    Used to capture errors that should respond according to
+    http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#query_parameters
+    """
+
+    pass


### PR DESCRIPTION
pgstac currently returns a 500 with an invalid date; this PR modifies this to return a 400.

Also allow backends to raise their own InvalidQueryParameter exceptions, which will be translated into a 400 by exception handling. This is another option for backends that want to handle query parameter validation in other ways besides stac-pydantic model validation.

[This line](https://github.com/stac-utils/stac-fastapi/blob/master/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py#L109) in the pgstac search model indicates that validation is done outside of the pydantic model, but there were instances of `asyncpg.exceptions.InvalidDatetimeFormatError` being thrown for bad datetime parameters. We could solve this by removing the overridden validator, but I'm not sure why this was overridden and also I think it's useful to provide a non-pydantic mechanism for backends to indicate parameters are invalid and having stac-fastapi return the right status code.