### PR TITLE
Use correct version of QueryExtension

### DIFF
--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py
@@ -3,7 +3,6 @@ from fastapi.responses import ORJSONResponse
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
-from stac_fastapi.extensions import QueryExtension
 from stac_fastapi.extensions.core import (
     FieldsExtension,
     SortExtension,
@@ -13,6 +12,7 @@ from stac_fastapi.extensions.core import (
 from stac_fastapi.pgstac.config import Settings
 from stac_fastapi.pgstac.core import CoreCrudClient
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
+from stac_fastapi.pgstac.extensions import QueryExtension
 from stac_fastapi.pgstac.transactions import TransactionsClient
 from stac_fastapi.pgstac.types.search import PgstacSearch
 


### PR DESCRIPTION
**Description:**
It looks like I missed an import irregularity in review of #203. This PR corrects that and puts ensures the pgstac container uses the correct implementation of `QueryExtension`


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).