### PR TITLE
Update filter conformance classes

### DIFF
--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -27,9 +27,7 @@ class FilterConformanceClasses(str, Enum):
     """
 
     FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
-    ITEM_SEARCH_FILTER = (
-        "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features#filter"
-    )
+    ITEM_SEARCH_FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
     CQL_TEXT = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-text"
     CQL_JSON = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-json"
     BASIC_CQL = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:basic-cql"

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -23,7 +23,7 @@ class FilterConformanceClasses(str, Enum):
 
     FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
     ITEM_SEARCH_FILTER = (
-        "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
+        "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features#filter"
     )
     CQL_TEXT = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-text"
     CQL_JSON = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-json"

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -27,7 +27,9 @@ class FilterConformanceClasses(str, Enum):
     """
 
     FILTER = "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter"
-    FEATURES_FILTER = "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter"
+    FEATURES_FILTER = (
+        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter"
+    )
     ITEM_SEARCH_FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
     CQL_TEXT = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-text"
     CQL_JSON = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-json"

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -21,9 +21,9 @@ class FilterConformanceClasses(str, Enum):
     See https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1/fragments/filter
     """
 
-    FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:filter"
+    FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
     ITEM_SEARCH_FILTER = (
-        "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:item-search-filter"
+        "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
     )
     CQL_TEXT = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-text"
     CQL_JSON = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-json"

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -26,7 +26,8 @@ class FilterConformanceClasses(str, Enum):
     See https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1/fragments/filter
     """
 
-    FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
+    FILTER = "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter"
+    FEATURES_FILTER = "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter"
     ITEM_SEARCH_FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
     CQL_TEXT = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-text"
     CQL_JSON = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter:cql-json"
@@ -68,6 +69,7 @@ class FilterExtension(ApiExtension):
     conformance_classes: List[str] = attr.ib(
         default=[
             FilterConformanceClasses.FILTER,
+            FilterConformanceClasses.FEATURES_FILTER,
             FilterConformanceClasses.ITEM_SEARCH_FILTER,
             FilterConformanceClasses.BASIC_CQL,
             FilterConformanceClasses.CQL_TEXT,


### PR DESCRIPTION
The filter conformance classes seem to be completely wrong. They don't even match the (wrong) ones in rc.1.

See also https://github.com/radiantearth/stac-api-spec/pull/312

I'm not sure which one of the constants if for ogcapi-features though, so the changes may need to be swapped.

Looking at this, the question also arises why for example `https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features#sort` is not used anywhere in stac-fastapi?