### PR TITLE
fix sqlalchemy bulk item insertion

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,14 +10,16 @@
 
 ### Changed
 
-* update FastAPI requirement to allow version >=0.73 ([#337](https://github.com/stac-utils/stac-fastapi/pull/337))
+* Update FastAPI requirement to allow version >=0.73 ([#337](https://github.com/stac-utils/stac-fastapi/pull/337))
+* Bulk Transactions object Items iterator now returns the Item objects rather than the string IDs of the Item objects
+  ([#355](https://github.com/stac-utils/stac-fastapi/issues/355))
 
 ### Removed
 
 ### Fixed
 * Bumped uvicorn version to 0.17 (from >=0.12, <=0.14) to resolve security vulnerability related to websockets dependency version ([#343](https://github.com/stac-utils/stac-fastapi/pull/343))
 * `AttributeError` and/or missing properties when requesting the complete `properties`-field in searches. Added test. ([#339](https://github.com/stac-utils/stac-fastapi/pull/339))
-
+* SQLAlchemy backend bulk item insert now works ([#356]https://github.com/stac-utils/stac-fastapi/issues/356))
 
 ## [2.3.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Hot-reloading docs:
 $ mkdocs serve
 ```
 
-To manually deploy docs (note you should never need to do this because Github
+To manually deploy docs (note you should never need to do this because GitHub
 Actions deploys automatically for new commits.):
 
 ```bash

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -12,13 +12,13 @@ from stac_fastapi.types.extension import ApiExtension
 
 
 class Items(BaseModel):
-    """A list of STAC items."""
+    """A group of STAC Item objects, in the form of a dictionary from Item.id -> Item."""
 
     items: Dict[str, Any]
 
     def __iter__(self):
-        """Return an iterable of STAC items."""
-        return iter(self.items)
+        """Return an iterable of STAC Item objects."""
+        return iter(self.items.values())
 
 
 @attr.s  # type: ignore
@@ -56,7 +56,16 @@ class BulkTransactionExtension(ApiExtension):
     """Bulk Transaction Extension.
 
     Bulk Transaction extension adds the `POST /collections/{collection_id}/bulk_items` endpoint to the application
-    for efficient bulk insertion of items.
+    for efficient bulk insertion of items. The input to this is an object with an attribute  "items", that has a value
+    that is an object with a group of attributes that are the ids of each Item, and the value is the Item entity.
+
+        {
+        "items": {
+            "id1": { "type": "Feature", ... },
+            "id2": { "type": "Feature", ... },
+            "id3": { "type": "Feature", ... }
+        }
+
     """
 
     client: BaseBulkTransactionsClient = attr.ib()


### PR DESCRIPTION
**Related Issue(s):** 

- #355
- #356
- #196

**Description:**

SQLAlchemy bulk item insertion failed because the `Items` iterator returns the keys for the dict it contains, rather than the Item objects themselves as it's docstring says it should (and that it would make sense to).

This fixes that problem, and documents what the format of the JSON object that is the input to the bulk insert endpoint is.

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
