### PR TITLE
Set content-type to geojson for search results

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+* Content-type response headers for the /search endpoint now reflect the geojson response expected in the STAC api spec ([#220](https://github.com/stac-utils/stac-fastapi/issues/220)
 * Links stored with Collections and Items (e.g. license links) are now returned with those STAC objects ([#282](https://github.com/stac-utils/stac-fastapi/pull/282))
 
 ## [2.2.0]

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -97,7 +97,7 @@ class StacApi:
         self,
         func: Callable,
         request_type: Union[Type[APIRequest], Type[BaseModel]],
-        resp_class: Type[Response] = response_class,
+        resp_class: Type[Response],
     ) -> Callable:
         """Create a FastAPI endpoint."""
         if isinstance(self.client, AsyncBaseCoreClient):
@@ -122,7 +122,9 @@ class StacApi:
             response_model_exclude_unset=False,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=self._create_endpoint(self.client.landing_page, EmptyRequest),
+            endpoint=self._create_endpoint(
+                self.client.landing_page, EmptyRequest, self.response_class
+            ),
         )
 
     def register_conformance_classes(self):
@@ -141,7 +143,9 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=self._create_endpoint(self.client.conformance, EmptyRequest),
+            endpoint=self._create_endpoint(
+                self.client.conformance, EmptyRequest, self.response_class
+            ),
         )
 
     def register_get_item(self):
@@ -158,7 +162,9 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=self._create_endpoint(self.client.get_item, ItemUri),
+            endpoint=self._create_endpoint(
+                self.client.get_item, ItemUri, self.response_class
+            ),
         )
 
     def register_post_search(self):
@@ -222,7 +228,9 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=self._create_endpoint(self.client.all_collections, EmptyRequest),
+            endpoint=self._create_endpoint(
+                self.client.all_collections, EmptyRequest, self.response_class
+            ),
         )
 
     def register_get_collection(self):
@@ -239,7 +247,9 @@ class StacApi:
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
-            endpoint=self._create_endpoint(self.client.get_collection, CollectionUri),
+            endpoint=self._create_endpoint(
+                self.client.get_collection, CollectionUri, self.response_class
+            ),
         )
 
     def register_get_item_collection(self):
@@ -259,7 +269,9 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.item_collection, self.item_collection_uri
+                self.client.item_collection,
+                self.item_collection_uri,
+                self.response_class,
             ),
         )
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -17,6 +17,7 @@ from stac_fastapi.api.models import (
     APIRequest,
     CollectionUri,
     EmptyRequest,
+    GeoJSONResponse,
     ItemCollectionUri,
     ItemUri,
     SearchGetRequest,
@@ -93,17 +94,16 @@ class StacApi:
         return None
 
     def _create_endpoint(
-        self, func: Callable, request_type: Union[Type[APIRequest], Type[BaseModel]]
+        self,
+        func: Callable,
+        request_type: Union[Type[APIRequest], Type[BaseModel]],
+        resp_class: Type[Response] = response_class,
     ) -> Callable:
         """Create a FastAPI endpoint."""
         if isinstance(self.client, AsyncBaseCoreClient):
-            return create_async_endpoint(
-                func, request_type, response_class=self.response_class
-            )
+            return create_async_endpoint(func, request_type, response_class=resp_class)
         elif isinstance(self.client, BaseCoreClient):
-            return create_sync_endpoint(
-                func, request_type, response_class=self.response_class
-            )
+            return create_sync_endpoint(func, request_type, response_class=resp_class)
         raise NotImplementedError
 
     def register_landing_page(self):
@@ -175,12 +175,12 @@ class StacApi:
             response_model=(ItemCollection if not fields_ext else None)
             if self.settings.enable_response_models
             else None,
-            response_class=self.response_class,
+            response_class=GeoJSONResponse,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=self._create_endpoint(
-                self.client.post_search, search_request_model
+                self.client.post_search, search_request_model, GeoJSONResponse
             ),
         )
 
@@ -197,12 +197,12 @@ class StacApi:
             response_model=(ItemCollection if not fields_ext else None)
             if self.settings.enable_response_models
             else None,
-            response_class=self.response_class,
+            response_class=GeoJSONResponse,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.get_search, self.search_get_request
+                self.client.get_search, self.search_get_request, GeoJSONResponse
             ),
         )
 

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -7,6 +7,7 @@ import attr
 from fastapi import Body, Path
 from pydantic import BaseModel, create_model
 from pydantic.fields import UndefinedType
+from starlette.responses import JSONResponse
 
 
 def _create_request_model(model: Type[BaseModel]) -> Type[BaseModel]:
@@ -127,3 +128,9 @@ class SearchGetRequest(APIRequest):
             "fields": self.fields.split(",") if self.fields else self.fields,
             "sortby": self.sortby.split(",") if self.sortby else self.sortby,
         }
+
+
+class GeoJSONResponse(JSONResponse):
+    """JSON with custom, vendor content-type."""
+
+    media_type = "application/geo+json"

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -1,13 +1,13 @@
 """api request/response models."""
 
 import abc
+import importlib
 from typing import Dict, Optional, Type, Union
 
 import attr
 from fastapi import Body, Path
 from pydantic import BaseModel, create_model
 from pydantic.fields import UndefinedType
-from starlette.responses import JSONResponse
 
 
 def _create_request_model(model: Type[BaseModel]) -> Type[BaseModel]:
@@ -130,7 +130,20 @@ class SearchGetRequest(APIRequest):
         }
 
 
-class GeoJSONResponse(JSONResponse):
-    """JSON with custom, vendor content-type."""
+# Test for ORJSON and use it rather than stdlib JSON where supported
+if importlib.util.find_spec("orjson") is not None:
+    from fastapi.responses import ORJSONResponse
 
-    media_type = "application/geo+json"
+    class GeoJSONResponse(ORJSONResponse):
+        """JSON with custom, vendor content-type."""
+
+        media_type = "application/geo+json"
+
+
+else:
+    from starlette.responses import JSONResponse
+
+    class GeoJSONResponse(JSONResponse):
+        """JSON with custom, vendor content-type."""
+
+        media_type = "application/geo+json"

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -24,6 +24,19 @@ STAC_TRANSACTION_ROUTES = [
 
 
 @pytest.mark.asyncio
+async def test_post_search_content_type(app_client):
+    params = {"limit": 1}
+    resp = await app_client.post("search", json=params)
+    assert resp.headers["content-type"] == "application/geo+json"
+
+
+@pytest.mark.asyncio
+async def test_get_search_content_type(app_client):
+    resp = await app_client.get("search")
+    assert resp.headers["content-type"] == "application/geo+json"
+
+
+@pytest.mark.asyncio
 async def test_core_router(api_client):
     core_routes = set(STAC_CORE_ROUTES)
     api_routes = set(

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -23,6 +23,17 @@ STAC_TRANSACTION_ROUTES = [
 ]
 
 
+def test_post_search_content_type(app_client):
+    params = {"limit": 1}
+    resp = app_client.post("search", json=params)
+    assert resp.headers["content-type"] == "application/geo+json"
+
+
+def test_get_search_content_type(app_client):
+    resp = app_client.get("search")
+    assert resp.headers["content-type"] == "application/geo+json"
+
+
 def test_core_router(api_client):
     core_routes = set(STAC_CORE_ROUTES)
     api_routes = set(


### PR DESCRIPTION
**Related Issue(s):** #220


**Description:**
This PR changes the /search endpoint's headers to reflect the fact that it returns geojson rather than mere json, which is in line with the STAC api spec

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).