### PR TITLE
Update to 1.0.0-beta.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* Add link with rel-type of 'service-doc', pointing to HTML API documentation ([#298](https://github.com/stac-utils/stac-fastapi/pull/298))
+
 ### Changed
 
 * Refactor to remove hardcoded search request models. Request models are now dynamically created based on the enabled extensions.
@@ -11,6 +13,7 @@
 * Change example data to use correct `type` for the example Joplin collection ([#314](https://github.com/stac-utils/stac-fastapi/pull/314))
 * Changed the geometry type in the Item model from Polygon to Geometry.
 * Upgrade pgstac backend to use version 0.4.2 ([#321](https://github.com/stac-utils/stac-fastapi/pull/321))
+* STAC 1.0.0-beta.4 conformance classes updated ([#298](https://github.com/stac-utils/stac-fastapi/pull/298))
 
 ### Removed
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -66,8 +66,11 @@ class StacApi:
     app: FastAPI = attr.ib(
         default=attr.Factory(
             lambda self: FastAPI(openapi_url=self.settings.openapi_url),
-            takes_self=True,
-        ),
+                openapi_url=self.settings.openapi_url,
+                docs_url=self.settings.docs_url,
+                redoc_url=None,
+            ),
+        takes_self=True,
         converter=update_openapi,
     )
     router: APIRouter = attr.ib(default=attr.Factory(APIRouter))

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -65,12 +65,13 @@ class StacApi:
     )
     app: FastAPI = attr.ib(
         default=attr.Factory(
-            lambda self: FastAPI(openapi_url=self.settings.openapi_url),
+            lambda self: FastAPI(
                 openapi_url=self.settings.openapi_url,
                 docs_url=self.settings.docs_url,
                 redoc_url=None,
             ),
-        takes_self=True,
+            takes_self=True,
+        ),
         converter=update_openapi,
     )
     router: APIRouter = attr.ib(default=attr.Factory(APIRouter))

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
@@ -18,10 +18,10 @@ class ContextExtension(ApiExtension):
     """
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.3/item-search/#context"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search/#context"]
     )
     schema_href: Optional[str] = attr.ib(
-        default="https://raw.githubusercontent.com/radiantearth/stac-api-spec/v1.0.0-beta.3/fragments/context/json-schema/schema.json"
+        default="https://raw.githubusercontent.com/radiantearth/stac-api-spec/v1.0.0-beta.4/fragments/context/json-schema/schema.json"
     )
 
     def register(self, app: FastAPI) -> None:

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
@@ -30,7 +30,7 @@ class FieldsExtension(ApiExtension):
     POST = FieldsExtensionPostRequest
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.3/item-search/#fields"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search/#fields"]
     )
     default_includes: Set[str] = attr.ib(
         factory=lambda: {

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -18,25 +18,25 @@ from .request import FilterExtensionGetRequest, FilterExtensionPostRequest
 class FilterConformanceClasses(str, Enum):
     """Conformance classes for the Filter extension.
 
-    See https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.3/fragments/filter
+    See https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.4/fragments/filter
     """
 
-    FILTER = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:filter"
+    FILTER = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:filter"
     ITEM_SEARCH_FILTER = (
-        "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:item-search-filter"
+        "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:item-search-filter"
     )
-    CQL_TEXT = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:cql-text"
-    CQL_JSON = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:cql-json"
-    BASIC_CQL = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:basic-cql"
-    BASIC_SPATIAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:basic-spatial-operators"
-    BASIC_TEMPORAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:basic-temporal-operators"
-    ENHANCED_COMPARISON_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:enhanced-comparison-operators"
-    ENHANCED_SPATIAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:enhanced-spatial-operators"
-    ENHANCED_TEMPORAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:enhanced-temporal-operators"
-    FUNCTIONS = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:functions"
-    ARITHMETIC = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:arithmetic"
-    ARRAYS = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:arrays"
-    QUERYABLE_SECOND_OPERAND = "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:queryable-second-operand"
+    CQL_TEXT = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:cql-text"
+    CQL_JSON = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:cql-json"
+    BASIC_CQL = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:basic-cql"
+    BASIC_SPATIAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:basic-spatial-operators"
+    BASIC_TEMPORAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:basic-temporal-operators"
+    ENHANCED_COMPARISON_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:enhanced-comparison-operators"
+    ENHANCED_SPATIAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:enhanced-spatial-operators"
+    ENHANCED_TEMPORAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:enhanced-temporal-operators"
+    FUNCTIONS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:functions"
+    ARITHMETIC = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:arithmetic"
+    ARRAYS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:arrays"
+    QUERYABLE_SECOND_OPERAND = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:queryable-second-operand"
 
 
 @attr.s

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/query/query.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/query/query.py
@@ -23,7 +23,7 @@ class QueryExtension(ApiExtension):
     POST = QueryExtensionPostRequest
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.3/item-search/#query"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search/#query"]
     )
     schema_href: Optional[str] = attr.ib(default=None)
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/sort/sort.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/sort/sort.py
@@ -23,7 +23,7 @@ class SortExtension(ApiExtension):
     POST = SortExtensionPostRequest
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.3/item-search/#sort"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search/#sort"]
     )
     schema_href: Optional[str] = attr.ib(default=None)
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -38,7 +38,7 @@ class TransactionExtension(ApiExtension):
     settings: ApiSettings = attr.ib()
     conformance_classes: List[str] = attr.ib(
         factory=lambda: [
-            "https://api.stacspec.org/v1.0.0-beta.3/ogcapi-features/extensions/transaction/",
+            "https://api.stacspec.org/v1.0.0-beta.4/ogcapi-features/extensions/transaction/",
             "http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/simpletx",
         ]
     )

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -33,7 +33,7 @@ def test_landing_page_health(response):
 link_tests = [
     ("root", "application/json", "/"),
     ("conformance", "application/json", "/conformance"),
-    ("docs", "application/json", "/docs"),
+    ("service-doc", "text/html", "/api.html"),
     ("service-desc", "application/vnd.oai.openapi+json;version=3.0", "/api"),
 ]
 

--- a/stac_fastapi/sqlalchemy/tests/resources/test_conformance.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_conformance.py
@@ -33,7 +33,7 @@ def test_landing_page_health(response):
 link_tests = [
     ("root", "application/json", "/"),
     ("conformance", "application/json", "/conformance"),
-    ("docs", "application/json", "/docs"),
+    ("service-doc", "text/html", "/api.html"),
     ("service-desc", "application/vnd.oai.openapi+json;version=3.0", "/api"),
 ]
 

--- a/stac_fastapi/types/stac_fastapi/types/config.py
+++ b/stac_fastapi/types/stac_fastapi/types/config.py
@@ -27,6 +27,7 @@ class ApiSettings(BaseSettings):
     enable_response_models: bool = False
 
     openapi_url: str = "/api"
+    docs_url: str = "/api.html"
 
     class Config:
         """model config (https://pydantic-docs.helpmanual.io/usage/model_config/)."""

--- a/stac_fastapi/types/stac_fastapi/types/conformance.py
+++ b/stac_fastapi/types/stac_fastapi/types/conformance.py
@@ -5,9 +5,9 @@ from enum import Enum
 class STACConformanceClasses(str, Enum):
     """Conformance classes for the STAC API spec."""
 
-    CORE = "https://api.stacspec.org/v1.0.0-beta.3/core"
-    OGC_API_FEAT = "https://api.stacspec.org/v1.0.0-beta.3/ogcapi-features"
-    ITEM_SEARCH = "https://api.stacspec.org/v1.0.0-beta.3/item-search"
+    CORE = "https://api.stacspec.org/v1.0.0-beta.4/core"
+    OGC_API_FEAT = "https://api.stacspec.org/v1.0.0-beta.4/ogcapi-features"
+    ITEM_SEARCH = "https://api.stacspec.org/v1.0.0-beta.4/item-search"
 
 
 class OAFConformanceClasses(str, Enum):

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -558,7 +558,6 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         )
 
         # Add human readable service-doc
-        print("???", request.app)
         landing_page["links"].append(
             {
                 "rel": "service-doc",

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -375,6 +375,17 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
                 "href": urljoin(base_url, request.app.openapi_url.lstrip("/")),
             }
         )
+
+        # Add human readable service-doc
+        landing_page["links"].append(
+            {
+                "rel": "service-doc",
+                "type": "text/html",
+                "title": "OpenAPI service documentation",
+                "href": urljoin(base_url, request.app.docs_url.lstrip("/")),
+            }
+        )
+
         return landing_page
 
     def conformance(self, **kwargs) -> stac_types.Conformance:
@@ -549,6 +560,17 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
                 "type": "application/vnd.oai.openapi+json;version=3.0",
                 "title": "OpenAPI service description",
                 "href": urljoin(base_url, request.app.openapi_url.lstrip("/")),
+            }
+        )
+
+        # Add human readable service-doc
+        print("???", request.app)
+        landing_page["links"].append(
+            {
+                "rel": "service-doc",
+                "type": "text/html",
+                "title": "OpenAPI service documentation",
+                "href": urljoin(base_url, request.app.docs_url.lstrip("/")),
             }
         )
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -264,12 +264,6 @@ class LandingPageMixin(abc.ABC):
                     "href": urljoin(base_url, "collections"),
                 },
                 {
-                    "rel": Relations.docs.value,
-                    "type": MimeTypes.json,
-                    "title": "OpenAPI docs",
-                    "href": urljoin(base_url, "docs"),
-                },
-                {
                     "rel": Relations.conformance.value,
                     "type": MimeTypes.json,
                     "title": "STAC/WFS3 conformance classes implemented by this server",


### PR DESCRIPTION
**Related Issue(s):** #294


**Description:**
This PR brings conformance classes up to 1.0.0-beta.4 and implements relevant updates where possible within stac-fastapi. Note that complete 1.0.0-beta.4 will also require upstream changes and therefore incrementing some dependencies (e.g. stac-pydantic).

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).