### PR TITLE
add middleware option to enable custom configuration

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -74,6 +74,7 @@ class StacApi:
     description: str = attr.ib(default="stac-fastapi")
     search_request_model: Type[Search] = attr.ib(default=STACSearch)
     response_class: Type[Response] = attr.ib(default=JSONResponse)
+    middlewares: List = attr.ib(default=attr.Factory(lambda: [BrotliMiddleware]))
 
     def get_extension(self, extension: Type[ApiExtension]) -> Optional[ApiExtension]:
         """Get an extension.
@@ -345,5 +346,6 @@ class StacApi:
         # customize openapi
         self.app.openapi = self.customize_openapi
 
-        # add compression middleware
-        self.app.add_middleware(BrotliMiddleware)
+        # add middlewares
+        for middleware in self.middlewares:
+            self.app.add_middleware(middleware)


### PR DESCRIPTION
**Related Issue(s):**  #265 


**Description:**
This PR adds a `middlewares` option in `stac_fastapi.api.app.StacApi`. The middlewares value will defaults to `[BrotliMiddleware]` for compatibility with previous version

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).