### PR TITLE
remove sqlalchemy dev dep on pytest-asyncio

### DIFF
--- a/stac_fastapi/sqlalchemy/setup.py
+++ b/stac_fastapi/sqlalchemy/setup.py
@@ -25,7 +25,6 @@ extra_reqs = {
     "dev": [
         "pytest",
         "pytest-cov",
-        "pytest-asyncio",
         "pre-commit",
         "requests",
     ],

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -87,7 +87,6 @@ def test_app_search_response_multipolygon(
     resp = app_client.get("/search", params={"collections": ["test-collection"]})
     assert resp.status_code == 200
     resp_json = resp.json()
-    print(resp_json)
 
     assert resp_json.get("type") == "FeatureCollection"
     assert resp_json.get("features")[0]["geometry"]["type"] == "MultiPolygon"


### PR DESCRIPTION
**Related Issue(s):** 

- n/a

**Description:**

- remove sqlalchemy dev dep on pytest-asyncio - unused and printing warning about asyncio_mode not being defined

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
