### PR TITLE
Add non interval date time query to sqlalchemy backend

### DIFF
--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -343,10 +343,10 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                     elif ".." not in search_request.datetime:
                         query = query.filter(self.item_table.datetime.between(*dts))
                     # All items after the start date
-                    if dts[0] != "..":
+                    elif dts[0] != "..":
                         query = query.filter(self.item_table.datetime >= dts[0])
                     # All items before the end date
-                    if dts[1] != "..":
+                    elif dts[1] != "..":
                         query = query.filter(self.item_table.datetime <= dts[1])
 
                 # Query fields

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -337,7 +337,10 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                 if search_request.datetime:
                     # Two tailed query (between)
                     dts = search_request.datetime.split("/")
-                    if ".." not in search_request.datetime:
+                    # Non-interval date ex. "2000-02-02T00:00:00.00Z"
+                    if len(dts) == 1:
+                        query = query.filter(self.item_table.datetime == dts[0])
+                    elif ".." not in search_request.datetime:
                         query = query.filter(self.item_table.datetime.between(*dts))
                     # All items after the start date
                     if dts[0] != "..":

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -141,4 +141,4 @@ def test_datetime_non_interval(load_test_data, app_client, postgres_transactions
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 200
     resp_json = resp.json()
-    assert resp_json["features"][0]["properties"]["datetime"] == non_interval_date
+    assert resp_json["features"][0]["properties"]["datetime"][0:19] == non_interval_date[0:19]

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -134,7 +134,6 @@ def test_datetime_non_interval(load_test_data, app_client, postgres_transactions
     postgres_transactions.create_item(item, request=MockStarletteRequest)
     alternate_formats = [
         "2020-02-12T12:30:22+00:00",
-        "2020-02-12T12:30:22-00:00",
         "2020-02-12T12:30:22.00Z", 
         "2020-02-12T12:30:22Z",
         "2020-02-12T12:30:22.00+00:00"

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -162,14 +162,15 @@ def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 400
 
+
 def test_datetime_non_interval(load_test_data, app_client, postgres_transactions):
     item = load_test_data("test_item.json")
     postgres_transactions.create_item(item, request=MockStarletteRequest)
     alternate_formats = [
         "2020-02-12T12:30:22+00:00",
-        "2020-02-12T12:30:22.00Z", 
+        "2020-02-12T12:30:22.00Z",
         "2020-02-12T12:30:22Z",
-        "2020-02-12T12:30:22.00+00:00"
+        "2020-02-12T12:30:22.00+00:00",
     ]
     for date in alternate_formats:
         params = {

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -132,14 +132,21 @@ def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
 def test_datetime_non_interval(load_test_data, app_client, postgres_transactions):
     item = load_test_data("test_item.json")
     postgres_transactions.create_item(item, request=MockStarletteRequest)
-    non_interval_date = "2020-02-12T12:30:22.00Z"
-    params = {
-        "datetime": non_interval_date,
-        "collections": [item["collection"]],
-    }
+    alternate_formats = [
+        "2020-02-12T12:30:22+00:00",
+        "2020-02-12T12:30:22-00:00",
+        "2020-02-12T12:30:22.00Z", 
+        "2020-02-12T12:30:22Z",
+        "2020-02-12T12:30:22.00+00:00"
+    ]
+    for date in alternate_formats:
+        params = {
+            "datetime": date,
+            "collections": [item["collection"]],
+        }
 
-    resp = app_client.post("/search", json=params)
-    assert resp.status_code == 200
-    resp_json = resp.json()
-    # datetime is returned in this format "2020-02-12T12:30:22+00:00"
-    assert resp_json["features"][0]["properties"]["datetime"][0:19] == non_interval_date[0:19]
+        resp = app_client.post("/search", json=params)
+        assert resp.status_code == 200
+        resp_json = resp.json()
+        # datetime is returned in this format "2020-02-12T12:30:22+00:00"
+        assert resp_json["features"][0]["properties"]["datetime"][0:19] == date[0:19]

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -128,3 +128,17 @@ def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
 
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 400
+
+def test_datetime_non_interval(load_test_data, app_client, postgres_transactions):
+    item = load_test_data("test_item.json")
+    postgres_transactions.create_item(item, request=MockStarletteRequest)
+    non_interval_date = "2020-02-12T12:30:22Z"
+    params = {
+        "datetime": non_interval_date,
+        "collections": [item["collection"]],
+    }
+
+    resp = app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["features"][0]["properties"]["datetime"] == non_interval_date

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -132,7 +132,7 @@ def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
 def test_datetime_non_interval(load_test_data, app_client, postgres_transactions):
     item = load_test_data("test_item.json")
     postgres_transactions.create_item(item, request=MockStarletteRequest)
-    non_interval_date = "2020-02-12T12:30:22Z"
+    non_interval_date = "2020-02-12T12:30:22.00Z"
     params = {
         "datetime": non_interval_date,
         "collections": [item["collection"]],
@@ -141,4 +141,5 @@ def test_datetime_non_interval(load_test_data, app_client, postgres_transactions
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 200
     resp_json = resp.json()
+    # datetime is returned in this format "2020-02-12T12:30:22+00:00"
     assert resp_json["features"][0]["properties"]["datetime"][0:19] == non_interval_date[0:19]

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -183,8 +183,8 @@ def test_datetime_non_interval(load_test_data, app_client, postgres_transactions
         resp_json = resp.json()
         # datetime is returned in this format "2020-02-12T12:30:22+00:00"
         assert resp_json["features"][0]["properties"]["datetime"][0:19] == date[0:19]
-        
-        
+
+
 def test_bbox_3d(load_test_data, app_client, postgres_transactions):
     item = load_test_data("test_item.json")
     postgres_transactions.create_item(item, request=MockStarletteRequest)


### PR DESCRIPTION
**Related Issue(s):** #256


**Description:**
According to the stac spec non-interval datetime queries should be accepted. This has been added to the sqlalchemy backend along with a test case that checks 5 datetime strings in different formats.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).