### PR TITLE
dont break on app startup when pagination extension is not included

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
   from the request body, if present, and falls back to using the path parameter if no `"collection"` property is found in the body
   ([#425](https://github.com/stac-utils/stac-fastapi/pull/425))
 * PGStac Backend Transactions endpoints return added Item/Collection instead of Item/Collection from request ([#424](https://github.com/stac-utils/stac-fastapi/pull/424))
+* Application no longer breaks on startup when pagination extension is not included ([#444](https://github.com/stac-utils/stac-fastapi/pull/444))
 
 ## [2.3.0]
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -275,11 +275,15 @@ class StacApi:
         Returns:
             None
         """
-        get_pagination_model = self.get_extension(self.pagination_extension).GET
+        is_paginated = self.get_extension(self.pagination_extension)
+        if is_paginated is not None:
+            mixins = [is_paginated.GET]
+        else:
+            mixins = None
         request_model = create_request_model(
             "ItemCollectionURI",
             base_model=ItemCollectionUri,
-            mixins=[get_pagination_model],
+            mixins=mixins,
         )
         self.router.add_api_route(
             name="Get ItemCollection",

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -275,9 +275,9 @@ class StacApi:
         Returns:
             None
         """
-        is_paginated = self.get_extension(self.pagination_extension)
-        if is_paginated is not None:
-            mixins = [is_paginated.GET]
+        pagination_extension = self.get_extension(self.pagination_extension)
+        if pagination_extension is not None:
+            mixins = [pagination_extension.GET]
         else:
             mixins = None
         request_model = create_request_model(


### PR DESCRIPTION
**Related Issue(s):** 

- closes #403

**Description:**
Fixes a bug where the application breaks on startup when pagination extension is not included.  Ran into this while writing tests for #441.

**PR Checklist:**
- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
