### PR TITLE
Specify platform for apps in docker-compose, so build works on M1 Macs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    platform: linux/amd64
     environment:
       - APP_HOST=0.0.0.0
       - APP_PORT=8081
@@ -40,6 +41,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    platform: linux/amd64
     environment:
       - APP_HOST=0.0.0.0
       - APP_PORT=8082


### PR DESCRIPTION
Running `docker-compose build` on an M1 Mac throws an error while building `rasterio`, because there is no aarch64 wheel available for rasterio. This causes us to attempt to build rasterio from source, which fails due to gdal-config not being installed.

```
ERROR: Command errored out with exit status 1:
#9 82.29    command: /usr/local/bin/python /usr/local/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py get_requires_for_build_wheel /tmp/tmpd14zyndd
#9 82.29        cwd: /tmp/pip-install-45d0y0hx/rasterio_4a54cb19ebb84bc58288ecedd65c5b00
#9 82.29   Complete output (2 lines):
#9 82.29   WARNING:root:Failed to get options via gdal-config: [Errno 2] No such file or directory: 'gdal-config'
```

Specifying the `linux/amd64` platform for app-sqlalchemy and app-pgstac allows the build to succeed.