### PR TITLE
include stac_extensions when ingesting joplin test dataset

### DIFF
--- a/scripts/ingest_joplin.py
+++ b/scripts/ingest_joplin.py
@@ -41,7 +41,6 @@ def ingest_joplin_data(app_host: str = app_host, data_dir: Path = joplindata):
         index = json.load(f)
 
     for feat in index["features"]:
-        del feat["stac_extensions"]
         post_or_put(urljoin(app_host, f"collections/{collection['id']}/items"), feat)
 
 


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #122 

**Description:**
We used to delete `stac_extensions` before ingesting test data because of an issue in stac-pydantic which has since been fixed.

Confirmed this works by running `docker-compose up` and sending requests to both backends.

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
