### PR TITLE
Add tests for 3d bbox in test_api.py

### DIFF
--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -167,6 +167,26 @@ async def test_search_invalid_date(load_test_data, app_client, load_test_collect
 
 
 @pytest.mark.asyncio
+async def test_bbox_3d(load_test_data, app_client, load_test_collection):
+    coll = load_test_collection
+    first_item = load_test_data("test_item.json")
+    resp = await app_client.post(f"/collections/{coll.id}/items", json=first_item)
+    assert resp.status_code == 200
+    
+    australia_bbox = [106.343365,-47.199523,0.1,168.218365,-19.437288,0.1]
+    params = {
+        "bbox": australia_bbox,
+        "collections": [coll.id],
+    }
+    resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 1
+
+
+
+@pytest.mark.asyncio
 async def test_app_search_response(load_test_data, app_client, load_test_collection):
     coll = load_test_collection
     params = {

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -172,18 +172,17 @@ async def test_bbox_3d(load_test_data, app_client, load_test_collection):
     first_item = load_test_data("test_item.json")
     resp = await app_client.post(f"/collections/{coll.id}/items", json=first_item)
     assert resp.status_code == 200
-    
-    australia_bbox = [106.343365,-47.199523,0.1,168.218365,-19.437288,0.1]
+
+    australia_bbox = [106.343365, -47.199523, 0.1, 168.218365, -19.437288, 0.1]
     params = {
         "bbox": australia_bbox,
         "collections": [coll.id],
     }
     resp = await app_client.post("/search", json=params)
     assert resp.status_code == 200
-    
+
     resp_json = resp.json()
     assert len(resp_json["features"]) == 1
-
 
 
 @pytest.mark.asyncio

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -128,3 +128,18 @@ def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
 
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 400
+
+def test_bbox_3d(load_test_data, app_client, postgres_transactions):
+    item = load_test_data("test_item.json")
+    postgres_transactions.create_item(item, request=MockStarletteRequest)
+
+    australia_bbox = [106.343365,-47.199523,0.1,168.218365,-19.437288,0.1]
+    params = {
+        "bbox": australia_bbox,
+        "collections": [item["collection"]],
+    }
+    resp = app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 1

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -129,17 +129,18 @@ def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 400
 
+
 def test_bbox_3d(load_test_data, app_client, postgres_transactions):
     item = load_test_data("test_item.json")
     postgres_transactions.create_item(item, request=MockStarletteRequest)
 
-    australia_bbox = [106.343365,-47.199523,0.1,168.218365,-19.437288,0.1]
+    australia_bbox = [106.343365, -47.199523, 0.1, 168.218365, -19.437288, 0.1]
     params = {
         "bbox": australia_bbox,
         "collections": [item["collection"]],
     }
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 200
-    
+
     resp_json = resp.json()
     assert len(resp_json["features"]) == 1


### PR DESCRIPTION
**Related Issue(s):** #162


**Description:**
Test 3d bbox in test_api.py in order to confirm that 3d bbox queries do work as expected.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).