### PR TITLE
pin pygeofilter to version instead of github

### DIFF
--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     "asyncpg",
     "buildpg",
     "brotli_asgi",
-    "pygeofilter @ git+https://github.com/geopython/pygeofilter@v0.1.1#egg=pygeofilter",
+    "pygeofilter>=0.1,<0.2",
     "pypgstac==0.6.*",
 ]
 


### PR DESCRIPTION
This PR update pygeofilter requirement to the GitHub URL to use module's `version`