### PR TITLE
Bump pgstac version to 0.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 * Refactor to remove hardcoded search request models. Request models are now dynamically created based on the enabled extensions.
   ([#213](https://github.com/stac-utils/stac-fastapi/pull/213))  
+* Upgrade pgstac from 0.3.4 to 0.4.0 ([#307](https://github.com/stac-utils/stac-fastapi/pull/307))
 
 ### Removed
 

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -25,7 +25,7 @@ extra_reqs = {
         "pytest-asyncio",
         "pre-commit",
         "requests",
-        "pypgstac==0.3.4",
+        "pypgstac==0.4.0",
         "httpx",
         "shapely",
     ],


### PR DESCRIPTION
**Related Issue(s):** #283


**Description:**
This PR upgrades the pgstac dependency to 0.4.0 which includes a number of bug fixes, performance improvements, and support for cql2.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).