### PR TITLE
Change type of example collection to 'Collection'

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 * Refactor to remove hardcoded search request models. Request models are now dynamically created based on the enabled extensions.
   ([#213](https://github.com/stac-utils/stac-fastapi/pull/213))
+* Change example data to use correct `type` for the example Joplin collection ([#314](https://github.com/stac-utils/stac-fastapi/pull/314))
 
 ### Removed
 

--- a/stac_fastapi/testdata/joplin/collection.json
+++ b/stac_fastapi/testdata/joplin/collection.json
@@ -10,7 +10,7 @@
             "title": "public domain"
         }
     ],
-    "type": "collection",
+    "type": "Collection",
     "extent": {
         "spatial": {
             "bbox": [


### PR DESCRIPTION
**Related Issue(s):** 
https://github.com/stac-utils/pystac-client/issues/129

**Description:**
The [STAC Collections Spec](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md) states that collections must have a `type` of `'Collection'`, but the example data had a collection with a type of `'collection'` which caused various other tools to fail when processing this collection (see https://github.com/stac-utils/pystac-client/issues/129). This PR fixes the example joplin collection to use the Title Case version.


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).