### PR TITLE
Fix content-type of /api response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 ### Fixed
 
 * Links stored with Collections and Items (e.g. license links) are now returned with those STAC objects ([#282](https://github.com/stac-utils/stac-fastapi/pull/282))
-* Content-type response headers for the /api endpoint now reflect those expected in the STAC api spec ([]())
+* Content-type response headers for the /api endpoint now reflect those expected in the STAC api spec ([#287](https://github.com/stac-utils/stac-fastapi/pull/287))
 
 ## [2.2.0]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 * Links stored with Collections and Items (e.g. license links) are now returned with those STAC objects ([#282](https://github.com/stac-utils/stac-fastapi/pull/282))
+* Content-type response headers for the /api endpoint now reflect those expected in the STAC api spec ([]())
 
 ## [2.2.0]
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -4,20 +4,13 @@ from typing import Any, Callable, Dict, List, Optional, Type, Union
 import attr
 from brotli_asgi import BrotliMiddleware
 from fastapi import APIRouter, FastAPI
-from fastapi.openapi.docs import (
-    get_redoc_html,
-    get_swagger_ui_html,
-    get_swagger_ui_oauth2_redirect_html,
-)
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import ORJSONResponse
 from pydantic import BaseModel
 from stac_pydantic import Collection, Item, ItemCollection
 from stac_pydantic.api import ConformanceClasses, LandingPage, Search
 from stac_pydantic.api.collections import Collections
 from stac_pydantic.version import STAC_VERSION
-from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, Response
+from starlette.responses import JSONResponse, Response
 
 from stac_fastapi.api.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from stac_fastapi.api.models import (
@@ -29,6 +22,7 @@ from stac_fastapi.api.models import (
     SearchGetRequest,
     _create_request_model,
 )
+from stac_fastapi.api.openapi import update_openapi
 from stac_fastapi.api.routes import create_async_endpoint, create_sync_endpoint
 
 # TODO: make this module not depend on `stac_fastapi.extensions`
@@ -37,69 +31,6 @@ from stac_fastapi.types.config import ApiSettings, Settings
 from stac_fastapi.types.core import AsyncBaseCoreClient, BaseCoreClient
 from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.search import STACSearch
-
-
-class VndOaiResponse(ORJSONResponse):
-    """JSON with custom, vendor content-type."""
-
-    media_type = "application/vnd.oai.openapi+json;version=3.0"
-
-
-class VndFastAPI(FastAPI):
-    """Custom FastAPI to support /api response with vendor content-type."""
-
-    def setup(self) -> None:
-        """Update vendor-specific content-type for /api."""
-        if self.openapi_url:
-            urls = (server_data.get("url") for server_data in self.servers)
-            server_urls = {url for url in urls if url}
-
-            async def openapi(req: Request) -> JSONResponse:
-                root_path = req.scope.get("root_path", "").rstrip("/")
-                if root_path not in server_urls:
-                    if root_path and self.root_path_in_servers:
-                        self.servers.insert(0, {"url": root_path})
-                        server_urls.add(root_path)
-                return VndOaiResponse(self.openapi())
-
-            self.add_route(self.openapi_url, openapi, include_in_schema=False)
-        if self.openapi_url and self.docs_url:
-
-            async def swagger_ui_html(req: Request) -> HTMLResponse:
-                root_path = req.scope.get("root_path", "").rstrip("/")
-                openapi_url = root_path + self.openapi_url
-                oauth2_redirect_url = self.swagger_ui_oauth2_redirect_url
-                if oauth2_redirect_url:
-                    oauth2_redirect_url = root_path + oauth2_redirect_url
-                return get_swagger_ui_html(
-                    openapi_url=openapi_url,
-                    title=self.title + " - Swagger UI",
-                    oauth2_redirect_url=oauth2_redirect_url,
-                    init_oauth=self.swagger_ui_init_oauth,
-                )
-
-            self.add_route(self.docs_url, swagger_ui_html, include_in_schema=False)
-
-            if self.swagger_ui_oauth2_redirect_url:
-
-                async def swagger_ui_redirect(req: Request) -> HTMLResponse:
-                    return get_swagger_ui_oauth2_redirect_html()
-
-                self.add_route(
-                    self.swagger_ui_oauth2_redirect_url,
-                    swagger_ui_redirect,
-                    include_in_schema=False,
-                )
-        if self.openapi_url and self.redoc_url:
-
-            async def redoc_html(req: Request) -> HTMLResponse:
-                root_path = req.scope.get("root_path", "").rstrip("/")
-                openapi_url = root_path + self.openapi_url
-                return get_redoc_html(
-                    openapi_url=openapi_url, title=self.title + " - ReDoc"
-                )
-
-            self.add_route(self.redoc_url, redoc_html, include_in_schema=False)
 
 
 @attr.s
@@ -134,9 +65,10 @@ class StacApi:
     )
     app: FastAPI = attr.ib(
         default=attr.Factory(
-            lambda self: VndFastAPI(openapi_url=self.settings.openapi_url),
+            lambda self: FastAPI(openapi_url=self.settings.openapi_url),
             takes_self=True,
-        )
+        ),
+        converter=update_openapi,
     )
     router: APIRouter = attr.ib(default=attr.Factory(APIRouter))
     title: str = attr.ib(default="stac-fastapi")
@@ -146,7 +78,7 @@ class StacApi:
     search_request_model: Type[Search] = attr.ib(default=STACSearch)
     search_get_request: Type[SearchGetRequest] = attr.ib(default=SearchGetRequest)
     item_collection_uri: Type[ItemCollectionUri] = attr.ib(default=ItemCollectionUri)
-    response_class: Type[Response] = attr.ib(default=ORJSONResponse)
+    response_class: Type[Response] = attr.ib(default=JSONResponse)
     middlewares: List = attr.ib(default=attr.Factory(lambda: [BrotliMiddleware]))
 
     def get_extension(self, extension: Type[ApiExtension]) -> Optional[ApiExtension]:

--- a/stac_fastapi/api/stac_fastapi/api/openapi.py
+++ b/stac_fastapi/api/stac_fastapi/api/openapi.py
@@ -1,9 +1,43 @@
 """openapi."""
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
 from stac_fastapi.api.config import ApiExtensions
 from stac_fastapi.types.config import ApiSettings
+
+
+class VndOaiResponse(JSONResponse):
+    """JSON with custom, vendor content-type."""
+
+    media_type = "application/vnd.oai.openapi+json;version=3.0"
+
+
+def update_openapi(app: FastAPI) -> FastAPI:
+    """Update OpenAPI response content-type.
+
+    This function modifies the openapi route to comply with the STAC API spec's
+    required content-type response header
+    """
+    urls = (server_data.get("url") for server_data in app.servers)
+    server_urls = {url for url in urls if url}
+
+    async def openapi(req: Request) -> JSONResponse:
+        root_path = req.scope.get("root_path", "").rstrip("/")
+        if root_path not in server_urls:
+            if root_path and app.root_path_in_servers:
+                app.servers.insert(0, {"url": root_path})
+                server_urls.add(root_path)
+        return VndOaiResponse(app.openapi())
+
+    # Remove the default openapi route
+    app.router.routes = list(
+        filter(lambda r: r.path != app.openapi_url, app.router.routes)
+    )
+    # Add the updated openapi route
+    app.add_route(app.openapi_url, openapi, include_in_schema=False)
+    return app
 
 
 # TODO: Remove or fix, this is currently unused

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -24,6 +24,15 @@ STAC_TRANSACTION_ROUTES = [
 
 
 @pytest.mark.asyncio
+async def test_api_headers(app_client):
+    resp = await app_client.get("/api")
+    assert (
+        resp.headers["content-type"] == "application/vnd.oai.openapi+json;version=3.0"
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_core_router(api_client):
     core_routes = set(STAC_CORE_ROUTES)
     api_routes = set(

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -23,6 +23,14 @@ STAC_TRANSACTION_ROUTES = [
 ]
 
 
+def test_api_headers(app_client):
+    resp = app_client.get("/api")
+    assert (
+        resp.headers["content-type"] == "application/vnd.oai.openapi+json;version=3.0"
+    )
+    assert resp.status_code == 200
+
+
 def test_core_router(api_client):
     core_routes = set(STAC_CORE_ROUTES)
     api_routes = set(


### PR DESCRIPTION
**Related Issue(s):** #281


**Description:**
/api provides open api JSON which is used for doc generation. This endpoint currently returns `application/json` as the content type, whereas OGC API Features - part 2 spec explicitly requires `application/vnd.oai.openapi+json;version=3.0` to be the content-type. This PR addresses that issue by extending the `FastAPI` class to update the `setup` method, which is hides the creation of the /api endpoint.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).