### PR TITLE
align error response with api spec

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Update error response payloads to match the API spec. ([#361](https://github.com/stac-utils/stac-fastapi/pull/361))
+
 ### Added
 
 * Add hook to allow adding dependencies to routes. ([#295](https://github.com/stac-utils/stac-fastapi/pull/295))

--- a/stac_fastapi/api/stac_fastapi/api/errors.py
+++ b/stac_fastapi/api/stac_fastapi/api/errors.py
@@ -39,9 +39,9 @@ class ErrorResponse(TypedDict):
         code: A code representing the error, semantics are up to implementor.
         description: A description of the error.
     """
+
     code: str
     description: str
-
 
 
 def exception_handler_factory(status_code: int) -> Callable:
@@ -58,12 +58,10 @@ def exception_handler_factory(status_code: int) -> Callable:
         """I handle exceptions!!."""
         logger.error(exc, exc_info=True)
         return JSONResponse(
-            content=ErrorResponse(
-                code=exc.__class__.__name__,
-                description=str(exc)
-            ),
-            status_code=status_code
+            content=ErrorResponse(code=exc.__class__.__name__, description=str(exc)),
+            status_code=status_code,
         )
+
     return handler
 
 
@@ -88,11 +86,8 @@ def add_exception_handlers(
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
         return JSONResponse(
-            content=ErrorResponse(
-                code=exc.__class__.__name__,
-                description=str(exc)
-            ),
-            status_code=status.HTTP_400_BAD_REQUEST
+            content=ErrorResponse(code=exc.__class__.__name__, description=str(exc)),
+            status_code=status.HTTP_400_BAD_REQUEST,
         )
 
     app.add_exception_handler(

--- a/stac_fastapi/api/stac_fastapi/api/errors.py
+++ b/stac_fastapi/api/stac_fastapi/api/errors.py
@@ -1,7 +1,7 @@
 """Error handling."""
 
 import logging
-from typing import Callable, Dict, Type
+from typing import Callable, Dict, Type, TypedDict
 
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
@@ -30,6 +30,20 @@ DEFAULT_STATUS_CODES = {
 }
 
 
+class ErrorResponse(TypedDict):
+    """A JSON error response returned by the API.
+
+    The STAC API spec expects that `code` and `description` are both present in the payload.
+
+    Attributes:
+        code: A code representing the error, semantics are up to implementor.
+        description: A description of the error.
+    """
+    code: str
+    description: str
+
+
+
 def exception_handler_factory(status_code: int) -> Callable:
     """Create a FastAPI exception handler for a particular status code.
 
@@ -43,8 +57,13 @@ def exception_handler_factory(status_code: int) -> Callable:
     def handler(request: Request, exc: Exception):
         """I handle exceptions!!."""
         logger.error(exc, exc_info=True)
-        return JSONResponse(content={"detail": str(exc)}, status_code=status_code)
-
+        return JSONResponse(
+            content=ErrorResponse(
+                code=exc.__class__.__name__,
+                description=str(exc)
+            ),
+            status_code=status_code
+        )
     return handler
 
 
@@ -69,8 +88,11 @@ def add_exception_handlers(
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
         return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            content={"detail": exc.errors()},
+            content=ErrorResponse(
+                code=exc.__class__.__name__,
+                description=str(exc)
+            ),
+            status_code=status.HTTP_400_BAD_REQUEST
         )
 
     app.add_exception_handler(


### PR DESCRIPTION
**Related Issue(s):** 

- #360 

**Description:**
Aligns responses from exception handlers with what is expected by the spec.  After running `docker-compose up` and sending a `/collections/abc` request, the application will now return:
```json
{
    "code": "NotFoundError",
    "description": "Collection abc not found"
}
```



**PR Checklist:**
- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
