### PR TITLE
change transactions clients method signatures to match use, allow result of None to return 204

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.routing import BaseRoute, Match
+from starlette.status import HTTP_204_NO_CONTENT
 
 from stac_fastapi.api.models import APIRequest
 
@@ -14,8 +15,10 @@ from stac_fastapi.api.models import APIRequest
 def _wrap_response(resp: Any, response_class: Type[Response]) -> Response:
     if isinstance(resp, Response):
         return resp
-    else:
+    elif resp is not None:
         return response_class(resp)
+    else:  # None is returned as 204 No Content
+        return Response(status_code=HTTP_204_NO_CONTENT)
 
 
 def create_async_endpoint(

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -77,7 +77,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
         Called with `GET /collections/{collection_id}`.
 
         Args:
-            id: Id of the collection.
+            collection_id: ID of the collection.
 
         Returns:
             Collection.
@@ -212,7 +212,8 @@ class CoreCrudClient(AsyncBaseCoreClient):
         Called with `GET /collections/{collection_id}/items/{item_id}`.
 
         Args:
-            id: Id of the item.
+            item_id: ID of the item.
+            collection_id: ID of the collection the item is in.
 
         Returns:
             Item.

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/transactions.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/transactions.py
@@ -1,9 +1,10 @@
 """transactions extension client."""
 
 import logging
-from typing import Dict
+from typing import Optional, Union
 
 import attr
+from starlette.responses import JSONResponse, Response
 
 from stac_fastapi.pgstac.db import dbfunc
 from stac_fastapi.types import stac as stac_types
@@ -17,14 +18,18 @@ logger.setLevel(logging.INFO)
 class TransactionsClient(AsyncBaseTransactionsClient):
     """Transactions extension specific CRUD operations."""
 
-    async def create_item(self, item: stac_types.Item, **kwargs) -> stac_types.Item:
+    async def create_item(
+        self, item: stac_types.Item, **kwargs
+    ) -> Optional[Union[stac_types.Item, Response]]:
         """Create item."""
         request = kwargs["request"]
         pool = request.app.state.writepool
         await dbfunc(pool, "create_item", item)
         return item
 
-    async def update_item(self, item: stac_types.Item, **kwargs) -> stac_types.Item:
+    async def update_item(
+        self, item: stac_types.Item, **kwargs
+    ) -> Optional[Union[stac_types.Item, Response]]:
         """Update item."""
         request = kwargs["request"]
         pool = request.app.state.writepool
@@ -33,7 +38,7 @@ class TransactionsClient(AsyncBaseTransactionsClient):
 
     async def create_collection(
         self, collection: stac_types.Collection, **kwargs
-    ) -> stac_types.Collection:
+    ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create collection."""
         request = kwargs["request"]
         pool = request.app.state.writepool
@@ -42,23 +47,27 @@ class TransactionsClient(AsyncBaseTransactionsClient):
 
     async def update_collection(
         self, collection: stac_types.Collection, **kwargs
-    ) -> stac_types.Collection:
+    ) -> Optional[Union[stac_types.Collection, Response]]:
         """Update collection."""
         request = kwargs["request"]
         pool = request.app.state.writepool
         await dbfunc(pool, "update_collection", collection)
         return collection
 
-    async def delete_item(self, item_id: str, collection_id: str, **kwargs) -> Dict:
-        """Delete collection."""
+    async def delete_item(
+        self, item_id: str, **kwargs
+    ) -> Optional[Union[stac_types.Item, Response]]:
+        """Delete item."""
         request = kwargs["request"]
         pool = request.app.state.writepool
         await dbfunc(pool, "delete_item", item_id)
-        return {"deleted item": item_id}
+        return JSONResponse({"deleted item": item_id})
 
-    async def delete_collection(self, collection_id: str, **kwargs) -> Dict:
+    async def delete_collection(
+        self, collection_id: str, **kwargs
+    ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete collection."""
         request = kwargs["request"]
         pool = request.app.state.writepool
         await dbfunc(pool, "delete_collection", collection_id)
-        return {"deleted collection": collection_id}
+        return JSONResponse({"deleted collection": collection_id})

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -6,10 +6,10 @@ from urllib.parse import urljoin
 
 import attr
 from fastapi import Request
-from stac_pydantic.api import Search
 from stac_pydantic.links import Relations
 from stac_pydantic.shared import MimeTypes
 from stac_pydantic.version import STAC_VERSION
+from starlette.responses import Response
 
 from stac_fastapi.types import stac as stac_types
 from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
@@ -23,16 +23,19 @@ StacType = Dict[str, Any]
 
 @attr.s  # type:ignore
 class BaseTransactionsClient(abc.ABC):
-    """Defines a pattern for implementing the STAC transaction extension."""
+    """Defines a pattern for implementing the STAC API Transaction Extension."""
 
     @abc.abstractmethod
-    def create_item(self, item: stac_types.Item, **kwargs) -> stac_types.Item:
+    def create_item(
+        self, item: stac_types.Item, **kwargs
+    ) -> Optional[Union[stac_types.Item, Response]]:
         """Create a new item.
 
         Called with `POST /collections/{collection_id}/items`.
 
         Args:
             item: the item
+            collection_id: the id of the collection from the resource path
 
         Returns:
             The item that was created.
@@ -41,7 +44,9 @@ class BaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def update_item(self, item: stac_types.Item, **kwargs) -> stac_types.Item:
+    def update_item(
+        self, item: stac_types.Item, **kwargs
+    ) -> Optional[Union[stac_types.Item, Response]]:
         """Perform a complete update on an existing item.
 
         Called with `PUT /collections/{collection_id}/items`. It is expected that this item already exists.  The update
@@ -50,6 +55,7 @@ class BaseTransactionsClient(abc.ABC):
 
         Args:
             item: the item (must be complete)
+            collection_id: the id of the collection from the resource path
 
         Returns:
             The updated item.
@@ -59,7 +65,7 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def delete_item(
         self, item_id: str, collection_id: str, **kwargs
-    ) -> stac_types.Item:
+    ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
         Called with `DELETE /collections/{collection_id}/items/{item_id}`
@@ -76,7 +82,7 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def create_collection(
         self, collection: stac_types.Collection, **kwargs
-    ) -> stac_types.Collection:
+    ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 
         Called with `POST /collections`.
@@ -92,7 +98,7 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def update_collection(
         self, collection: stac_types.Collection, **kwargs
-    ) -> stac_types.Collection:
+    ) -> Optional[Union[stac_types.Collection, Response]]:
         """Perform a complete update on an existing collection.
 
         Called with `PUT /collections`. It is expected that this item already exists.  The update should do a diff
@@ -101,6 +107,7 @@ class BaseTransactionsClient(abc.ABC):
 
         Args:
             collection: the collection (must be complete)
+            collection_id: the id of the collection from the resource path
 
         Returns:
             The updated collection.
@@ -108,7 +115,9 @@ class BaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def delete_collection(self, collection_id: str, **kwargs) -> stac_types.Collection:
+    def delete_collection(
+        self, collection_id: str, **kwargs
+    ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete a collection.
 
         Called with `DELETE /collections/{collection_id}`
@@ -127,7 +136,9 @@ class AsyncBaseTransactionsClient(abc.ABC):
     """Defines a pattern for implementing the STAC transaction extension."""
 
     @abc.abstractmethod
-    async def create_item(self, item: stac_types.Item, **kwargs) -> stac_types.Item:
+    async def create_item(
+        self, item: stac_types.Item, **kwargs
+    ) -> Optional[Union[stac_types.Item, Response]]:
         """Create a new item.
 
         Called with `POST /collections/{collection_id}/items`.
@@ -142,7 +153,9 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def update_item(self, item: stac_types.Item, **kwargs) -> stac_types.Item:
+    async def update_item(
+        self, item: stac_types.Item, **kwargs
+    ) -> Optional[Union[stac_types.Item, Response]]:
         """Perform a complete update on an existing item.
 
         Called with `PUT /collections/{collection_id}/items`. It is expected that this item already exists.  The update
@@ -160,7 +173,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def delete_item(
         self, item_id: str, collection_id: str, **kwargs
-    ) -> stac_types.Item:
+    ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
         Called with `DELETE /collections/{collection_id}/items/{item_id}`
@@ -177,7 +190,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def create_collection(
         self, collection: stac_types.Collection, **kwargs
-    ) -> stac_types.Collection:
+    ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 
         Called with `POST /collections`.
@@ -193,7 +206,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def update_collection(
         self, collection: stac_types.Collection, **kwargs
-    ) -> stac_types.Collection:
+    ) -> Optional[Union[stac_types.Collection, Response]]:
         """Perform a complete update on an existing collection.
 
         Called with `PUT /collections`. It is expected that this item already exists.  The update should do a diff
@@ -211,7 +224,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def delete_collection(
         self, collection_id: str, **kwargs
-    ) -> stac_types.Collection:
+    ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete a collection.
 
         Called with `DELETE /collections/{collection_id}`
@@ -394,7 +407,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
 
     @abc.abstractmethod
     def post_search(
-        self, search_request: Search, **kwargs
+        self, search_request: BaseSearchPostRequest, **kwargs
     ) -> stac_types.ItemCollection:
         """Cross catalog search (POST).
 
@@ -581,7 +594,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
 
     @abc.abstractmethod
     async def post_search(
-        self, search_request: Search, **kwargs
+        self, search_request: BaseSearchPostRequest, **kwargs
     ) -> stac_types.ItemCollection:
         """Cross catalog search (POST).
 


### PR DESCRIPTION

**Related Issue(s):** 

- https://github.com/stac-utils/stac-fastapi/issues/376

**Description:**

- for all Txn clients, update the method return types to match what can actually be returned. This is now None, a STAC object type, or a starlette Response.
- In addition to the existing behavior of returning a 200 + STAC object type or Response, also return a 204 No Content if the result value is None.

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
