### PR TITLE
Change geometry type in the items table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 * Refactor to remove hardcoded search request models. Request models are now dynamically created based on the enabled extensions.
   ([#213](https://github.com/stac-utils/stac-fastapi/pull/213))
+* Changed the geometry type in the Item model from Polygon to Geometry.
 
 ### Removed
 

--- a/stac_fastapi/sqlalchemy/alembic/versions/5909bd10f2e6_change_item_geometry_column_type.py
+++ b/stac_fastapi/sqlalchemy/alembic/versions/5909bd10f2e6_change_item_geometry_column_type.py
@@ -1,0 +1,34 @@
+"""change item geometry column type
+
+Revision ID: 5909bd10f2e6
+Revises: 821aa04011e8
+Create Date: 2021-11-23 10:14:17.974565
+
+"""
+from alembic import op
+
+from stac_fastapi.sqlalchemy.models.database import GeojsonGeometry
+
+# revision identifiers, used by Alembic.
+revision = "5909bd10f2e6"
+down_revision = "821aa04011e8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        schema="data",
+        table_name="items",
+        column_name="geometry",
+        type_=GeojsonGeometry("Geometry", srid=4326, spatial_index=True),
+    )
+
+
+def downgrade():
+    op.alter_column(
+        schema="data",
+        table_name="items",
+        column_name="geometry",
+        type_=GeojsonGeometry("Polygon", srid=4326, spatial_index=True),
+    )

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/models/database.py
@@ -64,7 +64,7 @@ class Item(BaseModel):  # type:ignore
     id = sa.Column(sa.VARCHAR(1024), nullable=False, primary_key=True)
     stac_version = sa.Column(sa.VARCHAR(300))
     stac_extensions = sa.Column(sa.ARRAY(sa.VARCHAR(300)), nullable=True)
-    geometry = sa.Column(GeojsonGeometry("POLYGON", srid=4326, spatial_index=True))
+    geometry = sa.Column(GeojsonGeometry("GEOMETRY", srid=4326, spatial_index=True))
     bbox = sa.Column(sa.ARRAY(sa.NUMERIC), nullable=False)
     properties = sa.Column(JSONB)
     assets = sa.Column(JSONB)

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -78,6 +78,21 @@ def test_app_search_response(load_test_data, app_client, postgres_transactions):
     assert resp_json.get("stac_extensions") is None
 
 
+def test_app_search_response_multipolygon(
+    load_test_data, app_client, postgres_transactions
+):
+    item = load_test_data("test_item_multipolygon.json")
+    postgres_transactions.create_item(item, request=MockStarletteRequest)
+
+    resp = app_client.get("/search", params={"collections": ["test-collection"]})
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    print(resp_json)
+
+    assert resp_json.get("type") == "FeatureCollection"
+    assert resp_json.get("features")[0]["geometry"]["type"] == "MultiPolygon"
+
+
 def test_app_context_extension(load_test_data, app_client, postgres_transactions):
     item = load_test_data("test_item.json")
     postgres_transactions.create_item(item, request=MockStarletteRequest)

--- a/stac_fastapi/sqlalchemy/tests/data/test_item_multipolygon.json
+++ b/stac_fastapi/sqlalchemy/tests/data/test_item_multipolygon.json
@@ -1,0 +1,454 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://landsat.usgs.gov/stac/landsat-extension/v1.1.1/schema.json",
+        "https://stac-extensions.github.io/view/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/storage/v1.0.0/schema.json"
+    ],
+    "id": "LE07_L2SP_092013_20211007_20211104_02_T2_SR",
+    "description": "Landsat Collection 2 Level-2 Surface Reflectance Product",
+    "bbox": [
+        175.93215804933186,
+        65.93036549677463,
+        -178.26673562596073,
+        68.07019813171695
+    ],
+    "geometry": {
+        "type": "MultiPolygon",
+        "coordinates": [
+            [
+                [
+                    [
+                        180.0,
+                        67.67956138964027
+                    ],
+                    [
+                        177.4008122028755,
+                        68.07019813171695
+                    ],
+                    [
+                        175.93215804933186,
+                        66.54096344674578
+                    ],
+                    [
+                        180.0,
+                        65.93733582837588
+                    ],
+                    [
+                        180.0,
+                        67.67956138964027
+                    ]
+                ]
+            ],
+            [
+                [
+                    [
+                        -180.0,
+                        65.93733582837588
+                    ],
+                    [
+                        -179.95302698810534,
+                        65.93036549677463
+                    ],
+                    [
+                        -178.3207049853914,
+                        67.36419976494292
+                    ],
+                    [
+                        -178.26673562596073,
+                        67.41036545485302
+                    ],
+                    [
+                        -178.27732165481333,
+                        67.42065687448587
+                    ],
+                    [
+                        -180.0,
+                        67.67956138964027
+                    ],
+                    [
+                        -180.0,
+                        65.93733582837588
+                    ]
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "datetime": "2021-10-07T22:29:48Z",
+        "eo:cloud_cover": 50.0,
+        "view:sun_azimuth": 158.59868248,
+        "view:sun_elevation": 15.64343101,
+        "platform": "LANDSAT_7",
+        "instruments": [
+            "ETM"
+        ],
+        "view:off_nadir": 0,
+        "landsat:cloud_cover_land": 0.0,
+        "landsat:wrs_type": "2",
+        "landsat:wrs_path": "092",
+        "landsat:wrs_row": "013",
+        "landsat:scene_id": "LE70920132021280ASN00",
+        "landsat:collection_category": "T2",
+        "landsat:collection_number": "02",
+        "landsat:correction": "L2SP",
+        "proj:epsg": 32660,
+        "proj:shape": [
+            8011,
+            8731
+        ],
+        "proj:transform": [
+            30.0,
+            0.0,
+            446085.0,
+            0.0,
+            -30.0,
+            7553415.0
+        ]
+    },
+    "assets": {
+        "thumbnail": {
+            "title": "Thumbnail image",
+            "type": "image/jpeg",
+            "roles": [
+                "thumbnail"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_thumb_small.jpeg",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_thumb_small.jpeg"
+                }
+            }
+        },
+        "reduced_resolution_browse": {
+            "title": "Reduced resolution browse image",
+            "type": "image/jpeg",
+            "roles": [
+                "overview"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_thumb_large.jpeg",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_thumb_large.jpeg"
+                }
+            }
+        },
+        "index": {
+            "title": "HTML index page",
+            "type": "text/html",
+            "roles": [
+                "metadata"
+            ],
+            "href": "https://landsatlook.usgs.gov/stac-browser/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2"
+        },
+        "blue": {
+            "title": "Blue Band (B1)",
+            "description": "Collection 2 Level-2 Blue Band (B1) Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "data"
+            ],
+            "eo:bands": [
+                {
+                    "name": "B1",
+                    "common_name": "blue",
+                    "gsd": 30,
+                    "center_wavelength": 0.48
+                }
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B1.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B1.TIF"
+                }
+            }
+        },
+        "green": {
+            "title": "Green Band (B2)",
+            "description": "Collection 2 Level-2 Green Band (B2) Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "data"
+            ],
+            "eo:bands": [
+                {
+                    "name": "B2",
+                    "common_name": "green",
+                    "gsd": 30,
+                    "center_wavelength": 0.56
+                }
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B2.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B2.TIF"
+                }
+            }
+        },
+        "red": {
+            "title": "Red Band (B3)",
+            "description": "Collection 2 Level-2 Red Band (B3) Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "data"
+            ],
+            "eo:bands": [
+                {
+                    "name": "B3",
+                    "common_name": "red",
+                    "gsd": 30,
+                    "center_wavelength": 0.65
+                }
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B3.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B3.TIF"
+                }
+            }
+        },
+        "nir08": {
+            "title": "Near Infrared Band 0.8 (B4)",
+            "description": "Collection 2 Level-2 Near Infrared Band 0.8 (B4) Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "data",
+                "reflectance"
+            ],
+            "eo:bands": [
+                {
+                    "name": "B4",
+                    "common_name": "nir08",
+                    "gsd": 30,
+                    "center_wavelength": 0.86
+                }
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B4.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B4.TIF"
+                }
+            }
+        },
+        "swir16": {
+            "title": "Short-wave Infrared Band 1.6 (B5)",
+            "description": "Collection 2 Level-2 Short-wave Infrared Band 1.6 (B6) Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "data",
+                "reflectance"
+            ],
+            "eo:bands": [
+                {
+                    "name": "B5",
+                    "common_name": "swir16",
+                    "gsd": 30,
+                    "center_wavelength": 1.6
+                }
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B5.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B5.TIF"
+                }
+            }
+        },
+        "swir22": {
+            "title": "Short-wave Infrared Band 2.2 (B7)",
+            "description": "Collection 2 Level-2 Short-wave Infrared Band 2.2 (B7) Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "data",
+                "reflectance"
+            ],
+            "eo:bands": [
+                {
+                    "name": "B7",
+                    "common_name": "swir22",
+                    "gsd": 30,
+                    "center_wavelength": 2.2
+                }
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B7.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_B7.TIF"
+                }
+            }
+        },
+        "atmos_opacity": {
+            "title": "Atmospheric Opacity Band",
+            "description": "Collection 2 Level-2 Atmospheric Opacity Band Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "data"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_ATMOS_OPACITY.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_ATMOS_OPACITY.TIF"
+                }
+            }
+        },
+        "cloud_qa": {
+            "title": "Cloud Quality Analysis Band",
+            "description": "Collection 2 Level-2 Cloud Quality Opacity Band Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "metadata",
+                "cloud",
+                "cloud-shadow",
+                "snow-ice",
+                "water-mask"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_CLOUD_QA.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_CLOUD_QA.TIF"
+                }
+            }
+        },
+        "ANG.txt": {
+            "title": "Angle Coefficients File",
+            "description": "Collection 2 Level-2 Angle Coefficients File (ANG)",
+            "type": "text/plain",
+            "roles": [
+                "metadata"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_ANG.txt",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_ANG.txt"
+                }
+            }
+        },
+        "MTL.txt": {
+            "title": "Product Metadata File",
+            "description": "Collection 2 Level-2 Product Metadata File (MTL)",
+            "type": "text/plain",
+            "roles": [
+                "metadata"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_MTL.txt",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_MTL.txt"
+                }
+            }
+        },
+        "MTL.xml": {
+            "title": "Product Metadata File (xml)",
+            "description": "Collection 2 Level-1 Product Metadata File (xml)",
+            "type": "application/xml",
+            "roles": [
+                "metadata"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_MTL.xml",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_MTL.xml"
+                }
+            }
+        },
+        "MTL.json": {
+            "title": "Product Metadata File (json)",
+            "description": "Collection 2 Level-2 Product Metadata File (json)",
+            "type": "application/json",
+            "roles": [
+                "metadata"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_MTL.json",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_MTL.json"
+                }
+            }
+        },
+        "qa_pixel": {
+            "title": "Pixel Quality Assessment Band",
+            "description": "Collection 2 Level-2 Pixel Quality Assessment Band Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "cloud",
+                "cloud-shadow",
+                "snow-ice",
+                "water-mask"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_QA_PIXEL.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_QA_PIXEL.TIF"
+                }
+            }
+        },
+        "qa_radsat": {
+            "title": "Radiometric Saturation Quality Assessment Band",
+            "description": "Collection 2 Level-2 Radiometric Saturation Quality Assessment Band Surface Reflectance",
+            "type": "image/vnd.stac.geotiff; cloud-optimized=true",
+            "roles": [
+                "saturation"
+            ],
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_QA_RADSAT.TIF",
+            "alternate": {
+                "s3": {
+                    "storage:platform": "AWS",
+                    "storage:requester_pays": true,
+                    "href": "s3://usgs-landsat/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_QA_RADSAT.TIF"
+                }
+            }
+        }
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://landsatlook.usgs.gov/data/catalog.json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/catalog.json"
+        },
+        {
+            "rel": "collection",
+            "href": "https://landsatlook.usgs.gov/data/collection02/landsat-c2l2-sr.json"
+        },
+        {
+            "rel": "self",
+            "href": "https://landsatlook.usgs.gov/data/collection02/level-2/standard/etm/2021/092/013/LE07_L2SP_092013_20211007_20211104_02_T2/LE07_L2SP_092013_20211007_20211104_02_T2_SR_stac.json"
+        }
+    ],
+    "collection": "test-collection"
+}


### PR DESCRIPTION
**Related Issue(s):** 
https://github.com/stac-utils/stac-fastapi/issues/284

**Description:**
This generalizes the geometry type of the geometry column in the Items table from `Polygon` to `Geometry`.

- As far as I understood, `Polygon` is a subset of `Geometry`, so this migration does not require a data migration step.
- I am not sure about the downgrade migration. It will only work if no other geometries are added to the DB after the change. So maybe there the alternative is simply be a `pass`, as the data in the table might not be backwards compatible. On the other hand, the way its proposed its the proper downgrade from a type perspective.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).