### PR TITLE
Allow custom models for search GET and items endpoints

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -73,6 +73,8 @@ class StacApi:
     stac_version: str = attr.ib(default=STAC_VERSION)
     description: str = attr.ib(default="stac-fastapi")
     search_request_model: Type[Search] = attr.ib(default=STACSearch)
+    search_get_request: Type[SearchGetRequest] = attr.ib(default=SearchGetRequest)
+    item_collection_uri: Type[ItemCollectionUri] = attr.ib(default=ItemCollectionUri)
     response_class: Type[Response] = attr.ib(default=JSONResponse)
     middlewares: List = attr.ib(default=attr.Factory(lambda: [BrotliMiddleware]))
 
@@ -199,7 +201,9 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=self._create_endpoint(self.client.get_search, SearchGetRequest),
+            endpoint=self._create_endpoint(
+                self.client.get_search, self.search_get_request
+            ),
         )
 
     def register_get_collections(self):
@@ -255,7 +259,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.item_collection, ItemCollectionUri
+                self.client.item_collection, self.item_collection_uri
             ),
         )
 


### PR DESCRIPTION
**Description:**
I use a different default limit than this project, which is 10. While currently you can override the `search_request_model` in the StacApi class, you can't do so for the models that give default values to the item collection endpoint and the GET search. This PR adds models that allow users to override these types. It also contains the ability for the pgstac backend to use a custom search model instead of building a PgstacSearch for the item collection and GET search endpoints. I made this change while tracking down why my overridden limit was not being used; this turns out not being needed for my specific use case (as the default limit comes from the arguments passed into the core client methods by ItemCollectionUri and SearchGetRequest), it seemed like a sensible change in case any other user would want to modify the behavior of the search model in more than just the search POST endpoint.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).