### PR TITLE
Use provided GET search basemodel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
 ### Changed
 
 * Refactor to remove hardcoded search request models. Request models are now dynamically created based on the enabled extensions.
-  ([#213](https://github.com/stac-utils/stac-fastapi/pull/213))  
+  ([#213](https://github.com/stac-utils/stac-fastapi/pull/213))
 
 ### Removed
 
@@ -25,11 +25,13 @@
 
 ### Added
 
+* Add CQL2 support ([#308](https://github.com/stac-utils/stac-fastapi/pull/308))
 * Add ability to override ItemCollectionUri and SearchGetRequest models ([#271](https://github.com/stac-utils/stac-fastapi/pull/271))
 * Added `collections` attribute to list of default fields to include, so that we satisfy the STAC API spec, which requires a `collections` attribute to be output when an item is part of a collection ([#276](https://github.com/stac-utils/stac-fastapi/pull/276))
 
 ### Changed
 
+* Update pgstac to 0.4.0 ([#308](https://github.com/stac-utils/stac-fastapi/pull/308))
 * Update get_item in sqlalchemy backend to allow for querying for items with same ids but in different collections. ([#275](https://github.com/stac-utils/stac-fastapi/pull/275))
 
 ## [2.1.1]

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -79,7 +79,7 @@ def create_get_request_model(
     """Wrap create_request_model to create the GET request model."""
     return create_request_model(
         "SearchGetRequest",
-        base_model=BaseSearchGetRequest,
+        base_model=base_model,
         extensions=extensions,
         request_type="GET",
     )


### PR DESCRIPTION
**Description:**
This PR corrects a couple oversights:
1. changelog entries for #308 have been added
2. the base_model is now used when constructing an extended search model


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).