### PR TITLE
Upgrade to pgstac 0.4.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * Refactor to remove hardcoded search request models. Request models are now dynamically created based on the enabled extensions.
   ([#213](https://github.com/stac-utils/stac-fastapi/pull/213))
 * Changed the geometry type in the Item model from Polygon to Geometry.
+* Upgrade pgstac backend to use version 0.4.2 ([#321](https://github.com/stac-utils/stac-fastapi/pull/321))
 
 ### Removed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
 
   database:
     container_name: stac-db
-    image: ghcr.io/stac-utils/pgstac:v0.4.0
+    image: ghcr.io/stac-utils/pgstac:v0.4.2
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -25,7 +25,7 @@ extra_reqs = {
         "pytest-asyncio",
         "pre-commit",
         "requests",
-        "pypgstac==0.4.0",
+        "pypgstac==0.4.2",
         "httpx",
         "shapely",
     ],


### PR DESCRIPTION
**Description:**
Upgrades pgstac backend to 0.4.2.

See: https://github.com/stac-utils/pgstac/releases/tag/v0.4.2

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).