### PR TITLE
Convert ge to gte and le to lte in sqlalchemy backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ packages:
 pip install stac-fastapi.api stac-fastapi.types stac-fastapi.extensions
 
 # Install a backend of your choice
-pip stac-fastapi.sqlalchemy
+pip install stac-fastapi.sqlalchemy
 # or
-pip stac-fastapi.pgstac
+pip install stac-fastapi.pgstac
 
 #/////////////////////
 # Install from sources

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -116,7 +116,7 @@ async def test_app_query_extension_gt(load_test_data, app_client, load_test_coll
     resp = await app_client.post(f"/collections/{coll.id}/items", json=item)
     assert resp.status_code == 200
 
-    params = {"query": {"proj:epsg": {"gt": item["properties"]["proj:epsg"] + 1}}}
+    params = {"query": {"proj:epsg": {"gt": item["properties"]["proj:epsg"]}}}
     resp = await app_client.post("/search", json=params)
     assert resp.status_code == 200
     resp_json = resp.json()

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -108,6 +108,7 @@ async def test_app_query_extension_limit_gt10000(
     resp = await app_client.post("/search", json=params)
     assert resp.status_code == 400
 
+
 @pytest.mark.asyncio
 async def test_app_query_extension_gt(load_test_data, app_client, load_test_collection):
     coll = load_test_collection
@@ -121,8 +122,11 @@ async def test_app_query_extension_gt(load_test_data, app_client, load_test_coll
     resp_json = resp.json()
     assert len(resp_json["features"]) == 0
 
+
 @pytest.mark.asyncio
-async def test_app_query_extension_gte(load_test_data, app_client, load_test_collection):
+async def test_app_query_extension_gte(
+    load_test_data, app_client, load_test_collection
+):
     coll = load_test_collection
     item = load_test_data("test_item.json")
     resp = await app_client.post(f"/collections/{coll.id}/items", json=item)

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -108,6 +108,32 @@ async def test_app_query_extension_limit_gt10000(
     resp = await app_client.post("/search", json=params)
     assert resp.status_code == 400
 
+@pytest.mark.asyncio
+async def test_app_query_extension_gt(load_test_data, app_client, load_test_collection):
+    coll = load_test_collection
+    item = load_test_data("test_item.json")
+    resp = await app_client.post(f"/collections/{coll.id}/items", json=item)
+    assert resp.status_code == 200
+
+    params = {"query": {"proj:epsg": {"gt": item["properties"]["proj:epsg"] + 1}}}
+    resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 0
+
+@pytest.mark.asyncio
+async def test_app_query_extension_gte(load_test_data, app_client, load_test_collection):
+    coll = load_test_collection
+    item = load_test_data("test_item.json")
+    resp = await app_client.post(f"/collections/{coll.id}/items", json=item)
+    assert resp.status_code == 200
+
+    params = {"query": {"proj:epsg": {"gte": item["properties"]["proj:epsg"]}}}
+    resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 1
+
 
 @pytest.mark.asyncio
 async def test_app_sort_extension(load_test_data, app_client, load_test_collection):

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -353,10 +353,8 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                         field = self.item_table.get_field(field_name)
                         for (op, value) in expr.items():
                             if op == Operator.gte:
-                                # op = Operator.ge
                                 query = query.filter(operator.ge(field, value))
                             elif op == Operator.lte:
-                                # op = Operator.le
                                 query = query.filter(operator.le(field, value))
                             else:
                                 query = query.filter(op.operator(field, value))

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -23,7 +23,7 @@ from stac_fastapi.sqlalchemy import serializers
 from stac_fastapi.sqlalchemy.models import database
 from stac_fastapi.sqlalchemy.session import Session
 from stac_fastapi.sqlalchemy.tokens import PaginationTokenClient
-from stac_fastapi.sqlalchemy.types.search import SQLAlchemySTACSearch
+from stac_fastapi.sqlalchemy.types.search import SQLAlchemySTACSearch, Operator
 from stac_fastapi.types.config import Settings
 from stac_fastapi.types.core import BaseCoreClient
 from stac_fastapi.types.errors import NotFoundError
@@ -351,6 +351,10 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     for (field_name, expr) in search_request.query.items():
                         field = self.item_table.get_field(field_name)
                         for (op, value) in expr.items():
+                            if op == Operator.gte:
+                                op = Operator.ge
+                            if op == Operator.lte:
+                                op = Operator.le  
                             query = query.filter(op.operator(field, value))
 
                 if self.extension_is_enabled("ContextExtension"):

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -1,6 +1,7 @@
 """Item crud client."""
 import json
 import logging
+import operator
 from datetime import datetime
 from typing import List, Optional, Set, Type, Union
 from urllib.parse import urlencode, urljoin
@@ -352,10 +353,13 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                         field = self.item_table.get_field(field_name)
                         for (op, value) in expr.items():
                             if op == Operator.gte:
-                                op = Operator.ge
-                            if op == Operator.lte:
-                                op = Operator.le  
-                            query = query.filter(op.operator(field, value))
+                                # op = Operator.ge
+                                query = query.filter(operator.ge(field, value))
+                            elif op == Operator.lte:
+                                # op = Operator.le  
+                                query = query.filter(operator.le(field, value))
+                            else:
+                                query = query.filter(op.operator(field, value))
 
                 if self.extension_is_enabled("ContextExtension"):
                     count_query = query.statement.with_only_columns(

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -24,7 +24,7 @@ from stac_fastapi.sqlalchemy import serializers
 from stac_fastapi.sqlalchemy.models import database
 from stac_fastapi.sqlalchemy.session import Session
 from stac_fastapi.sqlalchemy.tokens import PaginationTokenClient
-from stac_fastapi.sqlalchemy.types.search import SQLAlchemySTACSearch, Operator
+from stac_fastapi.sqlalchemy.types.search import Operator, SQLAlchemySTACSearch
 from stac_fastapi.types.config import Settings
 from stac_fastapi.types.core import BaseCoreClient
 from stac_fastapi.types.errors import NotFoundError
@@ -356,7 +356,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                                 # op = Operator.ge
                                 query = query.filter(operator.ge(field, value))
                             elif op == Operator.lte:
-                                # op = Operator.le  
+                                # op = Operator.le
                                 query = query.filter(operator.le(field, value))
                             else:
                                 query = query.filter(op.operator(field, value))

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/types/search.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/types/search.py
@@ -33,7 +33,6 @@ class Operator(str, AutoValueEnum):
     lt = auto()
     lte = auto()
     gt = auto()
-    ge = auto()
     gte = auto()
     # TODO: These are defined in the spec but aren't currently implemented by the api
     # startsWith = auto()
@@ -144,7 +143,7 @@ class SQLAlchemySTACSearch(Search):
     # Override default field extension to include default fields and pydantic includes/excludes factory
     field: FieldsExtension = Field(FieldsExtension(), alias="fields")
     # Override query extension with supported operators
-    query: Optional[Dict[str, Dict[Operator, Any]]]
+    query: Optional[Dict[Queryables, Dict[Operator, Any]]]
     token: Optional[str] = None
 
     @root_validator(pre=True)

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/types/search.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/types/search.py
@@ -31,9 +31,10 @@ class Operator(str, AutoValueEnum):
     eq = auto()
     ne = auto()
     lt = auto()
-    le = auto()
+    lte = auto()
     gt = auto()
     ge = auto()
+    gte = auto()
     # TODO: These are defined in the spec but aren't currently implemented by the api
     # startsWith = auto()
     # endsWith = auto()
@@ -143,7 +144,7 @@ class SQLAlchemySTACSearch(Search):
     # Override default field extension to include default fields and pydantic includes/excludes factory
     field: FieldsExtension = Field(FieldsExtension(), alias="fields")
     # Override query extension with supported operators
-    query: Optional[Dict[Queryables, Dict[Operator, Any]]]
+    query: Optional[Dict[str, Dict[Operator, Any]]]
     token: Optional[str] = None
 
     @root_validator(pre=True)

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -84,7 +84,7 @@ def test_app_query_extension_gt(load_test_data, app_client, postgres_transaction
     test_item = load_test_data("test_item.json")
     postgres_transactions.create_item(test_item, request=MockStarletteRequest)
 
-    params = {"query": {"proj:epsg": {"gt": test_item["properties"]["proj:epsg"] + 1}}}
+    params = {"query": {"proj:epsg": {"gt": test_item["properties"]["proj:epsg"]}}}
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 200
     resp_json = resp.json()

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -80,7 +80,7 @@ def test_app_fields_extension(load_test_data, app_client, postgres_transactions)
     assert list(resp_json["features"][0]["properties"]) == ["datetime"]
 
 
-def test_app_query_extension(load_test_data, app_client, postgres_transactions):
+def test_app_query_extension_gt(load_test_data, app_client, postgres_transactions):
     test_item = load_test_data("test_item.json")
     postgres_transactions.create_item(test_item, request=MockStarletteRequest)
 
@@ -89,6 +89,17 @@ def test_app_query_extension(load_test_data, app_client, postgres_transactions):
     assert resp.status_code == 200
     resp_json = resp.json()
     assert len(resp_json["features"]) == 0
+
+
+def test_app_query_extension_gte(load_test_data, app_client, postgres_transactions):
+    test_item = load_test_data("test_item.json")
+    postgres_transactions.create_item(test_item, request=MockStarletteRequest)
+
+    params = {"query": {"proj:epsg": {"gte": test_item["properties"]["proj:epsg"]}}}
+    resp = app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 1
 
 
 def test_app_sort_extension(load_test_data, app_client, postgres_transactions):

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -25,9 +25,9 @@ class Operator(str, AutoValueEnum):
     eq = auto()
     ne = auto()
     lt = auto()
-    le = auto()
+    lte = auto()
     gt = auto()
-    ge = auto()
+    gte = auto()
     # TODO: These are defined in the spec but aren't currently implemented by the api
     # startsWith = auto()
     # endsWith = auto()


### PR DESCRIPTION
**Related Issue(s):** #171


**Description:**
Operators should be lte and gte for less than and greater than. This pr changes this for the sqlalchemy backend. It's a simple fix that still uses the operator module. 

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).