### PR TITLE
replace ciso8601 with pyiso8601

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -85,7 +85,13 @@ jobs:
           cd stac_fastapi/api && pipenv run pytest -svvv
         env:
           ENVIRONMENT: testing
-      
+
+      - name: Run test suite
+        run: |
+          cd stac_fastapi/types && pipenv run pytest -svvv
+        env:
+          ENVIRONMENT: testing
+
       - name: Run test suite
         run: |
           cd stac_fastapi/sqlalchemy && pipenv run pytest -svvv

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ### Removed
 
 ### Fixed
+* `ciso8601` fails to build in some environments, instead use `pyiso8601` to parse datetimes.
 
 ## [2.4.0]
 

--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -11,7 +11,7 @@ install_requires = [
     "pydantic[dotenv]",
     "stac_pydantic==2.0.*",
     "pystac==1.*",
-    "ciso8601~=2.2.0",
+    "iso8601~=1.0.2",
 ]
 
 extra_reqs = {

--- a/stac_fastapi/types/stac_fastapi/types/rfc3339.py
+++ b/stac_fastapi/types/stac_fastapi/types/rfc3339.py
@@ -1,16 +1,18 @@
 """rfc3339."""
-
+import re
 from datetime import datetime, timezone
 from typing import Optional, Tuple
 
-import ciso8601
+import iso8601
 from pystac.utils import datetime_to_str
+
+RFC33339_PATTERN = r"^(\d\d\d\d)\-(\d\d)\-(\d\d)(T|t)(\d\d):(\d\d):(\d\d)([.]\d+)?(Z|([-+])(\d\d):(\d\d))$"
 
 
 def rfc3339_str_to_datetime(s: str) -> datetime:
     """Convert a string conforming to RFC 3339 to a :class:`datetime.datetime`.
 
-    Uses :meth:`ciso8601.parse_rfc3339` under the hood.
+    Uses :meth:`iso8601.parse_date` under the hood.
 
     Args:
         s (str) : The string to convert to :class:`datetime.datetime`.
@@ -21,7 +23,16 @@ def rfc3339_str_to_datetime(s: str) -> datetime:
     Raises:
         ValueError: If the string is not a valid RFC 3339 string.
     """
-    return ciso8601.parse_rfc3339(s)
+    # Uppercase the string
+    s = s.upper()
+
+    # Match against RFC3339 regex.
+    result = re.match(RFC33339_PATTERN, s)
+    if not result:
+        raise ValueError("Invalid RFC3339 datetime.")
+
+    # Parse with pyiso8601
+    return iso8601.parse_date(s)
 
 
 def str_to_interval(


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #447 

**Description:**
Replaces the ciso8601 dependency with pyiso8601, following validation logic recommended in the stac api [implementation guide](https://github.com/radiantearth/stac-api-spec/blob/master/implementation.md#datetime-parameter-handling):
- Upper case the date string.
- Match against the regex `^(\d\d\d\d)\-(\d\d)\-(\d\d)(T|t)(\d\d):(\d\d):(\d\d)([.]\d+)?(Z|([-+])(\d\d):(\d\d))$`
- Parse with pyiso8601.

The date parsing unittests are quite good and all pass with pyiso8601.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
