### PR TITLE
Pgstac v0.4.0b

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
 
   database:
     container_name: stac-db
-    image: ghcr.io/stac-utils/pgstac:v0.3.4
+    image: ghcr.io/stac-utils/pgstac:v0.4.0
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -86,12 +86,12 @@ def create_get_request_model(
 
 
 def create_post_request_model(
-    extensions, base_model: BaseSearchPostRequest = BaseSearchGetRequest
+    extensions, base_model: BaseSearchPostRequest = BaseSearchPostRequest
 ):
     """Wrap create_request_model to create the POST request model."""
     return create_request_model(
         "SearchPostRequest",
-        base_model=BaseSearchPostRequest,
+        base_model=base_model,
         extensions=extensions,
         request_type="POST",
     )

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
@@ -1,11 +1,26 @@
 """Filter extension request models."""
 
+from enum import Enum
 from typing import Any, Dict, Optional
 
 import attr
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from stac_fastapi.types.search import APIRequest
+
+
+class FilterLang(str, Enum):
+    """Choices for filter-lang value in a POST request.
+
+    Based on https://github.com/radiantearth/stac-api-spec/tree/master/fragments/filter#queryables
+
+    Note the addition of cql2-json, which is used by the pgstac backend,
+    but is not included in the spec above.
+    """
+
+    cql_json = "cql-json"
+    cql2_json = "cql2-json"
+    cql_text = "cql-text"
 
 
 @attr.s
@@ -19,3 +34,5 @@ class FilterExtensionPostRequest(BaseModel):
     """Filter extension POST request model."""
 
     filter: Optional[Dict[str, Any]] = None
+    filter_crs: Optional[str] = Field(alias="filter-crs", default=None)
+    filter_lang: Optional[FilterLang] = Field(alias="filter-lang", default=None)

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -25,7 +25,7 @@ extra_reqs = {
         "pytest-asyncio",
         "pre-commit",
         "requests",
-        "pypgstac==0.3.4",
+        "pypgstac==0.4.0",
         "httpx",
         "shapely",
     ],

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -120,7 +120,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         pool = request.app.state.readpool
 
         # pool = kwargs["request"].app.state.readpool
-        req = search_request.json(exclude_none=True)
+        req = search_request.json(exclude_none=True, by_alias=True)
 
         try:
             async with pool.acquire() as conn:

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
@@ -1,6 +1,6 @@
 """stac_fastapi.types.search module."""
 
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import validator
 
@@ -14,6 +14,7 @@ class PgstacSearch(BaseSearchPostRequest):
     """
 
     datetime: Optional[str] = None
+    conf: Optional[Dict] = None
 
     @validator("datetime")
     def validate_datetime(cls, v):

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
@@ -20,3 +20,24 @@ class PgstacSearch(BaseSearchPostRequest):
     def validate_datetime(cls, v):
         """Pgstac does not require the base validator for datetime."""
         return v
+
+    @validator("filter_lang", pre=False, check_fields=False, always=True)
+    def validate_query_uses_cql(cls, v, values):
+        """If using query syntax, forces cql-json."""
+        retval = v
+        if values.get("query", None) is not None:
+            retval = "cql-json"
+        if values.get("collections", None) is not None:
+            retval = "cql-json"
+        if values.get("ids", None) is not None:
+            retval = "cql-json"
+        if values.get("datetime", None) is not None:
+            retval = "cql-json"
+        if values.get("bbox", None) is not None:
+            retval = "cql-json"
+        if v == "cql2-json" and retval == "cql-json":
+            raise ValueError(
+                "query, collections, ids, datetime, and bbox"
+                "parameters are not available in cql2-json"
+            )
+        return retval

--- a/stac_fastapi/pgstac/tests/conftest.py
+++ b/stac_fastapi/pgstac/tests/conftest.py
@@ -45,7 +45,10 @@ async def pg():
     try:
         await conn.execute("CREATE DATABASE pgstactestdb;")
         await conn.execute(
-            "ALTER DATABASE pgstactestdb SET search_path to pgstac, public;"
+            """
+            ALTER DATABASE pgstactestdb SET search_path to pgstac, public;
+            ALTER DATABASE pgstactestdb SET log_statement to 'all';
+            """
         )
     except asyncpg.exceptions.DuplicateDatabaseError:
         await conn.execute("DROP DATABASE pgstactestdb;")
@@ -78,7 +81,14 @@ async def pgstac(pg):
     yield
     print("Truncating Data")
     conn = await asyncpg.connect(dsn=settings.testing_connection_string)
-    await conn.execute("TRUNCATE items CASCADE; TRUNCATE collections CASCADE;")
+    await conn.execute(
+        """
+        TRUNCATE pgstac.items CASCADE;
+        TRUNCATE pgstac.collections CASCADE;
+        TRUNCATE pgstac.searches CASCADE;
+        TRUNCATE pgstac.search_wheres CASCADE;
+        """
+    )
     await conn.close()
 
 

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -73,7 +73,7 @@ class BaseSearchGetRequest(APIRequest):
     ids: Optional[str] = attr.ib(default=None, converter=str2list)
     bbox: Optional[str] = attr.ib(default=None, converter=str2list)
     intersects: Optional[str] = attr.ib(default=None, converter=str2list)
-    datetime: Optional[Union[str]] = attr.ib(default=None)
+    datetime: Optional[Union[str, Dict]] = attr.ib(default=None)
     limit: Optional[int] = attr.ib(default=10)
 
 


### PR DESCRIPTION
**Related Issue(s):** #283
This PR should supersede #307 and #305 


**Description:**
 - Upgrades pgstac backend to 0.4.0
 - Enables cql2-json
   - pgstac enables as default (settable in pgstac configuration)
   - can be set per query using "filter-lang" parameter ("cql-json" or "cql2-json")
   - stac-fastapi-pgstac will automatically use cql-json if query, bbox, ids, collections, or datetime parameter are set for backwards compatibility


**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).