### PR TITLE
POST a feature collection to the items route

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 ### Added
 
 * Add hook to allow adding dependencies to routes. ([#295](https://github.com/stac-utils/stac-fastapi/pull/295))
+* Ability to POST an ItemCollection to the collections/{collectionId}/items route. ([#367](https://github.com/stac-utils/stac-fastapi/pull/367))
 
 ### Changed
 

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
@@ -42,7 +42,7 @@ class TransactionsClient(BaseTransactionsClient):
             bulk_client = BulkTransactionsClient(session=self.session)
             bulk_client.bulk_item_insert(items=model["features"])
             return None
-            
+
         # Otherwise a single item has been posted
         data = self.item_serializer.stac_to_db(model)
         with self.session.writer.context_session() as session:

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
@@ -40,10 +40,9 @@ class TransactionsClient(BaseTransactionsClient):
         # If a feature collection is posted
         if model["type"] == "FeatureCollection":
             bulk_client = BulkTransactionsClient(session=self.session)
-            return_msg = bulk_client.bulk_item_insert(items=model["features"])
-
-            return return_msg
-
+            bulk_client.bulk_item_insert(items=model["features"])
+            return None
+            
         # Otherwise a single item has been posted
         data = self.item_serializer.stac_to_db(model)
         with self.session.writer.context_session() as session:

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
@@ -39,7 +39,7 @@ class TransactionsClient(BaseTransactionsClient):
 
         # If a feature collection is posted
         if model["type"] == "FeatureCollection":
-            bulk_client = BulkTransactionsClient()
+            bulk_client = BulkTransactionsClient(session=self.session)
             return_msg = bulk_client.bulk_item_insert(items=model["features"])
 
             return return_msg

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
@@ -36,7 +36,7 @@ class TransactionsClient(BaseTransactionsClient):
 
     def create_item(
         self, model: Union[stac_types.Item, stac_types.ItemCollection], **kwargs
-    ) -> Optional[Union[stac_types.Item, Response]]:
+    ) -> Optional[stac_types.Item]:
         """Create item."""
         base_url = str(kwargs["request"].base_url)
 

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/transactions.py
@@ -36,6 +36,15 @@ class TransactionsClient(BaseTransactionsClient):
     def create_item(self, model: stac_types.Item, **kwargs) -> stac_types.Item:
         """Create item."""
         base_url = str(kwargs["request"].base_url)
+
+        # If a feature collection is posted
+        if model["type"] == "FeatureCollection":
+            bulk_client = BulkTransactionsClient()
+            return_msg = bulk_client.bulk_item_insert(items=model["features"])
+
+            return return_msg
+
+        # Otherwise a single item has been posted
         data = self.item_serializer.stac_to_db(model)
         with self.session.writer.context_session() as session:
             session.add(data)

--- a/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
+++ b/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
@@ -330,7 +330,7 @@ def test_feature_collection_insert(
     feature_collection = {"type": "FeatureCollection", "features": features}
 
     postgres_transactions.create_item(feature_collection, request=MockStarletteRequest)
-    # time.sleep(3)
+    
     fc = postgres_core.item_collection(coll["id"], request=MockStarletteRequest)
     assert len(fc["features"]) >= 10
 

--- a/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
+++ b/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
@@ -310,6 +310,7 @@ def test_bulk_item_insert_chunked(
             item["id"], item["collection"], request=MockStarletteRequest
         )
 
+
 def test_feature_collection_insert(
     postgres_core: CoreCrudClient,
     postgres_transactions: TransactionsClient,
@@ -337,6 +338,7 @@ def test_feature_collection_insert(
         postgres_transactions.delete_item(
             item["id"], item["collection"], request=MockStarletteRequest
         )
+
 
 def test_landing_page_no_collection_title(
     postgres_core: CoreCrudClient,

--- a/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
+++ b/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
@@ -310,6 +310,33 @@ def test_bulk_item_insert_chunked(
             item["id"], item["collection"], request=MockStarletteRequest
         )
 
+def test_feature_collection_insert(
+    postgres_core: CoreCrudClient,
+    postgres_transactions: TransactionsClient,
+    load_test_data: Callable,
+):
+    coll = load_test_data("test_collection.json")
+    postgres_transactions.create_collection(coll, request=MockStarletteRequest)
+
+    item = load_test_data("test_item.json")
+
+    features = []
+    for _ in range(10):
+        _item = deepcopy(item)
+        _item["id"] = str(uuid.uuid4())
+        features.append(_item)
+
+    feature_collection = {"type": "FeatureCollection", "features": features}
+
+    postgres_transactions.create_item(feature_collection, request=MockStarletteRequest)
+    # time.sleep(3)
+    fc = postgres_core.item_collection(coll["id"], request=MockStarletteRequest)
+    assert len(fc["features"]) >= 10
+
+    for item in features:
+        postgres_transactions.delete_item(
+            item["id"], item["collection"], request=MockStarletteRequest
+        )
 
 def test_landing_page_no_collection_title(
     postgres_core: CoreCrudClient,

--- a/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
+++ b/stac_fastapi/sqlalchemy/tests/clients/test_postgres.py
@@ -330,7 +330,7 @@ def test_feature_collection_insert(
     feature_collection = {"type": "FeatureCollection", "features": features}
 
     postgres_transactions.create_item(feature_collection, request=MockStarletteRequest)
-    
+
     fc = postgres_core.item_collection(coll["id"], request=MockStarletteRequest)
     assert len(fc["features"]) >= 10
 


### PR DESCRIPTION
**Related Issue(s):** 

- #362 

**Description:**
Allow for the items route to accept a feature collection as well as a single item.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
