### PR TITLE
Return existing links in pgstac

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ coverage.xml
 *.log
 .git
 .envrc
+
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ docs/api/*
 
 # Direnv
 .envrc
+
+# Virtualenv
+venv

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+* Links stored with Collections and Items (e.g. license links) are now returned with those STAC objects ([#282](https://github.com/stac-utils/stac-fastapi/pull/282))
+
 ## [2.2.0]
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ run-database:
 run-joplin-sqlalchemy:
 	docker-compose run --rm loadjoplin-sqlalchemy
 
+.PHONY: run-joplin-pgstac
+run-joplin-pgstac:
+	docker-compose run --rm loadjoplin-pgstac
+
 .PHONY: test
 test: test-sqlalchemy test-pgstac
 

--- a/scripts/ingest_joplin.py
+++ b/scripts/ingest_joplin.py
@@ -15,27 +15,33 @@ if not app_host:
     raise Exception("You must include full path/port to stac instance")
 
 
+def post_or_put(url: str, data: dict):
+    """Post or put data to url."""
+    r = requests.post(url, json=data)
+    if r.status_code == 409:
+        # Exists, so update
+        r = requests.put(url, json=data)
+        # Unchanged may throw a 404
+        if not r.status_code == 404:
+            r.raise_for_status()
+    else:
+        r.raise_for_status()
+
+
 def ingest_joplin_data(app_host: str = app_host, data_dir: Path = joplindata):
     """ingest data."""
 
     with open(data_dir / "collection.json") as f:
         collection = json.load(f)
 
-    r = requests.post(urljoin(app_host, "collections"), json=collection)
-    if r.status_code not in (200, 409):
-        r.raise_for_status()
+    post_or_put(urljoin(app_host, "/collections"), collection)
 
     with open(data_dir / "index.geojson") as f:
         index = json.load(f)
 
     for feat in index["features"]:
         del feat["stac_extensions"]
-        r = requests.post(
-            urljoin(app_host, f"collections/{collection['id']}/items"), json=feat
-        )
-        if r.status_code == 409:
-            continue
-        r.raise_for_status()
+        post_or_put(urljoin(app_host, f"collections/{collection['id']}/items"), feat)
 
 
 if __name__ == "__main__":

--- a/stac_fastapi/pgstac/tests/data/test_collection.json
+++ b/stac_fastapi/pgstac/tests/data/test_collection.json
@@ -100,24 +100,9 @@
   },
   "links": [
     {
-      "href": "http://localhost:8081/collections/landsat-8-l1",
-      "rel": "self",
-      "type": "application/json"
-    },
-    {
-      "href": "http://localhost:8081/",
-      "rel": "parent",
-      "type": "application/json"
-    },
-    {
-      "href": "http://localhost:8081/collections/landsat-8-l1/items",
-      "rel": "item",
-      "type": "application/geo+json"
-    },
-    {
-      "href": "http://localhost:8081/",
-      "rel": "root",
-      "type": "application/json"
+        "rel": "license",
+        "href": "https://creativecommons.org/licenses/publicdomain/",
+        "title": "public domain"
     }
   ],
   "title": "Landsat 8 L1",

--- a/stac_fastapi/pgstac/tests/data/test_item.json
+++ b/stac_fastapi/pgstac/tests/data/test_item.json
@@ -500,6 +500,11 @@
       "href": "http://localhost:8081/",
       "rel": "root",
       "type": "application/json"
+    },
+    {
+      "href": "preview.html",
+      "rel": "preview",
+      "type": "application/html"
     }
   ]
 }

--- a/stac_fastapi/pgstac/tests/resources/test_collection.py
+++ b/stac_fastapi/pgstac/tests/resources/test_collection.py
@@ -164,3 +164,14 @@ async def test_returns_valid_links_in_collections(app_client, load_test_data):
         for i in collection.to_dict()["links"]
         if i not in single_coll_mocked_link.to_dict()["links"]
     ] == []
+
+
+@pytest.mark.asyncio
+async def test_returns_license_link(app_client, load_test_collection):
+    coll = load_test_collection
+
+    resp = await app_client.get(f"/collections/{coll.id}")
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    link_rel_types = [link["rel"] for link in resp_json["links"]]
+    assert "license" in link_rel_types

--- a/stac_fastapi/testdata/joplin/collection.json
+++ b/stac_fastapi/testdata/joplin/collection.json
@@ -3,7 +3,13 @@
     "description": "This imagery was acquired by the NOAA Remote Sensing Division to support NOAA national security and emergency response requirements. In addition, it will be used for ongoing research efforts for testing and developing standards for airborne digital imagery. Individual images have been combined into a larger mosaic and tiled for distribution. The approximate ground sample distance (GSD) for each pixel is 35 cm (1.14 feet).",
     "stac_version": "1.0.0",
     "license": "public-domain",
-    "links": [],
+    "links": [
+        {
+            "rel": "license",
+            "href": "https://creativecommons.org/licenses/publicdomain/",
+            "title": "public domain"
+        }
+    ],
     "type": "collection",
     "extent": {
         "spatial": {


### PR DESCRIPTION
**Description:**
Collections and Items stored in pgstac may have existing links. The example that uncovered this bug is for Collections to link to their licenses with rel=license link. These are currently being overwritten by the hierarchical links derived by stac-fastapi. This change passes through any non-hierarchical links in the pgstac backend.

This also changes the joplin ingest code to use a PUT if the collection or item already exists - useful for changing the development data and re-ingesting.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).