### PR TITLE
update fastapi requirements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+* update FastAPI requirement to allow version >=0.73 ([#337](https://github.com/stac-utils/stac-fastapi/pull/337))
+
 ### Removed
 
 ### Fixed

--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -6,9 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    # We need to pin fastapi for the openapi schema
-    # See https://github.com/stac-utils/stac-fastapi/issues/242
-    "fastapi==0.67.*",
+    "fastapi>=0.67,!=0.68.0,!=0.68.1,!=0.68.2,!=0.69.0,!=0.70.0,!=0.70.1,!=0.71.0,!=0.72.0",
     "attrs",
     "pydantic[dotenv]",
     "stac_pydantic==2.0.*",

--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "fastapi>=0.67,!=0.68.0,!=0.68.1,!=0.68.2,!=0.69.0,!=0.70.0,!=0.70.1,!=0.71.0,!=0.72.0",
+    "fastapi>=0.73.0",
     "attrs",
     "pydantic[dotenv]",
     "stac_pydantic==2.0.*",


### PR DESCRIPTION
**Related Issue(s):** #

- https://github.com/stac-utils/stac-fastapi/issues/242
- https://github.com/tiangolo/fastapi/releases/tag/0.73.0

**Description:**

This PR update the FastAPI version requirement to allow >=0.73 which resolves the issue with Tuple in OpenAPI.


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).