### PR TITLE
Document the postgis>=3 requirement of the sqlalchemy backend

### DIFF
--- a/stac_fastapi/sqlalchemy/README.md
+++ b/stac_fastapi/sqlalchemy/README.md
@@ -1,0 +1,3 @@
+# Requirements
+
+The SQLAlchemy backend requires **PostGIS>=3**.


### PR DESCRIPTION
This adds a bit documentation for the requirements SQLAlchemy backend in regards to the required PostGIS Version.

PostGIS >= 3 is required as the backend is depending on the new default SRID behaviour of the [ST_GeomFromGeoJSON](https://postgis.net/docs/ST_GeomFromGeoJSON.html) function. Otherwise users will run in the following error (observed with PostGIS 2.5):

```
sqlalchemy.exc.DataError: (psycopg2.errors.InvalidParameterValue) Geometry SRID (0) does not match column SRID (4326)

[SQL: INSERT INTO data.items (id, stac_version, stac_extensions, geometry, bbox, properties, assets, collection_id, datetime) VALUES (%(id)s, %(stac_version)s, %(stac_extensions)s, ST_GeomFromGeoJSON(%(geometry)s), %(bbox)s, %(properties)s, %(assets)s, %(collection_id)s, %(datetime)s)]
```

Not sure if that Readme is the best place for that, though. 