### PR TITLE
Ensure limit 0 searches return 400

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+* The minimum `limit` value for searches is now 1 ([#296](https://github.com/stac-utils/stac-fastapi/pull/296))
 * Links stored with Collections and Items (e.g. license links) are now returned with those STAC objects ([#282](https://github.com/stac-utils/stac-fastapi/pull/282))
 
 ## [2.2.0]

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
@@ -100,7 +100,7 @@ class PgstacSearch(Search):
     token: Optional[str] = None
     datetime: Optional[str] = None
     sortby: Any
-    limit: Optional[conint(ge=0, le=10000)] = 10
+    limit: Optional[conint(gt=0, le=10000)] = 10
 
     @root_validator(pre=True)
     def validate_query_fields(cls, values: Dict) -> Dict:

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -82,6 +82,20 @@ async def test_app_query_extension_limit_1(
 
 
 @pytest.mark.asyncio
+async def test_app_query_extension_limit_eq0(
+    load_test_data, app_client, load_test_collection
+):
+    coll = load_test_collection
+    item = load_test_data("test_item.json")
+    resp = await app_client.post(f"/collections/{coll.id}/items", json=item)
+    assert resp.status_code == 200
+
+    params = {"limit": 0}
+    resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_app_query_extension_limit_lt0(
     load_test_data, app_client, load_test_collection
 ):

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -82,14 +82,7 @@ async def test_app_query_extension_limit_1(
 
 
 @pytest.mark.asyncio
-async def test_app_query_extension_limit_eq0(
-    load_test_data, app_client, load_test_collection
-):
-    coll = load_test_collection
-    item = load_test_data("test_item.json")
-    resp = await app_client.post(f"/collections/{coll.id}/items", json=item)
-    assert resp.status_code == 200
-
+async def test_app_query_extension_limit_eq0(app_client):
     params = {"limit": 0}
     resp = await app_client.post("/search", json=params)
     assert resp.status_code == 400

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/types/search.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/types/search.py
@@ -145,7 +145,7 @@ class SQLAlchemySTACSearch(Search):
     # Override query extension with supported operators
     query: Optional[Dict[Queryables, Dict[Operator, Any]]]
     token: Optional[str] = None
-    limit: Optional[conint(ge=0, le=10000)] = 10
+    limit: Optional[conint(gt=0, le=10000)] = 10
 
     @root_validator(pre=True)
     def validate_query_fields(cls, values: Dict) -> Dict:

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -102,12 +102,7 @@ def test_app_query_extension_gte(load_test_data, app_client, postgres_transactio
     assert len(resp_json["features"]) == 1
 
 
-def test_app_query_extension_limit_eq0(
-    load_test_data, app_client, postgres_transactions
-):
-    item = load_test_data("test_item.json")
-    postgres_transactions.create_item(item, request=MockStarletteRequest)
-
+def test_app_query_extension_limit_eq0(app_client):
     params = {"limit": 0}
     resp = app_client.post("/search", json=params)
     assert resp.status_code == 400

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -102,6 +102,17 @@ def test_app_query_extension_gte(load_test_data, app_client, postgres_transactio
     assert len(resp_json["features"]) == 1
 
 
+def test_app_query_extension_limit_eq0(
+    load_test_data, app_client, postgres_transactions
+):
+    item = load_test_data("test_item.json")
+    postgres_transactions.create_item(item, request=MockStarletteRequest)
+
+    params = {"limit": 0}
+    resp = app_client.post("/search", json=params)
+    assert resp.status_code == 400
+
+
 def test_app_query_extension_limit_lt0(
     load_test_data, app_client, postgres_transactions
 ):


### PR DESCRIPTION
**Related Issue(s):** #291


**Description:**
This PR adjusts the minimum limit value to be greater than 0 rather than greater than or equal to.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).