### PR TITLE
fix search, next, and prev media types

### DIFF
--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
@@ -125,7 +125,7 @@ class PagingLinks(BaseLinks):
                 href = merge_params(self.url, {"token": f"next:{self.next}"})
                 link = dict(
                     rel=Relations.next.value,
-                    type=MimeTypes.json.value,
+                    type=MimeTypes.geojson.value,
                     method=method,
                     href=href,
                 )
@@ -133,7 +133,7 @@ class PagingLinks(BaseLinks):
             if method == "POST":
                 return {
                     "rel": Relations.next,
-                    "type": MimeTypes.json,
+                    "type": MimeTypes.geojson,
                     "method": method,
                     "href": f"{self.request.url}",
                     "body": {**self.request.postbody, "token": f"next:{self.next}"},
@@ -149,14 +149,14 @@ class PagingLinks(BaseLinks):
                 href = merge_params(self.url, {"token": f"prev:{self.prev}"})
                 return dict(
                     rel=Relations.previous.value,
-                    type=MimeTypes.json.value,
+                    type=MimeTypes.geojson.value,
                     method=method,
                     href=href,
                 )
             if method == "POST":
                 return {
                     "rel": Relations.previous,
-                    "type": MimeTypes.json,
+                    "type": MimeTypes.geojson,
                     "method": method,
                     "href": f"{self.request.url}",
                     "body": {**self.request.postbody, "token": f"prev:{self.prev}"},

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -1,5 +1,6 @@
 import urllib.parse
 from typing import Dict, Optional
+
 import pytest
 
 
@@ -16,8 +17,11 @@ async def response_json(response) -> Dict:
 def get_link(landing_page, rel_type, method: Optional[str] = None):
     return next(
         filter(
-            lambda link: link["rel"] == rel_type and (not method or link.get("method") == method),
-            landing_page["links"]), None
+            lambda link: link["rel"] == rel_type
+            and (not method or link.get("method") == method),
+            landing_page["links"],
+        ),
+        None,
     )
 
 
@@ -43,7 +47,7 @@ link_tests = [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("rel_type,expected_media_type,expected_path", link_tests)
 async def test_landing_page_links(
-        response_json: Dict, app_client, rel_type, expected_media_type, expected_path
+    response_json: Dict, app_client, rel_type, expected_media_type, expected_path
 ):
     link = get_link(response_json, rel_type)
 
@@ -62,7 +66,10 @@ async def test_landing_page_links(
 # https://github.com/stac-utils/stac-fastapi/pull/227 has been merged we can add this to the
 # parameterized tests above.
 def test_search_link(response_json: Dict):
-    for search_link in [get_link(response_json, "search", "GET"), get_link(response_json, "search", "POST")]:
+    for search_link in [
+        get_link(response_json, "search", "GET"),
+        get_link(response_json, "search", "POST"),
+    ]:
         assert search_link is not None
         assert search_link.get("type") == "application/geo+json"
 

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -1,5 +1,5 @@
 import urllib.parse
-
+from typing import Dict, Optional
 import pytest
 
 
@@ -9,13 +9,15 @@ async def response(app_client):
 
 
 @pytest.fixture(scope="module")
-async def response_json(response):
+async def response_json(response) -> Dict:
     return response.json()
 
 
-def get_link(landing_page, rel_type):
+def get_link(landing_page, rel_type, method: Optional[str] = None):
     return next(
-        filter(lambda link: link["rel"] == rel_type, landing_page["links"]), None
+        filter(
+            lambda link: link["rel"] == rel_type and (not method or link.get("method") == method),
+            landing_page["links"]), None
     )
 
 
@@ -41,7 +43,7 @@ link_tests = [
 @pytest.mark.asyncio
 @pytest.mark.parametrize("rel_type,expected_media_type,expected_path", link_tests)
 async def test_landing_page_links(
-    response_json, app_client, rel_type, expected_media_type, expected_path
+        response_json: Dict, app_client, rel_type, expected_media_type, expected_path
 ):
     link = get_link(response_json, rel_type)
 
@@ -59,11 +61,10 @@ async def test_landing_page_links(
 # code here seems meaningless since it would be the same as if the endpoint did not exist. Once
 # https://github.com/stac-utils/stac-fastapi/pull/227 has been merged we can add this to the
 # parameterized tests above.
-def test_search_link(response_json):
-    search_link = get_link(response_json, "search")
+def test_search_link(response_json: Dict):
+    for search_link in [get_link(response_json, "search", "GET"), get_link(response_json, "search", "POST")]:
+        assert search_link is not None
+        assert search_link.get("type") == "application/geo+json"
 
-    assert search_link is not None
-    assert search_link.get("type") == "application/geo+json"
-
-    search_path = urllib.parse.urlsplit(search_link.get("href")).path
-    assert search_path == "/search"
+        search_path = urllib.parse.urlsplit(search_link.get("href")).path
+        assert search_path == "/search"

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -278,7 +278,7 @@ class LandingPageMixin(abc.ABC):
                 },
                 {
                     "rel": Relations.search.value,
-                    "type": MimeTypes.json,
+                    "type": MimeTypes.geojson,
                     "title": "STAC search",
                     "href": urljoin(base_url, "search"),
                     "method": "POST",


### PR DESCRIPTION
**Related Issue(s):** 

- https://github.com/stac-utils/stac-fastapi/issues/357

**Description:**

- root POST search link advertises type `application/geojson` (only GET was doing this)
- pagination links advertise `application/geojson`

**PR Checklist:**

- [X] Code is formatted and linted (run `pre-commit run --all-files`)
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
