### PR TITLE
Bugfix: List collection ID in NotFoundError

### DIFF
--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -98,7 +98,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             )
             collection = await conn.fetchval(q, *p)
         if collection is None:
-            raise NotFoundError(f"Collection {id} does not exist.")
+            raise NotFoundError(f"Collection {collection_id} does not exist.")
 
         collection["links"] = await CollectionLinks(
             collection_id=collection_id, request=request


### PR DESCRIPTION
Currently, we are logging the `id()` function, resulting in `404` responses that look like:

```
{
    "code": "NotFoundError",
    "description": "Collection <built-in function id> does not exist."
}
```

**Related Issue(s):** 

- #419

**Description:**


**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
