### PR TITLE
pgstac: move asyncio-mode config into pytest.ini and remove unnecessary pytest.mark.asyncio tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ docker-shell-pgstac:
 
 .PHONY: test-sqlalchemy
 test-sqlalchemy: run-joplin-sqlalchemy
-	$(run_docker) /bin/bash -c 'export && ./scripts/wait-for-it.sh database:5432 && cd /app/stac_fastapi/sqlalchemy/tests/ && pytest'
+	$(run_docker) /bin/bash -c 'export && ./scripts/wait-for-it.sh database:5432 && cd /app/stac_fastapi/sqlalchemy/tests/ && pytest -vvv'
 
 .PHONY: test-pgstac
 test-pgstac:
-	$(run_pgstac) /bin/bash -c 'export && ./scripts/wait-for-it.sh database:5432 && cd /app/stac_fastapi/pgstac/tests/ && pytest -vvv --asyncio-mode=auto'
+	$(run_pgstac) /bin/bash -c 'export && ./scripts/wait-for-it.sh database:5432 && cd /app/stac_fastapi/pgstac/tests/ && pytest -vvv'
 
 .PHONY: run-database
 run-database:

--- a/stac_fastapi/pgstac/pytest.ini
+++ b/stac_fastapi/pgstac/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+addopts = -sv
+asyncio_mode = auto

--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -23,7 +23,7 @@ extra_reqs = {
     "dev": [
         "pytest",
         "pytest-cov",
-        "pytest-asyncio",
+        "pytest-asyncio>=0.17",
         "pre-commit",
         "requests",
         "pypgstac==0.4.5",

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timedelta
 
-import pytest
-
 STAC_CORE_ROUTES = [
     "GET /",
     "GET /collections",
@@ -23,20 +21,17 @@ STAC_TRANSACTION_ROUTES = [
 ]
 
 
-@pytest.mark.asyncio
 async def test_post_search_content_type(app_client):
     params = {"limit": 1}
     resp = await app_client.post("search", json=params)
     assert resp.headers["content-type"] == "application/geo+json"
 
 
-@pytest.mark.asyncio
 async def test_get_search_content_type(app_client):
     resp = await app_client.get("search")
     assert resp.headers["content-type"] == "application/geo+json"
 
 
-@pytest.mark.asyncio
 async def test_api_headers(app_client):
     resp = await app_client.get("/api")
     assert (
@@ -45,7 +40,6 @@ async def test_api_headers(app_client):
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
 async def test_core_router(api_client):
     core_routes = set(STAC_CORE_ROUTES)
     api_routes = set(
@@ -54,7 +48,6 @@ async def test_core_router(api_client):
     assert not core_routes - api_routes
 
 
-@pytest.mark.asyncio
 async def test_transactions_router(api_client):
     transaction_routes = set(STAC_TRANSACTION_ROUTES)
     api_routes = set(
@@ -63,7 +56,6 @@ async def test_transactions_router(api_client):
     assert not transaction_routes - api_routes
 
 
-@pytest.mark.asyncio
 async def test_app_transaction_extension(
     app_client, load_test_data, load_test_collection
 ):
@@ -73,7 +65,6 @@ async def test_app_transaction_extension(
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
 async def test_app_query_extension(load_test_data, app_client, load_test_collection):
     coll = load_test_collection
     item = load_test_data("test_item.json")
@@ -87,7 +78,6 @@ async def test_app_query_extension(load_test_data, app_client, load_test_collect
     assert len(resp_json["features"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_app_query_extension_limit_1(
     load_test_data, app_client, load_test_collection
 ):
@@ -103,14 +93,12 @@ async def test_app_query_extension_limit_1(
     assert len(resp_json["features"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_app_query_extension_limit_eq0(app_client):
     params = {"limit": 0}
     resp = await app_client.post("/search", json=params)
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
 async def test_app_query_extension_limit_lt0(
     load_test_data, app_client, load_test_collection
 ):
@@ -124,7 +112,6 @@ async def test_app_query_extension_limit_lt0(
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
 async def test_app_query_extension_limit_gt10000(
     load_test_data, app_client, load_test_collection
 ):
@@ -138,7 +125,6 @@ async def test_app_query_extension_limit_gt10000(
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
 async def test_app_query_extension_gt(load_test_data, app_client, load_test_collection):
     coll = load_test_collection
     item = load_test_data("test_item.json")
@@ -152,7 +138,6 @@ async def test_app_query_extension_gt(load_test_data, app_client, load_test_coll
     assert len(resp_json["features"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_app_query_extension_gte(
     load_test_data, app_client, load_test_collection
 ):
@@ -168,7 +153,6 @@ async def test_app_query_extension_gte(
     assert len(resp_json["features"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_app_sort_extension(load_test_data, app_client, load_test_collection):
     coll = load_test_collection
     first_item = load_test_data("test_item.json")
@@ -209,7 +193,6 @@ async def test_app_sort_extension(load_test_data, app_client, load_test_collecti
     assert resp_json["features"][0]["id"] == second_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_search_invalid_date(load_test_data, app_client, load_test_collection):
     coll = load_test_collection
     first_item = load_test_data("test_item.json")
@@ -225,7 +208,6 @@ async def test_search_invalid_date(load_test_data, app_client, load_test_collect
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
 async def test_bbox_3d(load_test_data, app_client, load_test_collection):
     coll = load_test_collection
     first_item = load_test_data("test_item.json")
@@ -244,7 +226,6 @@ async def test_bbox_3d(load_test_data, app_client, load_test_collection):
     assert len(resp_json["features"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_app_search_response(load_test_data, app_client, load_test_collection):
     coll = load_test_collection
     params = {
@@ -260,7 +241,6 @@ async def test_app_search_response(load_test_data, app_client, load_test_collect
     assert resp_json.get("stac_extensions") is None
 
 
-@pytest.mark.asyncio
 async def test_search_point_intersects(
     load_test_data, app_client, load_test_collection
 ):
@@ -282,7 +262,6 @@ async def test_search_point_intersects(
     assert len(resp_json["features"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_search_line_string_intersects(
     load_test_data, app_client, load_test_collection
 ):

--- a/stac_fastapi/pgstac/tests/clients/test_postgres.py
+++ b/stac_fastapi/pgstac/tests/clients/test_postgres.py
@@ -1,13 +1,11 @@
 import uuid
 from typing import Callable
 
-import pytest
 from stac_pydantic import Collection, Item
 
 # from tests.conftest import MockStarletteRequest
 
 
-@pytest.mark.asyncio
 async def test_create_collection(app_client, load_test_data: Callable):
     in_json = load_test_data("test_collection.json")
     in_coll = Collection.parse_obj(in_json)
@@ -24,7 +22,6 @@ async def test_create_collection(app_client, load_test_data: Callable):
     assert post_coll.dict(exclude={"links"}) == get_coll.dict(exclude={"links"})
 
 
-@pytest.mark.asyncio
 async def test_update_collection(app_client, load_test_collection):
     in_coll = load_test_collection
     in_coll.keywords.append("newkeyword")
@@ -40,7 +37,6 @@ async def test_update_collection(app_client, load_test_collection):
     assert "newkeyword" in get_coll.keywords
 
 
-@pytest.mark.asyncio
 async def test_delete_collection(app_client, load_test_collection):
     in_coll = load_test_collection
 
@@ -51,7 +47,6 @@ async def test_delete_collection(app_client, load_test_collection):
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_create_item(app_client, load_test_data: Callable, load_test_collection):
     coll = load_test_collection
 
@@ -73,7 +68,6 @@ async def test_create_item(app_client, load_test_data: Callable, load_test_colle
     assert in_item.dict(exclude={"links"}) == get_item.dict(exclude={"links"})
 
 
-@pytest.mark.asyncio
 async def test_update_item(app_client, load_test_collection, load_test_item):
     coll = load_test_collection
     item = load_test_item
@@ -91,7 +85,6 @@ async def test_update_item(app_client, load_test_collection, load_test_item):
     assert get_item.properties.description == "Update Test"
 
 
-@pytest.mark.asyncio
 async def test_delete_item(app_client, load_test_collection, load_test_item):
     coll = load_test_collection
     item = load_test_item
@@ -103,7 +96,6 @@ async def test_delete_item(app_client, load_test_collection, load_test_item):
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_get_collection_items(app_client, load_test_collection, load_test_item):
     coll = load_test_collection
     item = load_test_item

--- a/stac_fastapi/pgstac/tests/conftest.py
+++ b/stac_fastapi/pgstac/tests/conftest.py
@@ -118,7 +118,6 @@ def api_client(pg):
     return api
 
 
-@pytest.mark.asyncio
 @pytest.fixture(scope="session")
 async def app(api_client):
     time.time()
@@ -130,7 +129,6 @@ async def app(api_client):
     await close_db_connection(app)
 
 
-@pytest.mark.asyncio
 @pytest.fixture(scope="session")
 async def app_client(app):
     async with AsyncClient(app=app, base_url="http://test") as c:

--- a/stac_fastapi/pgstac/tests/resources/test_collection.py
+++ b/stac_fastapi/pgstac/tests/resources/test_collection.py
@@ -1,11 +1,9 @@
 from typing import Callable
 
 import pystac
-import pytest
 from stac_pydantic import Collection
 
 
-@pytest.mark.asyncio
 async def test_create_collection(app_client, load_test_data: Callable):
     in_json = load_test_data("test_collection.json")
     in_coll = Collection.parse_obj(in_json)
@@ -22,7 +20,6 @@ async def test_create_collection(app_client, load_test_data: Callable):
     assert post_coll.dict(exclude={"links"}) == get_coll.dict(exclude={"links"})
 
 
-@pytest.mark.asyncio
 async def test_update_collection(app_client, load_test_data, load_test_collection):
     in_coll = load_test_collection
     in_coll.keywords.append("newkeyword")
@@ -38,7 +35,6 @@ async def test_update_collection(app_client, load_test_data, load_test_collectio
     assert "newkeyword" in get_coll.keywords
 
 
-@pytest.mark.asyncio
 async def test_delete_collection(
     app_client, load_test_data: Callable, load_test_collection
 ):
@@ -51,7 +47,6 @@ async def test_delete_collection(
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_create_collection_conflict(app_client, load_test_data: Callable):
     in_json = load_test_data("test_collection.json")
     Collection.parse_obj(in_json)
@@ -68,7 +63,6 @@ async def test_create_collection_conflict(app_client, load_test_data: Callable):
     assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
 async def test_delete_missing_collection(
     app_client,
 ):
@@ -76,7 +70,6 @@ async def test_delete_missing_collection(
     assert resp.status_code == 405
 
 
-@pytest.mark.asyncio
 async def test_update_new_collection(app_client, load_test_collection):
     in_coll = load_test_collection
     in_coll.id = "test-updatenew"
@@ -85,7 +78,6 @@ async def test_update_new_collection(app_client, load_test_collection):
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_nocollections(
     app_client,
 ):
@@ -93,7 +85,6 @@ async def test_nocollections(
     assert resp.status_code == 200
 
 
-@pytest.mark.asyncio
 async def test_returns_valid_collection(app_client, load_test_data):
     """Test updating a collection which already exists"""
     in_json = load_test_data("test_collection.json")
@@ -117,7 +108,6 @@ async def test_returns_valid_collection(app_client, load_test_data):
     collection.validate()
 
 
-@pytest.mark.asyncio
 async def test_returns_valid_links_in_collections(app_client, load_test_data):
     """Test links from listing collections"""
     in_json = load_test_data("test_collection.json")
@@ -166,7 +156,6 @@ async def test_returns_valid_links_in_collections(app_client, load_test_data):
     ] == []
 
 
-@pytest.mark.asyncio
 async def test_returns_license_link(app_client, load_test_collection):
     coll = load_test_collection
 

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -38,7 +38,6 @@ link_tests = [
 ]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("rel_type,expected_media_type,expected_path", link_tests)
 async def test_landing_page_links(
     response_json, app_client, rel_type, expected_media_type, expected_path

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -5,7 +5,6 @@ from typing import Callable
 from urllib.parse import parse_qs, urljoin, urlparse
 
 import pystac
-import pytest
 from httpx import AsyncClient
 from shapely.geometry import Polygon
 from stac_pydantic import Collection, Item
@@ -15,7 +14,6 @@ from starlette.requests import Request
 from stac_fastapi.pgstac.models.links import CollectionLinks
 
 
-@pytest.mark.asyncio
 async def test_create_collection(app_client, load_test_data: Callable):
     in_json = load_test_data("test_collection.json")
     in_coll = Collection.parse_obj(in_json)
@@ -32,7 +30,6 @@ async def test_create_collection(app_client, load_test_data: Callable):
     assert post_coll.dict(exclude={"links"}) == get_coll.dict(exclude={"links"})
 
 
-@pytest.mark.asyncio
 async def test_update_collection(app_client, load_test_data, load_test_collection):
     in_coll = load_test_collection
     in_coll.keywords.append("newkeyword")
@@ -48,7 +45,6 @@ async def test_update_collection(app_client, load_test_data, load_test_collectio
     assert "newkeyword" in get_coll.keywords
 
 
-@pytest.mark.asyncio
 async def test_delete_collection(
     app_client, load_test_data: Callable, load_test_collection
 ):
@@ -61,7 +57,6 @@ async def test_delete_collection(
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_create_item(app_client, load_test_data: Callable, load_test_collection):
     coll = load_test_collection
 
@@ -83,7 +78,6 @@ async def test_create_item(app_client, load_test_data: Callable, load_test_colle
     assert in_item.dict(exclude={"links"}) == get_item.dict(exclude={"links"})
 
 
-@pytest.mark.asyncio
 async def test_fetches_valid_item(
     app_client, load_test_data: Callable, load_test_collection
 ):
@@ -112,7 +106,6 @@ async def test_fetches_valid_item(
     item.validate()
 
 
-@pytest.mark.asyncio
 async def test_update_item(
     app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
@@ -132,7 +125,6 @@ async def test_update_item(
     assert get_item.properties.description == "Update Test"
 
 
-@pytest.mark.asyncio
 async def test_delete_item(
     app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
@@ -147,7 +139,6 @@ async def test_delete_item(
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_get_collection_items(app_client, load_test_collection, load_test_item):
     coll = load_test_collection
     item = load_test_item
@@ -169,7 +160,6 @@ async def test_get_collection_items(app_client, load_test_collection, load_test_
     assert len(fc["features"]) == 5
 
 
-@pytest.mark.asyncio
 async def test_create_item_conflict(
     app_client, load_test_data: Callable, load_test_collection
 ):
@@ -190,7 +180,6 @@ async def test_create_item_conflict(
     assert resp.status_code == 409
 
 
-@pytest.mark.asyncio
 async def test_delete_missing_item(
     app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
@@ -206,7 +195,6 @@ async def test_delete_missing_item(
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_create_item_missing_collection(
     app_client, load_test_data: Callable, load_test_collection
 ):
@@ -218,7 +206,6 @@ async def test_create_item_missing_collection(
     assert resp.status_code == 424
 
 
-@pytest.mark.asyncio
 async def test_update_new_item(
     app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
@@ -230,7 +217,6 @@ async def test_update_new_item(
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_update_item_missing_collection(
     app_client, load_test_data: Callable, load_test_collection, load_test_item
 ):
@@ -242,7 +228,6 @@ async def test_update_item_missing_collection(
     assert resp.status_code == 424
 
 
-@pytest.mark.asyncio
 async def test_pagination(app_client, load_test_data, load_test_collection):
     """Test item collection pagination (paging extension)"""
     coll = load_test_collection
@@ -319,7 +304,6 @@ async def test_pagination(app_client, load_test_data, load_test_collection):
     ]
 
 
-@pytest.mark.asyncio
 async def test_item_search_by_id_post(app_client, load_test_data, load_test_collection):
     """Test POST search by item id (core)"""
     ids = ["test1", "test2", "test3"]
@@ -339,7 +323,6 @@ async def test_item_search_by_id_post(app_client, load_test_data, load_test_coll
     assert set([feat["id"] for feat in resp_json["features"]]) == set(ids)
 
 
-@pytest.mark.asyncio
 async def test_item_search_by_id_no_results_post(
     app_client, load_test_data, load_test_collection
 ):
@@ -355,7 +338,6 @@ async def test_item_search_by_id_no_results_post(
     assert len(resp_json["features"]) == 0
 
 
-@pytest.mark.asyncio
 async def test_item_search_spatial_query_post(
     app_client, load_test_data, load_test_collection
 ):
@@ -384,7 +366,6 @@ async def test_item_search_spatial_query_post(
     assert resp_json["features"][0]["id"] == test_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_item_search_temporal_query_post(
     app_client, load_test_data, load_test_collection
 ):
@@ -419,7 +400,6 @@ async def test_item_search_temporal_query_post(
     assert resp_json["features"][0]["id"] == test_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_item_search_temporal_window_post(
     app_client, load_test_data, load_test_collection
 ):
@@ -451,7 +431,6 @@ async def test_item_search_temporal_window_post(
     assert resp_json["features"][0]["id"] == test_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_item_search_temporal_open_window(
     app_client, load_test_data, load_test_collection
 ):
@@ -478,7 +457,6 @@ async def test_item_search_temporal_open_window(
     assert len(resp_json["features"]) == 2
 
 
-@pytest.mark.asyncio
 async def test_item_search_sort_post(app_client, load_test_data, load_test_collection):
     """Test POST search with sorting (sort extension)"""
     first_item = load_test_data("test_item.json")
@@ -508,7 +486,6 @@ async def test_item_search_sort_post(app_client, load_test_data, load_test_colle
     assert resp_json["features"][1]["id"] == second_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_item_search_by_id_get(app_client, load_test_data, load_test_collection):
     """Test GET search by item id (core)"""
     ids = ["test1", "test2", "test3"]
@@ -528,7 +505,6 @@ async def test_item_search_by_id_get(app_client, load_test_data, load_test_colle
     assert set([feat["id"] for feat in resp_json["features"]]) == set(ids)
 
 
-@pytest.mark.asyncio
 async def test_item_search_bbox_get(app_client, load_test_data, load_test_collection):
     """Test GET search with spatial query (core)"""
     test_item = load_test_data("test_item.json")
@@ -555,7 +531,6 @@ async def test_item_search_bbox_get(app_client, load_test_data, load_test_collec
     assert resp_json["features"][0]["id"] == test_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_item_search_get_without_collections(
     app_client, load_test_data, load_test_collection
 ):
@@ -583,7 +558,6 @@ async def test_item_search_get_without_collections(
     assert resp_json["features"][0]["id"] == test_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_item_search_temporal_window_get(
     app_client, load_test_data, load_test_collection
 ):
@@ -615,7 +589,6 @@ async def test_item_search_temporal_window_get(
     assert resp_json["features"][0]["id"] == test_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_item_search_sort_get(app_client, load_test_data, load_test_collection):
     """Test GET search with sorting (sort extension)"""
     first_item = load_test_data("test_item.json")
@@ -641,7 +614,6 @@ async def test_item_search_sort_get(app_client, load_test_data, load_test_collec
     assert resp_json["features"][1]["id"] == second_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_item_search_post_without_collection(
     app_client, load_test_data, load_test_collection
 ):
@@ -667,7 +639,6 @@ async def test_item_search_post_without_collection(
     assert resp_json["features"][0]["id"] == test_item["id"]
 
 
-@pytest.mark.asyncio
 async def test_item_search_properties_jsonb(
     app_client, load_test_data, load_test_collection
 ):
@@ -693,7 +664,6 @@ async def test_item_search_properties_jsonb(
     assert len(resp_json["features"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_item_search_properties_field(
     app_client, load_test_data, load_test_collection
 ):
@@ -718,7 +688,6 @@ async def test_item_search_properties_field(
     assert len(resp_json["features"]) == 1
 
 
-@pytest.mark.asyncio
 async def test_item_search_get_query_extension(
     app_client, load_test_data, load_test_collection
 ):
@@ -759,7 +728,6 @@ async def test_item_search_get_query_extension(
     )
 
 
-@pytest.mark.asyncio
 async def test_item_search_get_filter_extension_cql(
     app_client, load_test_data, load_test_collection
 ):
@@ -810,7 +778,6 @@ async def test_item_search_get_filter_extension_cql(
     )
 
 
-@pytest.mark.asyncio
 async def test_item_search_get_filter_extension_cql2(
     app_client, load_test_data, load_test_collection
 ):
@@ -866,7 +833,6 @@ async def test_item_search_get_filter_extension_cql2(
     )
 
 
-@pytest.mark.asyncio
 async def test_item_search_get_filter_extension_cql2_with_query_fails(
     app_client, load_test_data, load_test_collection
 ):
@@ -902,21 +868,18 @@ async def test_item_search_get_filter_extension_cql2_with_query_fails(
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
 async def test_get_missing_item_collection(app_client):
     """Test reading a collection which does not exist"""
     resp = await app_client.get("/collections/invalid-collection/items")
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_get_item_from_missing_item_collection(app_client):
     """Test reading an item from a collection which does not exist"""
     resp = await app_client.get("/collections/invalid-collection/items/some-item")
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_pagination_item_collection(
     app_client, load_test_data, load_test_collection
 ):
@@ -963,7 +926,6 @@ async def test_pagination_item_collection(
     assert not set(item_ids) - set(ids)
 
 
-@pytest.mark.asyncio
 async def test_pagination_post(app_client, load_test_data, load_test_collection):
     """Test POST pagination (paging extension)"""
     test_item = load_test_data("test_item.json")
@@ -1012,7 +974,6 @@ async def test_pagination_post(app_client, load_test_data, load_test_collection)
     assert not set(item_ids) - set(ids)
 
 
-@pytest.mark.asyncio
 async def test_pagination_token_idempotent(
     app_client, load_test_data, load_test_collection
 ):
@@ -1058,7 +1019,6 @@ async def test_pagination_token_idempotent(
     ]
 
 
-@pytest.mark.asyncio
 async def test_field_extension_get(app_client, load_test_data, load_test_collection):
     """Test GET search with included fields (fields extension)"""
     test_item = load_test_data("test_item.json")
@@ -1073,7 +1033,6 @@ async def test_field_extension_get(app_client, load_test_data, load_test_collect
     assert not set(feat_properties) - {"proj:epsg", "gsd", "datetime"}
 
 
-@pytest.mark.asyncio
 async def test_field_extension_post(app_client, load_test_data, load_test_collection):
     """Test POST search with included and excluded fields (fields extension)"""
     test_item = load_test_data("test_item.json")
@@ -1105,7 +1064,6 @@ async def test_field_extension_post(app_client, load_test_data, load_test_collec
     }
 
 
-@pytest.mark.asyncio
 async def test_field_extension_exclude_and_include(
     app_client, load_test_data, load_test_collection
 ):
@@ -1128,7 +1086,6 @@ async def test_field_extension_exclude_and_include(
     assert "properties" not in resp_json["features"][0]
 
 
-@pytest.mark.asyncio
 async def test_field_extension_exclude_default_includes(
     app_client, load_test_data, load_test_collection
 ):
@@ -1146,7 +1103,6 @@ async def test_field_extension_exclude_default_includes(
     assert "geometry" not in resp_json["features"][0]
 
 
-@pytest.mark.asyncio
 async def test_search_intersects_and_bbox(app_client):
     """Test POST search intersects and bbox are mutually exclusive (core)"""
     bbox = [-118, 34, -117, 35]
@@ -1156,7 +1112,6 @@ async def test_search_intersects_and_bbox(app_client):
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
 async def test_get_missing_item(app_client, load_test_data):
     """Test read item which does not exist (transactions extension)"""
     test_coll = load_test_data("test_collection.json")
@@ -1164,7 +1119,6 @@ async def test_get_missing_item(app_client, load_test_data):
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
 async def test_relative_link_construction():
     req = Request(
         scope={
@@ -1182,7 +1136,6 @@ async def test_relative_link_construction():
     assert links.link_items()["href"] == "http://test/stac/collections/naip/items"
 
 
-@pytest.mark.asyncio
 async def test_search_bbox_errors(app_client):
     body = {"query": {"bbox": [0]}}
     resp = await app_client.post("/search", json=body)
@@ -1197,7 +1150,6 @@ async def test_search_bbox_errors(app_client):
     assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
 async def test_preserves_extra_link(
     app_client: AsyncClient, load_test_data, load_test_collection
 ):
@@ -1220,7 +1172,6 @@ async def test_preserves_extra_link(
     assert extra_link[0]["href"] == expected_href
 
 
-@pytest.mark.asyncio
 async def test_item_search_get_filter_extension_cql_explicitlang(
     app_client, load_test_data, load_test_collection
 ):
@@ -1267,7 +1218,6 @@ async def test_item_search_get_filter_extension_cql_explicitlang(
     )
 
 
-@pytest.mark.asyncio
 async def test_item_search_get_filter_extension_cql2_2(
     app_client, load_test_data, load_test_collection
 ):
@@ -1341,7 +1291,6 @@ async def test_item_search_get_filter_extension_cql2_2(
     )
 
 
-@pytest.mark.asyncio
 async def test_search_datetime_validation_errors(app_client):
     bad_datetimes = [
         "37-01-01T12:00:27.87Z",
@@ -1362,7 +1311,6 @@ async def test_search_datetime_validation_errors(app_client):
         assert resp.status_code == 400
 
 
-@pytest.mark.asyncio
 async def test_filter_cql2text(app_client, load_test_data, load_test_collection):
     """Test GET search with cql2-text"""
     test_item = load_test_data("test_item.json")

--- a/stac_fastapi/pgstac/tests/resources/test_mgmt.py
+++ b/stac_fastapi/pgstac/tests/resources/test_mgmt.py
@@ -1,7 +1,3 @@
-import pytest
-
-
-@pytest.mark.asyncio
 async def test_ping_no_param(app_client):
     """
     Test ping endpoint with a mocked client.


### PR DESCRIPTION
**Related Issue(s):** 

- n/a

**Description:**

- move asyncio-mode config into pytest.ini 
- remove unnecessary pytest.mark.asyncio tags (pytest-asyncio recommends using auto mode which does not require these decorators if not using multiple asyncio frameworks)

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
