### PR TITLE
Fix media type for queryables endpoints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@
 * Fixed stray `/` before the `#` in several extension conformance class strings ([383](https://github.com/stac-utils/stac-fastapi/pull/383))
 * SQLAlchemy backend bulk item insert now works ([#356](https://github.com/stac-utils/stac-fastapi/issues/356))
 * PGStac Backend has stricter implementation of Fields Extension syntax ([#397](https://github.com/stac-utils/stac-fastapi/pull/397))
+* `/queryables` endpoint now has type `application/schema+json` instead of `application/json` ([#421](https://github.com/stac-utils/stac-fastapi/pull/421))
 
 ## [2.3.0]
 

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -160,6 +160,11 @@ if importlib.util.find_spec("orjson") is not None:
 
         media_type = "application/geo+json"
 
+    class JSONSchemaResponse(ORJSONResponse):
+        """JSON with custom, vendor content-type."""
+
+        media_type = "application/schema+json"
+
 else:
     from starlette.responses import JSONResponse
 
@@ -167,3 +172,8 @@ else:
         """JSON with custom, vendor content-type."""
 
         media_type = "application/geo+json"
+
+    class JSONSchemaResponse(JSONResponse):
+        """JSON with custom, vendor content-type."""
+
+        media_type = "application/schema+json"

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -5,9 +5,14 @@ from typing import Callable, List, Type, Union
 
 import attr
 from fastapi import APIRouter, FastAPI
-from starlette.responses import JSONResponse, Response
+from starlette.responses import Response
 
-from stac_fastapi.api.models import APIRequest, CollectionUri, EmptyRequest
+from stac_fastapi.api.models import (
+    APIRequest,
+    CollectionUri,
+    EmptyRequest,
+    JSONSchemaResponse,
+)
 from stac_fastapi.api.routes import create_async_endpoint, create_sync_endpoint
 from stac_fastapi.types.core import AsyncBaseFiltersClient, BaseFiltersClient
 from stac_fastapi.types.extension import ApiExtension
@@ -71,7 +76,7 @@ class FilterExtension(ApiExtension):
         ]
     )
     router: APIRouter = attr.ib(factory=APIRouter)
-    response_class: Type[Response] = attr.ib(default=JSONResponse)
+    response_class: Type[Response] = attr.ib(default=JSONSchemaResponse)
 
     def _create_endpoint(
         self,

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -32,6 +32,15 @@ async def test_get_search_content_type(app_client):
     assert resp.headers["content-type"] == "application/geo+json"
 
 
+async def test_get_queryables_content_type(app_client, load_test_collection):
+    resp = await app_client.get("queryables")
+    assert resp.headers["content-type"] == "application/schema+json"
+
+    coll = load_test_collection
+    resp = await app_client.get(f"collections/{coll.id}/queryables")
+    assert resp.headers["content-type"] == "application/schema+json"
+
+
 async def test_api_headers(app_client):
     resp = await app_client.get("/api")
     assert (


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #400 

**Description:**

Creates a new `JSONSchemaResponse` class with a `application/schema+json` media type that is used in the `/queryables` responses.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
