### PR TITLE
Test alternate geometries in pgstac and sqlalchemy

### DIFF
--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -181,8 +181,11 @@ async def test_app_search_response(load_test_data, app_client, load_test_collect
     assert resp_json.get("stac_version") is None
     assert resp_json.get("stac_extensions") is None
 
+
 @pytest.mark.asyncio
-async def test_search_point_intersects(load_test_data, app_client, load_test_collection):
+async def test_search_point_intersects(
+    load_test_data, app_client, load_test_collection
+):
     coll = load_test_collection
     item = load_test_data("test_item.json")
     resp = await app_client.post(f"/collections/{coll.id}/items", json=item)
@@ -202,7 +205,9 @@ async def test_search_point_intersects(load_test_data, app_client, load_test_col
 
 
 @pytest.mark.asyncio
-async def test_search_line_string_intersects(load_test_data, app_client, load_test_collection):
+async def test_search_line_string_intersects(
+    load_test_data, app_client, load_test_collection
+):
     coll = load_test_collection
     item = load_test_data("test_item.json")
     resp = await app_client.post(f"/collections/{coll.id}/items", json=item)

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -180,3 +180,42 @@ async def test_app_search_response(load_test_data, app_client, load_test_collect
     # stac_version and stac_extensions were removed in v1.0.0-beta.3
     assert resp_json.get("stac_version") is None
     assert resp_json.get("stac_extensions") is None
+
+@pytest.mark.asyncio
+async def test_search_point_intersects(load_test_data, app_client, load_test_collection):
+    coll = load_test_collection
+    item = load_test_data("test_item.json")
+    resp = await app_client.post(f"/collections/{coll.id}/items", json=item)
+    assert resp.status_code == 200
+
+    point = [150.04, -33.14]
+    intersects = {"type": "Point", "coordinates": point}
+
+    params = {
+        "intersects": intersects,
+        "collections": [item["collection"]],
+    }
+    resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_line_string_intersects(load_test_data, app_client, load_test_collection):
+    coll = load_test_collection
+    item = load_test_data("test_item.json")
+    resp = await app_client.post(f"/collections/{coll.id}/items", json=item)
+    assert resp.status_code == 200
+
+    line = [[150.04, -33.14], [150.22, -33.89]]
+    intersects = {"type": "LineString", "coordinates": line}
+
+    params = {
+        "intersects": intersects,
+        "collections": [item["collection"]],
+    }
+    resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 1

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -311,12 +311,12 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
 
             else:
                 # Spatial query
-                poly = None
+                geom = None
                 if search_request.intersects is not None:
-                    poly = shape(search_request.intersects)
+                    geom = shape(search_request.intersects)
                 elif search_request.bbox:
                     if len(search_request.bbox) == 4:
-                        poly = ShapelyPolygon.from_bounds(*search_request.bbox)
+                        geom = ShapelyPolygon.from_bounds(*search_request.bbox)
                     elif len(search_request.bbox) == 6:
                         """Shapely doesn't support 3d bounding boxes we'll just use the 2d portion"""
                         bbox_2d = [
@@ -325,10 +325,10 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                             search_request.bbox[3],
                             search_request.bbox[4],
                         ]
-                        poly = ShapelyPolygon.from_bounds(*bbox_2d)
+                        geom = ShapelyPolygon.from_bounds(*bbox_2d)
 
-                if poly:
-                    filter_geom = ga.shape.from_shape(poly, srid=4326)
+                if geom:
+                    filter_geom = ga.shape.from_shape(geom, srid=4326)
                     query = query.filter(
                         ga.func.ST_Intersects(self.item_table.geometry, filter_geom)
                     )

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -180,7 +180,9 @@ def test_search_point_intersects(load_test_data, app_client, postgres_transactio
     assert len(resp_json["features"]) == 1
 
 
-def test_search_line_string_intersects(load_test_data, app_client, postgres_transactions):
+def test_search_line_string_intersects(
+    load_test_data, app_client, postgres_transactions
+):
     item = load_test_data("test_item.json")
     postgres_transactions.create_item(item, request=MockStarletteRequest)
 
@@ -195,4 +197,3 @@ def test_search_line_string_intersects(load_test_data, app_client, postgres_tran
     assert resp.status_code == 200
     resp_json = resp.json()
     assert len(resp_json["features"]) == 1
-    

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -161,3 +161,38 @@ def test_search_invalid_date(load_test_data, app_client, postgres_transactions):
 
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 400
+
+
+def test_search_point_intersects(load_test_data, app_client, postgres_transactions):
+    item = load_test_data("test_item.json")
+    postgres_transactions.create_item(item, request=MockStarletteRequest)
+
+    point = [150.04, -33.14]
+    intersects = {"type": "Point", "coordinates": point}
+
+    params = {
+        "intersects": intersects,
+        "collections": [item["collection"]],
+    }
+    resp = app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 1
+
+
+def test_search_line_string_intersects(load_test_data, app_client, postgres_transactions):
+    item = load_test_data("test_item.json")
+    postgres_transactions.create_item(item, request=MockStarletteRequest)
+
+    line = [[150.04, -33.14], [150.22, -33.89]]
+    intersects = {"type": "LineString", "coordinates": line}
+
+    params = {
+        "intersects": intersects,
+        "collections": [item["collection"]],
+    }
+    resp = app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 1
+    


### PR DESCRIPTION
**Related Issue(s):** #87


**Description:**
Add tests in pgstac and sqlalchemy for alternate geojson types. Change variable name 'poly' to 'geom' in sqlalchemy core.py so it doesn't seem like only Polygons are supported. 

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).