### PR TITLE
bump uvicorn version to resolve websockets security vulnerability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
 ### Removed
 
 ### Fixed
-
+* Bumped uvicorn version to 0.17 (from >=0.12, <=0.14) to resolve security vulnerability related to websockets dependency version ([#343](https://github.com/stac-utils/stac-fastapi/pull/343))
 
 ## [2.3.0]
 

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -30,7 +30,7 @@ extra_reqs = {
         "shapely",
     ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],
-    "server": ["uvicorn[standard]==0.17.*"],
+    "server": ["uvicorn[standard]==0.17.0"],
     "awslambda": ["mangum"],
 }
 

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -30,7 +30,7 @@ extra_reqs = {
         "shapely",
     ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],
-    "server": ["uvicorn[standard]>=0.12.0,<0.14.0"],
+    "server": ["uvicorn[standard]==0.17.*"],
     "awslambda": ["mangum"],
 }
 

--- a/stac_fastapi/sqlalchemy/setup.py
+++ b/stac_fastapi/sqlalchemy/setup.py
@@ -30,7 +30,7 @@ extra_reqs = {
         "requests",
     ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],
-    "server": ["uvicorn[standard]==0.17.*"],
+    "server": ["uvicorn[standard]==0.17.0"],
 }
 
 

--- a/stac_fastapi/sqlalchemy/setup.py
+++ b/stac_fastapi/sqlalchemy/setup.py
@@ -30,7 +30,7 @@ extra_reqs = {
         "requests",
     ],
     "docs": ["mkdocs", "mkdocs-material", "pdocs"],
-    "server": ["uvicorn[standard]>=0.12.0,<0.14.0"],
+    "server": ["uvicorn[standard]==0.17.*"],
 }
 
 


### PR DESCRIPTION
**Related Issue(s):** #342 


**Description:**
Bumped uvicorn version to 0.17 (from >=0.12, <=0.14) to resolve security vulnerability related to websockets dependency version

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/master/CHANGES.md).