### PR TITLE
include `stac_version` to default search attributes: #253

### DIFF
--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields.py
@@ -32,6 +32,7 @@ class FieldsExtension(ApiExtension):
         factory=lambda: {
             "id",
             "type",
+            "stac_version",
             "geometry",
             "bbox",
             "links",


### PR DESCRIPTION
**Related Issue(s):** #253 


**Description:**
Adds `stac_version` to default attributes advertised o `/search` results. Extra fields `properties.proj:epsg` and `properties.odc:product` are a "good to have" but they require tests modified to accommodate them.

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).