### PR TITLE
Set collection_id on search for pgstac get_item; update to pgstac 0.3.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
 
 * Pin FastAPI to 0.67 to avoid issues with rendering OpenAPI documentation ([#246](https://github.com/stac-utils/stac-fastapi/pull/246))
 * Add `stac_version` to default search attributes ([#268](https://github.com/stac-utils/stac-fastapi/pull/268))
+* pgstac backend specifies collection_id when fetching a single item ([#279](https://github.com/stac-utils/stac-fastapi/pull/270))
 
 ## [2.1.0]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
 
   database:
     container_name: stac-db
-    image: ghcr.io/stac-utils/pgstac:v0.3.3
+    image: ghcr.io/stac-utils/pgstac:v0.3.4
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -25,7 +25,7 @@ extra_reqs = {
         "pytest-asyncio",
         "pre-commit",
         "requests",
-        "pypgstac==0.3.3",
+        "pypgstac==0.3.4",
         "httpx",
         "shapely",
     ],

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -207,7 +207,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         # If collection does not exist, NotFoundError wil be raised
         await self.get_collection(collection_id, **kwargs)
 
-        req = PgstacSearch(ids=[item_id], limit=1)
+        req = PgstacSearch(ids=[item_id], collections=[collection_id], limit=1)
         item_collection = await self._search_base(req, **kwargs)
         if not item_collection["features"]:
             raise NotFoundError(f"Collection {collection_id} does not exist.")

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -210,7 +210,9 @@ class CoreCrudClient(AsyncBaseCoreClient):
         req = PgstacSearch(ids=[item_id], collections=[collection_id], limit=1)
         item_collection = await self._search_base(req, **kwargs)
         if not item_collection["features"]:
-            raise NotFoundError(f"Collection {collection_id} does not exist.")
+            raise NotFoundError(
+                f"Item {item_id} in Collection {collection_id} does not exist."
+            )
 
         return Item(**item_collection["features"][0])
 


### PR DESCRIPTION
**Description:**
This change modifies the behavior of get_item in the pgstac backend to set the collection ID. This is correct behavior - item Ids must be unique within a collection, and a collection_id is supplied in the call. Also, as mentioned in https://github.com/stac-utils/pgstac/issues/58, pgstac can return incorrect results if queried with just an Item ID without the Collection ID set. 

This PR also updates to pgstac 0.3.4, and fixes the NotFoundError message in get_item.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).