### PR TITLE
Fix joplin pgstac

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - PGHOST=localhost
       - PGDATABASE=postgis
     ports:
-      - "5432:5432"
+      - "5439:5432"
     command: postgres -N 500
 
   # Load joplin demo dataset into the SQLAlchemy Application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
 
   database:
     container_name: stac-db
-    image: ghcr.io/stac-utils/pgstac:v0.6.2
+    image: ghcr.io/stac-utils/pgstac:v0.6.6
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       - "/app/scripts/ingest_joplin.py"
       - "http://app-pgstac:8082"
     depends_on:
+      - database
       - app-pgstac
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,11 +100,6 @@ services:
     image: stac-utils/stac-fastapi
     environment:
       - ENVIRONMENT=development
-      - POSTGRES_USER=username
-      - POSTGRES_PASS=password
-      - POSTGRES_DBNAME=postgis
-      - POSTGRES_HOST=database
-      - POSTGRES_PORT=5432
     volumes:
       - ./stac_fastapi:/app/stac_fastapi
       - ./scripts:/app/scripts
@@ -116,7 +111,6 @@ services:
       - "/app/scripts/ingest_joplin.py"
       - "http://app-pgstac:8082"
     depends_on:
-      - database
       - app-pgstac
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - PGHOST=localhost
       - PGDATABASE=postgis
     ports:
-      - "5439:5432"
+      - "5432:5432"
     command: postgres -N 500
 
   # Load joplin demo dataset into the SQLAlchemy Application


### PR DESCRIPTION
**Related Issue(s):** 

# Small fixes in stac-fastapi (with pgstac) joplin example

**Description:**

This PR addresses small fixes in the joplin example with pgstac.
- wrong database port mapping (or I just have missed something here?)
- bump pgstac image version
- useless environment variables removed from the loadjoplin-pgstac container (for a newbie like me, discovering STAC, it is quite confusing to see those database related settings on this side)

I didn't try the SQLAlchemy example, but it might need the same corrections maybe.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
