### PR TITLE
Throw 400s for invalid datetime formats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,8 +24,10 @@
 * The minimum `limit` value for searches is now 1 ([#296](https://github.com/stac-utils/stac-fastapi/pull/296))
 * Links stored with Collections and Items (e.g. license links) are now returned with those STAC objects ([#282](https://github.com/stac-utils/stac-fastapi/pull/282))
 * Content-type response headers for the /api endpoint now reflect those expected in the STAC api spec ([#287](https://github.com/stac-utils/stac-fastapi/pull/287))
-* Changed type options for datetime in BaseSearchGetRequest ([#315](https://github.com/stac-utils/stac-fastapi/pull/318))
-* Expanded on tests to ensure properly testing get and post searches ([#315](https://github.com/stac-utils/stac-fastapi/pull/318))
+* Changed type options for datetime in BaseSearchGetRequest ([#318](https://github.com/stac-utils/stac-fastapi/pull/318))
+* Expanded on tests to ensure properly testing get and post searches ([#318](https://github.com/stac-utils/stac-fastapi/pull/318))
+* Ensure invalid datetimes result in 400s ([#323](https://github.com/stac-utils/stac-fastapi/pull/323))
+
 
 ## [2.2.0]
 

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -274,6 +274,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             "token": token,
             "query": orjson.loads(query) if query else query,
         }
+
         if datetime:
             base_args["datetime"] = datetime
 

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/types/search.py
@@ -13,13 +13,7 @@ class PgstacSearch(BaseSearchPostRequest):
     Overrides the validation for datetime from the base request model.
     """
 
-    datetime: Optional[str] = None
     conf: Optional[Dict] = None
-
-    @validator("datetime")
-    def validate_datetime(cls, v):
-        """Pgstac does not require the base validator for datetime."""
-        return v
 
     @validator("filter_lang", pre=False, check_fields=False, always=True)
     def validate_query_uses_cql(cls, v, values):

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -1232,3 +1232,24 @@ async def test_item_search_get_filter_extension_cql2(
         resp_json["features"][0]["properties"]["proj:epsg"]
         == test_item["properties"]["proj:epsg"]
     )
+
+
+@pytest.mark.asyncio
+async def test_search_datetime_validation_errors(app_client):
+    bad_datetimes = [
+        "37-01-01T12:00:27.87Z",
+        "1985-13-12T23:20:50.52Z",
+        "1985-12-32T23:20:50.52Z",
+        "1985-12-01T25:20:50.52Z",
+        "1985-12-01T00:60:50.52Z",
+        "1985-12-01T00:06:61.52Z",
+        "1990-12-31T23:59:61Z",
+        "1986-04-12T23:20:50.52Z/1985-04-12T23:20:50.52Z",
+    ]
+    for dt in bad_datetimes:
+        body = {"query": {"datetime": dt}}
+        resp = await app_client.post("/search", json=body)
+        assert resp.status_code == 400
+
+        resp = await app_client.get("/search?datetime={}".format(dt))
+        assert resp.status_code == 400

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -206,8 +206,10 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
             "token": token,
             "query": json.loads(query) if query else query,
         }
+
         if datetime:
             base_args["datetime"] = datetime
+
         if sortby:
             # https://github.com/radiantearth/stac-spec/tree/master/api-spec/extensions/sort#http-get-or-post-form
             sort_param = []

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -926,3 +926,23 @@ def test_conformance_classes_configurable():
     os.environ["WRITER_CONN_STRING"] = "testing"
     client = CoreCrudClient(base_conformance_classes=["this is a test"])
     assert client.conformance_classes()[0] == "this is a test"
+
+
+def test_search_datetime_validation_errors(app_client):
+    bad_datetimes = [
+        "37-01-01T12:00:27.87Z",
+        "1985-13-12T23:20:50.52Z",
+        "1985-12-32T23:20:50.52Z",
+        "1985-12-01T25:20:50.52Z",
+        "1985-12-01T00:60:50.52Z",
+        "1985-12-01T00:06:61.52Z",
+        "1990-12-31T23:59:61Z",
+        "1986-04-12T23:20:50.52Z/1985-04-12T23:20:50.52Z",
+    ]
+    for dt in bad_datetimes:
+        body = {"query": {"datetime": dt}}
+        resp = app_client.post("/search", json=body)
+        assert resp.status_code == 400
+
+        resp = app_client.get("/search?datetime={}".format(dt))
+        assert resp.status_code == 400


### PR DESCRIPTION
**Related Issue(s):** #258


**Description:**
STAC-spec verification tools have revealed that 400s aren't being thrown in case of certain non-complying datetime formats. This PR ensures that pydantic checks *always* occur prior to injecting arguments into database queries. Validation errors in pydantic are always 400s but errors from within e.g. postgres can result in 500s (in violation of spec)


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).