### PR TITLE
Fix #259 (stac_validator error NULL in title element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 * Pin FastAPI to 0.67 to avoid issues with rendering OpenAPI documentation ([#246](https://github.com/stac-utils/stac-fastapi/pull/246))
 * Restrict `limit` parameter in sqlalchemy backend to between 1 and 10,000. ([#251](https://github.com/stac-utils/stac-fastapi/pull/251))
 * Fix OAS conformance URL ([#263](https://github.com/stac-utils/stac-fastapi/pull/263))
+* Links to children collections from the landing pagge always have a title ([#260](https://github.com/stac-utils/stac-fastapi/pull/260))
 
 ## [2.1.0]
 

--- a/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
+++ b/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
@@ -269,4 +269,4 @@ def test_landing_page_no_collection_title(
     landing_page = postgres_core.landing_page(request=MockStarletteRequestWithApp)
     for link in landing_page["links"]:
         if link["href"].split("/")[-1] == coll["id"]:
-            assert not link["title"]
+            assert link["title"]

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -359,7 +359,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
                 {
                     "rel": Relations.child.value,
                     "type": MimeTypes.json.value,
-                    "title": collection.get("title"),
+                    "title": collection.get("title") or collection.get("id"),
                     "href": urljoin(base_url, f"collections/{collection['id']}"),
                 }
             )


### PR DESCRIPTION
While looking at another ticket, I found and opened issue #259 where stac_validator was returning a error because the JSON returned had a NULL in it for a string element. This PR fixes the issue.
