### PR TITLE
update all conformance classes to 1.0.0-rc.1 and fix several extension cc URIs with extra forward-slash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,24 +2,27 @@
 
 ## Unreleased
 
-* Update error response payloads to match the API spec. ([#361](https://github.com/stac-utils/stac-fastapi/pull/361))
-
 ### Added
 
 * Add hook to allow adding dependencies to routes. ([#295](https://github.com/stac-utils/stac-fastapi/pull/295))
+* Add STAC API - Collections conformance class. ([383](https://github.com/stac-utils/stac-fastapi/pull/383))
 
 ### Changed
 
 * update FastAPI requirement to allow version >=0.73 ([#337](https://github.com/stac-utils/stac-fastapi/pull/337))
 * Bump version of PGStac to 0.4.5  ([#346](https://github.com/stac-utils/stac-fastapi/pull/346))
 * Add support for PGStac Backend to use PyGeofilter to convert Get Request with cql2-text into cql2-json to send to PGStac backend ([#346](https://github.com/stac-utils/stac-fastapi/pull/346))
+* Updated all conformance classes to 1.0.0-rc.1. ([383](https://github.com/stac-utils/stac-fastapi/pull/383))
 
 ### Removed
 
 ### Fixed
+
 * Bumped uvicorn version to 0.17 (from >=0.12, <=0.14) to resolve security vulnerability related to websockets dependency version ([#343](https://github.com/stac-utils/stac-fastapi/pull/343))
 * `AttributeError` and/or missing properties when requesting the complete `properties`-field in searches. Added test. ([#339](https://github.com/stac-utils/stac-fastapi/pull/339))
 * Fixes issues (and adds tests) for issues caused by regression in pgstac ([#345](https://github.com/stac-utils/stac-fastapi/issues/345)
+* Update error response payloads to match the API spec. ([#361](https://github.com/stac-utils/stac-fastapi/pull/361))
+* Fixed stray `/` before the `#` in several extension conformance class strings ([383](https://github.com/stac-utils/stac-fastapi/pull/383))
 
 
 ## [2.3.0]

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
@@ -18,10 +18,10 @@ class ContextExtension(ApiExtension):
     """
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search/#context"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.1/item-search#context"]
     )
     schema_href: Optional[str] = attr.ib(
-        default="https://raw.githubusercontent.com/radiantearth/stac-api-spec/v1.0.0-beta.4/fragments/context/json-schema/schema.json"
+        default="https://raw.githubusercontent.com/radiantearth/stac-api-spec/v1.0.0-rc.1/fragments/context/json-schema/schema.json"
     )
 
     def register(self, app: FastAPI) -> None:

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
@@ -30,7 +30,7 @@ class FieldsExtension(ApiExtension):
     POST = FieldsExtensionPostRequest
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search/#fields"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.1/item-search#fields"]
     )
     default_includes: Set[str] = attr.ib(
         factory=lambda: {

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -18,25 +18,25 @@ from .request import FilterExtensionGetRequest, FilterExtensionPostRequest
 class FilterConformanceClasses(str, Enum):
     """Conformance classes for the Filter extension.
 
-    See https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-beta.4/fragments/filter
+    See https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1/fragments/filter
     """
 
-    FILTER = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:filter"
+    FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:filter"
     ITEM_SEARCH_FILTER = (
-        "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:item-search-filter"
+        "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:item-search-filter"
     )
-    CQL_TEXT = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:cql-text"
-    CQL_JSON = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:cql-json"
-    BASIC_CQL = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:basic-cql"
-    BASIC_SPATIAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:basic-spatial-operators"
-    BASIC_TEMPORAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:basic-temporal-operators"
-    ENHANCED_COMPARISON_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:enhanced-comparison-operators"
-    ENHANCED_SPATIAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:enhanced-spatial-operators"
-    ENHANCED_TEMPORAL_OPERATORS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:enhanced-temporal-operators"
-    FUNCTIONS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:functions"
-    ARITHMETIC = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:arithmetic"
-    ARRAYS = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:arrays"
-    QUERYABLE_SECOND_OPERAND = "https://api.stacspec.org/v1.0.0-beta.4/item-search#filter:queryable-second-operand"
+    CQL_TEXT = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-text"
+    CQL_JSON = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-json"
+    BASIC_CQL = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:basic-cql"
+    BASIC_SPATIAL_OPERATORS = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:basic-spatial-operators"
+    BASIC_TEMPORAL_OPERATORS = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:basic-temporal-operators"
+    ENHANCED_COMPARISON_OPERATORS = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:enhanced-comparison-operators"
+    ENHANCED_SPATIAL_OPERATORS = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:enhanced-spatial-operators"
+    ENHANCED_TEMPORAL_OPERATORS = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:enhanced-temporal-operators"
+    FUNCTIONS = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:functions"
+    ARITHMETIC = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:arithmetic"
+    ARRAYS = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:arrays"
+    QUERYABLE_SECOND_OPERAND = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:queryable-second-operand"
 
 
 @attr.s

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/query/query.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/query/query.py
@@ -23,7 +23,7 @@ class QueryExtension(ApiExtension):
     POST = QueryExtensionPostRequest
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search/#query"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.1/item-search#query"]
     )
     schema_href: Optional[str] = attr.ib(default=None)
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/sort/sort.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/sort/sort.py
@@ -23,7 +23,7 @@ class SortExtension(ApiExtension):
     POST = SortExtensionPostRequest
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-beta.4/item-search/#sort"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.1/item-search#sort"]
     )
     schema_href: Optional[str] = attr.ib(default=None)
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -38,7 +38,7 @@ class TransactionExtension(ApiExtension):
     settings: ApiSettings = attr.ib()
     conformance_classes: List[str] = attr.ib(
         factory=lambda: [
-            "https://api.stacspec.org/v1.0.0-beta.4/ogcapi-features/extensions/transaction/",
+            "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features/extensions/transaction",
             "http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/simpletx",
         ]
     )

--- a/stac_fastapi/types/stac_fastapi/types/conformance.py
+++ b/stac_fastapi/types/stac_fastapi/types/conformance.py
@@ -7,6 +7,7 @@ class STACConformanceClasses(str, Enum):
 
     CORE = "https://api.stacspec.org/v1.0.0-rc.1/core"
     OGC_API_FEAT = "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features"
+    COLLECTIONS = "https://api.stacspec.org/v1.0.0-rc.1/collections"
     ITEM_SEARCH = "https://api.stacspec.org/v1.0.0-rc.1/item-search"
 
 
@@ -21,6 +22,7 @@ class OAFConformanceClasses(str, Enum):
 BASE_CONFORMANCE_CLASSES = [
     STACConformanceClasses.CORE,
     STACConformanceClasses.OGC_API_FEAT,
+    STACConformanceClasses.COLLECTIONS,
     STACConformanceClasses.ITEM_SEARCH,
     OAFConformanceClasses.CORE,
     OAFConformanceClasses.OPEN_API,

--- a/stac_fastapi/types/stac_fastapi/types/conformance.py
+++ b/stac_fastapi/types/stac_fastapi/types/conformance.py
@@ -5,9 +5,9 @@ from enum import Enum
 class STACConformanceClasses(str, Enum):
     """Conformance classes for the STAC API spec."""
 
-    CORE = "https://api.stacspec.org/v1.0.0-beta.4/core"
-    OGC_API_FEAT = "https://api.stacspec.org/v1.0.0-beta.4/ogcapi-features"
-    ITEM_SEARCH = "https://api.stacspec.org/v1.0.0-beta.4/item-search"
+    CORE = "https://api.stacspec.org/v1.0.0-rc.1/core"
+    OGC_API_FEAT = "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features"
+    ITEM_SEARCH = "https://api.stacspec.org/v1.0.0-rc.1/item-search"
 
 
 class OAFConformanceClasses(str, Enum):


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-fastapi/issues/371
- https://github.com/stac-utils/stac-fastapi/issues/366

**Description:**

- update all the conformance classes to be rc.1
- fix the few extension conformance classes that had an extra `/` before the `#`
- add the collections conformance class 

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
