### PR TITLE
add default CORS middleware

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -14,7 +14,7 @@ from stac_pydantic.version import STAC_VERSION
 from starlette.responses import JSONResponse, Response
 
 from stac_fastapi.api.errors import DEFAULT_STATUS_CODES, add_exception_handlers
-from stac_fastapi.api.middleware import ProxyHeaderMiddleware
+from stac_fastapi.api.middleware import CORSMiddleware, ProxyHeaderMiddleware
 from stac_fastapi.api.models import (
     APIRequest,
     CollectionUri,
@@ -93,7 +93,9 @@ class StacApi:
     pagination_extension = attr.ib(default=TokenPaginationExtension)
     response_class: Type[Response] = attr.ib(default=JSONResponse)
     middlewares: List = attr.ib(
-        default=attr.Factory(lambda: [BrotliMiddleware, ProxyHeaderMiddleware])
+        default=attr.Factory(
+            lambda: [BrotliMiddleware, CORSMiddleware, ProxyHeaderMiddleware]
+        )
     )
     route_dependencies: List[Tuple[List[Scope], List[Depends]]] = attr.ib(default=[])
 

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -1,10 +1,46 @@
 """api middleware."""
-
 import re
+import typing
 from http.client import HTTP_PORT, HTTPS_PORT
 from typing import List, Tuple
 
+from starlette.middleware.cors import CORSMiddleware as _CORSMiddleware
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+class CORSMiddleware(_CORSMiddleware):
+    """
+    Subclass of Starlette's standard CORS middleware with default values set to those reccomended by the STAC API spec.
+
+    https://github.com/radiantearth/stac-api-spec/blob/914cf8108302e2ec734340080a45aaae4859bb63/implementation.md#cors
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        allow_origins: typing.Sequence[str] = ("*",),
+        allow_methods: typing.Sequence[str] = (
+            "OPTIONS",
+            "POST",
+            "GET",
+        ),
+        allow_headers: typing.Sequence[str] = ("Content-Type",),
+        allow_credentials: bool = False,
+        allow_origin_regex: typing.Optional[str] = None,
+        expose_headers: typing.Sequence[str] = (),
+        max_age: int = 600,
+    ) -> None:
+        """Create CORS middleware."""
+        super().__init__(
+            app,
+            allow_origins,
+            allow_methods,
+            allow_headers,
+            allow_credentials,
+            allow_origin_regex,
+            expose_headers,
+            max_age,
+        )
 
 
 class ProxyHeaderMiddleware:


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #436

**Description:**
Adds a subclass of starlette's standard CORS middleware w/ defaults set to those recommended by the stac spec.  Added the CORS middleware to default set of middleware used by the application.


**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
