### PR TITLE
Allow users configuration of search limit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* Users can now specify a maximum `limit` value through the `max_search_limit` configuration value ([290](https://github.com/stac-utils/stac-fastapi/pull/290))
+
 ### Changed
 
 ### Removed

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
@@ -100,7 +100,19 @@ class PgstacSearch(Search):
     token: Optional[str] = None
     datetime: Optional[str] = None
     sortby: Any
-    limit: Optional[conint(ge=0, le=10000)] = 10
+    limit: Optional[conint(gt=0)] = 10
+
+    @validator("limit")
+    def validate_limit(cls, v):
+        """Validate limit according to max_limit set in configuration.
+
+        Limit validation needs to be conducted via a custom functionto set
+        a maximum from within the config
+        """
+        max_limit = Settings.get().max_search_limit
+        if v > max_limit:
+            raise ValueError(f"must be less than {max_limit}")
+        return v
 
     @root_validator(pre=True)
     def validate_query_fields(cls, values: Dict) -> Dict:

--- a/stac_fastapi/types/stac_fastapi/types/config.py
+++ b/stac_fastapi/types/stac_fastapi/types/config.py
@@ -28,6 +28,9 @@ class ApiSettings(BaseSettings):
 
     openapi_url: str = "/api"
 
+    # The maximum limit which can be specified in search parameters
+    max_search_limit: int = 10000
+
     class Config:
         """model config (https://pydantic-docs.helpmanual.io/usage/model_config/)."""
 


### PR DESCRIPTION
**Related Issue(s):** #290


**Description:**
This PR enables end users to customize the maximum `limit` value for search parameters. The spec *suggests* 10000 as the maximum limit but implementations are free to set their own. This fix should allow implementers to put a limit on extremely large requests as may be necessary to avoid errors (the source of the 500s mentioned in issue #290) or to limit costs

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).