### PR TITLE
Add support for APIRouter prefix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 * Ability to POST an ItemCollection to the collections/{collectionId}/items route. ([#367](https://github.com/stac-utils/stac-fastapi/pull/367))
 * Add STAC API - Collections conformance class. ([383](https://github.com/stac-utils/stac-fastapi/pull/383))
 * Bulk item inserts for pgstac implementation. ([411](https://github.com/stac-utils/stac-fastapi/pull/411))
+* Add APIRouter prefix support for pgstac implementation. ([429](https://github.com/stac-utils/stac-fastapi/pull/429))
 
 ### Changed
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -333,7 +333,7 @@ class StacApi:
 
     def add_health_check(self):
         """Add a health check."""
-        mgmt_router = APIRouter()
+        mgmt_router = APIRouter(prefix=self.app.state.router_prefix)
 
         @mgmt_router.get("/_mgmt/ping")
         async def ping():
@@ -380,6 +380,10 @@ class StacApi:
         # Register core STAC endpoints
         self.register_core()
         self.app.include_router(self.router)
+
+        # keep link to the router prefix value
+        router_prefix = self.router.prefix
+        self.app.state.router_prefix = router_prefix if router_prefix else ""
 
         # register extensions
         for ext in self.extensions:

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -105,6 +105,7 @@ class FilterExtension(ApiExtension):
         Returns:
             None
         """
+        self.router.prefix = app.state.router_prefix
         self.router.add_api_route(
             name="Queryables",
             path="/queryables",

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -160,6 +160,7 @@ class TransactionExtension(ApiExtension):
         Returns:
             None
         """
+        self.router.prefix = app.state.router_prefix
         self.register_create_item()
         self.register_update_item()
         self.register_delete_item()

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -116,7 +116,7 @@ class BulkTransactionExtension(ApiExtension):
         """
         items_request_model = create_request_model("Items", base_model=Items)
 
-        router = APIRouter()
+        router = APIRouter(prefix=app.state.router_prefix)
         router.add_api_route(
             name="Bulk Create Item",
             path="/collections/{collection_id}/bulk_items",

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -23,6 +23,7 @@ from stac_fastapi.pgstac.types.search import PgstacSearch
 from stac_fastapi.pgstac.utils import filter_fields
 from stac_fastapi.types.core import AsyncBaseCoreClient
 from stac_fastapi.types.errors import InvalidQueryParameter, NotFoundError
+from stac_fastapi.types.requests import get_base_url
 from stac_fastapi.types.stac import Collection, Collections, Item, ItemCollection
 
 NumType = Union[float, int]
@@ -35,7 +36,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
     async def all_collections(self, **kwargs) -> Collections:
         """Read all collections from the database."""
         request: Request = kwargs["request"]
-        base_url = str(request.base_url)
+        base_url = get_base_url(request)
         pool = request.app.state.readpool
 
         async with pool.acquire() as conn:

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/models/links.py
@@ -8,6 +8,8 @@ from stac_pydantic.links import Relations
 from stac_pydantic.shared import MimeTypes
 from starlette.requests import Request
 
+from stac_fastapi.types.requests import get_base_url
+
 # These can be inferred from the item/collection so they aren't included in the database
 # Instead they are dynamically generated when querying the database using the classes defined below
 INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root"]
@@ -45,7 +47,7 @@ class BaseLinks:
     @property
     def base_url(self):
         """Get the base url."""
-        return str(self.request.base_url)
+        return get_base_url(self.request)
 
     @property
     def url(self):

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -49,16 +49,24 @@ async def test_api_headers(app_client):
     assert resp.status_code == 200
 
 
-async def test_core_router(api_client):
-    core_routes = set(STAC_CORE_ROUTES)
+async def test_core_router(api_client, app):
+    core_routes = set()
+    for core_route in STAC_CORE_ROUTES:
+        method, path = core_route.split(" ")
+        core_routes.add("{} {}".format(method, app.state.router_prefix + path))
+
     api_routes = set(
         [f"{list(route.methods)[0]} {route.path}" for route in api_client.app.routes]
     )
     assert not core_routes - api_routes
 
 
-async def test_transactions_router(api_client):
-    transaction_routes = set(STAC_TRANSACTION_ROUTES)
+async def test_transactions_router(api_client, app):
+    transaction_routes = set()
+    for transaction_route in STAC_TRANSACTION_ROUTES:
+        method, path = transaction_route.split(" ")
+        transaction_routes.add("{} {}".format(method, app.state.router_prefix + path))
+
     api_routes = set(
         [f"{list(route.methods)[0]} {route.path}" for route in api_client.app.routes]
     )

--- a/stac_fastapi/pgstac/tests/resources/test_conformance.py
+++ b/stac_fastapi/pgstac/tests/resources/test_conformance.py
@@ -46,7 +46,7 @@ link_tests = [
 
 @pytest.mark.parametrize("rel_type,expected_media_type,expected_path", link_tests)
 async def test_landing_page_links(
-    response_json: Dict, app_client, rel_type, expected_media_type, expected_path
+    response_json: Dict, app_client, app, rel_type, expected_media_type, expected_path
 ):
     link = get_link(response_json, rel_type)
 
@@ -54,9 +54,9 @@ async def test_landing_page_links(
     assert link.get("type") == expected_media_type
 
     link_path = urllib.parse.urlsplit(link.get("href")).path
-    assert link_path == expected_path
+    assert link_path == app.state.router_prefix + expected_path
 
-    resp = await app_client.get(link_path)
+    resp = await app_client.get(link_path.rsplit("/", 1)[-1])
     assert resp.status_code == 200
 
 
@@ -64,7 +64,7 @@ async def test_landing_page_links(
 # code here seems meaningless since it would be the same as if the endpoint did not exist. Once
 # https://github.com/stac-utils/stac-fastapi/pull/227 has been merged we can add this to the
 # parameterized tests above.
-def test_search_link(response_json: Dict):
+def test_search_link(response_json: Dict, app):
     for search_link in [
         get_link(response_json, "search", "GET"),
         get_link(response_json, "search", "POST"),
@@ -73,4 +73,4 @@ def test_search_link(response_json: Dict):
         assert search_link.get("type") == "application/geo+json"
 
         search_path = urllib.parse.urlsplit(search_link.get("href")).path
-        assert search_path == "/search"
+        assert search_path == app.state.router_prefix + "/search"

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -1164,7 +1164,7 @@ async def test_get_missing_item(app_client, load_test_data):
     assert resp.status_code == 404
 
 
-async def test_relative_link_construction():
+async def test_relative_link_construction(app):
     req = Request(
         scope={
             "type": "http",
@@ -1175,10 +1175,13 @@ async def test_relative_link_construction():
             "raw_path": b"/tab/abc",
             "query_string": b"",
             "headers": {},
+            "app": app,
         }
     )
     links = CollectionLinks(collection_id="naip", request=req)
-    assert links.link_items()["href"] == "http://test/stac/collections/naip/items"
+    assert links.link_items()["href"] == (
+        "http://test/stac{}/collections/naip/items".format(app.state.router_prefix)
+    )
 
 
 async def test_search_bbox_errors(app_client):

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -14,6 +14,7 @@ from starlette.responses import Response
 from stac_fastapi.types import stac as stac_types
 from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
+from stac_fastapi.types.requests import get_base_url
 from stac_fastapi.types.search import BaseSearchPostRequest
 from stac_fastapi.types.stac import Conformance
 
@@ -349,7 +350,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
             API landing page, serving as an entry point to the API.
         """
         request: Request = kwargs["request"]
-        base_url = str(request.base_url)
+        base_url = get_base_url(request)
         extension_schemas = [
             schema.schema_href for schema in self.extensions if schema.schema_href
         ]
@@ -377,7 +378,9 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
                 "rel": "service-desc",
                 "type": "application/vnd.oai.openapi+json;version=3.0",
                 "title": "OpenAPI service description",
-                "href": urljoin(base_url, request.app.openapi_url.lstrip("/")),
+                "href": urljoin(
+                    str(request.base_url), request.app.openapi_url.lstrip("/")
+                ),
             }
         )
 
@@ -387,7 +390,9 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
                 "rel": "service-doc",
                 "type": "text/html",
                 "title": "OpenAPI service documentation",
-                "href": urljoin(base_url, request.app.docs_url.lstrip("/")),
+                "href": urljoin(
+                    str(request.base_url), request.app.docs_url.lstrip("/")
+                ),
             }
         )
 
@@ -538,7 +543,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
             API landing page, serving as an entry point to the API.
         """
         request: Request = kwargs["request"]
-        base_url = str(request.base_url)
+        base_url = get_base_url(request)
         extension_schemas = [
             schema.schema_href for schema in self.extensions if schema.schema_href
         ]
@@ -564,7 +569,9 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
                 "rel": "service-desc",
                 "type": "application/vnd.oai.openapi+json;version=3.0",
                 "title": "OpenAPI service description",
-                "href": urljoin(base_url, request.app.openapi_url.lstrip("/")),
+                "href": urljoin(
+                    str(request.base_url), request.app.openapi_url.lstrip("/")
+                ),
             }
         )
 
@@ -574,7 +581,9 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
                 "rel": "service-doc",
                 "type": "text/html",
                 "title": "OpenAPI service documentation",
-                "href": urljoin(base_url, request.app.docs_url.lstrip("/")),
+                "href": urljoin(
+                    str(request.base_url), request.app.docs_url.lstrip("/")
+                ),
             }
         )
 

--- a/stac_fastapi/types/stac_fastapi/types/requests.py
+++ b/stac_fastapi/types/stac_fastapi/types/requests.py
@@ -1,0 +1,14 @@
+"""requests helpers."""
+
+from starlette.requests import Request
+
+
+def get_base_url(request: Request) -> str:
+    """Get base URL with respect of APIRouter prefix."""
+    app = request.app
+    if not app.state.router_prefix:
+        return str(request.base_url)
+    else:
+        return "{}{}/".format(
+            str(request.base_url), app.state.router_prefix.lstrip("/")
+        )


### PR DESCRIPTION
**Related Issue(s):** 

* https://github.com/stac-utils/stac-fastapi/issues/427

**Description:**

Add support for APIRouter prefix (pgstac backend only). 


**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
