### PR TITLE
Improve separation of concerns between core and backend libraries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+tests
 docker-compose.yml
 **/__pycache__
 *.pyc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
       dockerfile: Dockerfile
     platform: linux/amd64
     volumes:
-      - ./stac_fastapi:/app/stac_fastapi
-      - ./scripts:/app/scripts
-      - ./tests:/app/tests
+      - ./stac_fastapi:/opt/src/stac_fastapi
+      - ./scripts:/opt/src/scripts
+      - ./tests:/opt/src/tests
     command:
       - bash
       - -c

--- a/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/app.py
@@ -205,7 +205,9 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=self._create_endpoint(
-                self.client.handle_post_search, self.search_post_request_model, GeoJSONResponse
+                self.client.handle_post_search,
+                self.search_post_request_model,
+                GeoJSONResponse,
             ),
         )
 
@@ -227,7 +229,9 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.handle_get_search, self.search_get_request_model, GeoJSONResponse
+                self.client.handle_get_search,
+                self.search_get_request_model,
+                GeoJSONResponse,
             ),
         )
 

--- a/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/app.py
@@ -143,7 +143,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.landing_page, EmptyRequest, self.response_class
+                self.client.handle_landing_page, EmptyRequest, self.response_class
             ),
         )
 
@@ -164,7 +164,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.conformance, EmptyRequest, self.response_class
+                self.client.handle_conformance, EmptyRequest, self.response_class
             ),
         )
 
@@ -183,7 +183,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.get_item, ItemUri, self.response_class
+                self.client.handle_get_item, ItemUri, self.response_class
             ),
         )
 
@@ -205,7 +205,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=self._create_endpoint(
-                self.client.post_search, self.search_post_request_model, GeoJSONResponse
+                self.client.handle_post_search, self.search_post_request_model, GeoJSONResponse
             ),
         )
 
@@ -227,7 +227,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.get_search, self.search_get_request_model, GeoJSONResponse
+                self.client.handle_get_search, self.search_get_request_model, GeoJSONResponse
             ),
         )
 
@@ -248,7 +248,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.all_collections, EmptyRequest, self.response_class
+                self.client.handle_all_collections, EmptyRequest, self.response_class
             ),
         )
 
@@ -267,7 +267,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.get_collection, CollectionUri, self.response_class
+                self.client.handle_get_collection, CollectionUri, self.response_class
             ),
         )
 
@@ -298,7 +298,7 @@ class StacApi:
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=self._create_endpoint(
-                self.client.item_collection, request_model, self.response_class
+                self.client.handle_collection_items, request_model, self.response_class
             ),
         )
 

--- a/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/core/transaction.py
@@ -91,7 +91,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["POST"],
-            endpoint=self._create_endpoint(self.client.create_item, PostItem),
+            endpoint=self._create_endpoint(self.client.handle_create_item, PostItem),
         )
 
     def register_update_item(self):
@@ -104,7 +104,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["PUT"],
-            endpoint=self._create_endpoint(self.client.update_item, PutItem),
+            endpoint=self._create_endpoint(self.client.handle_update_item, PutItem),
         )
 
     def register_delete_item(self):
@@ -117,7 +117,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["DELETE"],
-            endpoint=self._create_endpoint(self.client.delete_item, ItemUri),
+            endpoint=self._create_endpoint(self.client.handle_delete_item, ItemUri),
         )
 
     def register_create_collection(self):
@@ -131,7 +131,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=self._create_endpoint(
-                self.client.create_collection, stac_types.Collection
+                self.client.handle_create_collection, stac_types.Collection
             ),
         )
 
@@ -146,7 +146,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["PUT"],
             endpoint=self._create_endpoint(
-                self.client.update_collection, stac_types.Collection
+                self.client.handle_update_collection, stac_types.Collection
             ),
         )
 
@@ -161,7 +161,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["DELETE"],
             endpoint=self._create_endpoint(
-                self.client.delete_collection, CollectionUri
+                self.client.handle_delete_collection, CollectionUri
             ),
         )
 

--- a/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -57,7 +57,7 @@ class AsyncBaseBulkTransactionsClient(abc.ABC):
     """BulkTransactionsClient."""
 
     @abc.abstractmethod
-    async def bulk_item_insert(self, items: Items, **kwargs) -> str:
+    async def handle_bulk_item_insert(self, items: Items, **kwargs) -> str:
         """Bulk creation of items.
 
         Args:

--- a/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -36,7 +36,7 @@ class BaseBulkTransactionsClient(abc.ABC):
             yield lst[i : i + n]
 
     @abc.abstractmethod
-    def bulk_item_insert(
+    def handle_bulk_item_insert(
         self, items: Items, chunk_size: Optional[int] = None, **kwargs
     ) -> str:
         """Bulk creation of items.
@@ -125,7 +125,7 @@ class BulkTransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=self._create_endpoint(
-                self.client.bulk_item_insert, items_request_model
+                self.client.handle_bulk_item_insert, items_request_model
             ),
         )
         app.include_router(router, tags=["Bulk Transaction Extension"])

--- a/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/core.py
@@ -27,7 +27,7 @@ class BaseTransactionsClient(abc.ABC):
     """Defines a pattern for implementing the STAC API Transaction Extension."""
 
     @abc.abstractmethod
-    def create_item(
+    def handle_create_item(
         self, collection_id: str, item: stac_types.Item, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Create a new item.
@@ -45,7 +45,7 @@ class BaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def update_item(
+    def handle_update_item(
         self, collection_id: str, item_id: str, item: stac_types.Item, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Perform a complete update on an existing item.
@@ -64,7 +64,7 @@ class BaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def delete_item(
+    def handle_delete_item(
         self, item_id: str, collection_id: str, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
@@ -81,7 +81,7 @@ class BaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def create_collection(
+    def handle_create_collection(
         self, collection: stac_types.Collection, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
@@ -97,7 +97,7 @@ class BaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def update_collection(
+    def handle_update_collection(
         self, collection: stac_types.Collection, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Perform a complete update on an existing collection.
@@ -116,7 +116,7 @@ class BaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def delete_collection(
+    def handle_delete_collection(
         self, collection_id: str, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete a collection.
@@ -137,7 +137,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     """Defines a pattern for implementing the STAC transaction extension."""
 
     @abc.abstractmethod
-    async def create_item(
+    async def handle_create_item(
         self, collection_id: str, item: stac_types.Item, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Create a new item.
@@ -154,7 +154,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def update_item(
+    async def handle_update_item(
         self, collection_id: str, item_id: str, item: stac_types.Item, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Perform a complete update on an existing item.
@@ -172,7 +172,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def delete_item(
+    async def handle_delete_item(
         self, item_id: str, collection_id: str, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
@@ -189,7 +189,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def create_collection(
+    async def handle_create_collection(
         self, collection: stac_types.Collection, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
@@ -205,7 +205,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def update_collection(
+    async def handle_update_collection(
         self, collection: stac_types.Collection, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Perform a complete update on an existing collection.
@@ -223,7 +223,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def delete_collection(
+    async def handle_delete_collection(
         self, collection_id: str, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete a collection.
@@ -341,7 +341,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
 
         return base_conformance
 
-    def landing_page(self, **kwargs) -> stac_types.LandingPage:
+    def handle_landing_page(self, **kwargs) -> stac_types.LandingPage:
         """Landing page.
 
         Called with `GET /`.
@@ -361,7 +361,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         )
 
         # Add Collections links
-        collections = self.all_collections(request=kwargs["request"])
+        collections = self.handle_all_collections(request=kwargs["request"])
         for collection in collections["collections"]:
             landing_page["links"].append(
                 {
@@ -398,7 +398,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
 
         return landing_page
 
-    def conformance(self, **kwargs) -> stac_types.Conformance:
+    def handle_conformance(self, **kwargs) -> stac_types.Conformance:
         """Conformance classes.
 
         Called with `GET /conformance`.
@@ -409,7 +409,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         return Conformance(conformsTo=self.conformance_classes())
 
     @abc.abstractmethod
-    def post_search(
+    def handle_post_search(
         self, search_request: BaseSearchPostRequest, **kwargs
     ) -> stac_types.ItemCollection:
         """Cross catalog search (POST).
@@ -425,7 +425,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_search(
+    def handle_get_search(
         self,
         collections: Optional[List[str]] = None,
         ids: Optional[List[str]] = None,
@@ -448,7 +448,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_item(self, item_id: str, collection_id: str, **kwargs) -> stac_types.Item:
+    def handle_get_item(self, item_id: str, collection_id: str, **kwargs) -> stac_types.Item:
         """Get item by id.
 
         Called with `GET /collections/{collection_id}/items/{item_id}`.
@@ -463,7 +463,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def all_collections(self, **kwargs) -> stac_types.Collections:
+    def handle_all_collections(self, **kwargs) -> stac_types.Collections:
         """Get all available collections.
 
         Called with `GET /collections`.
@@ -474,7 +474,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_collection(self, collection_id: str, **kwargs) -> stac_types.Collection:
+    def handle_get_collection(self, collection_id: str, **kwargs) -> stac_types.Collection:
         """Get collection by id.
 
         Called with `GET /collections/{collection_id}`.
@@ -488,7 +488,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    def item_collection(
+    def handle_collection_items(
         self, collection_id: str, limit: int = 10, token: str = None, **kwargs
     ) -> stac_types.ItemCollection:
         """Get all items from a specific collection.
@@ -534,7 +534,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         """Check if an api extension is enabled."""
         return any([type(ext).__name__ == extension for ext in self.extensions])
 
-    async def landing_page(self, **kwargs) -> stac_types.LandingPage:
+    async def handle_landing_page(self, **kwargs) -> stac_types.LandingPage:
         """Landing page.
 
         Called with `GET /`.
@@ -552,7 +552,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
             conformance_classes=self.conformance_classes(),
             extension_schemas=extension_schemas,
         )
-        collections = await self.all_collections(request=kwargs["request"])
+        collections = await self.handle_all_collections(request=kwargs["request"])
         for collection in collections["collections"]:
             landing_page["links"].append(
                 {
@@ -589,7 +589,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
 
         return landing_page
 
-    async def conformance(self, **kwargs) -> stac_types.Conformance:
+    async def handle_conformance(self, **kwargs) -> stac_types.Conformance:
         """Conformance classes.
 
         Called with `GET /conformance`.
@@ -600,7 +600,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         return Conformance(conformsTo=self.conformance_classes())
 
     @abc.abstractmethod
-    async def post_search(
+    async def handle_post_search(
         self, search_request: BaseSearchPostRequest, **kwargs
     ) -> stac_types.ItemCollection:
         """Cross catalog search (POST).
@@ -616,7 +616,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def get_search(
+    async def handle_get_search(
         self,
         collections: Optional[List[str]] = None,
         ids: Optional[List[str]] = None,
@@ -639,7 +639,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def get_item(
+    async def handle_get_item(
         self, item_id: str, collection_id: str, **kwargs
     ) -> stac_types.Item:
         """Get item by id.
@@ -656,7 +656,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def all_collections(self, **kwargs) -> stac_types.Collections:
+    async def handle_all_collections(self, **kwargs) -> stac_types.Collections:
         """Get all available collections.
 
         Called with `GET /collections`.
@@ -667,7 +667,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def get_collection(
+    async def handle_get_collection(
         self, collection_id: str, **kwargs
     ) -> stac_types.Collection:
         """Get collection by id.
@@ -683,7 +683,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def item_collection(
+    async def handle_collection_items(
         self, collection_id: str, limit: int = 10, token: str = None, **kwargs
     ) -> stac_types.ItemCollection:
         """Get all items from a specific collection.

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,9 +1,11 @@
-from fastapi import Depends, HTTPException, security, status
+from typing import List
+
+from fastapi import Depends, HTTPException, security, status, Request
 from starlette.testclient import TestClient
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.extensions.core import TokenPaginationExtension, TransactionExtension
-from stac_fastapi.types import config, core
+from stac_fastapi.types import config, core, stac as stac_types
 
 
 class TestRouteDependencies:
@@ -77,7 +79,7 @@ class TestRouteDependencies:
 
 
 class DummyCoreClient(core.BaseCoreClient):
-    def handle_all_collections(self, *args, **kwargs):
+    def list_all_collections(self, request: Request) -> List[stac_types.Collection]:
         ...
 
     def handle_get_collection(self, *args, **kwargs):

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -77,44 +77,44 @@ class TestRouteDependencies:
 
 
 class DummyCoreClient(core.BaseCoreClient):
-    def all_collections(self, *args, **kwargs):
+    def handle_all_collections(self, *args, **kwargs):
         ...
 
-    def get_collection(self, *args, **kwargs):
+    def handle_get_collection(self, *args, **kwargs):
         ...
 
-    def get_item(self, *args, **kwargs):
+    def handle_get_item(self, *args, **kwargs):
         ...
 
-    def get_search(self, *args, **kwargs):
+    def handle_get_search(self, *args, **kwargs):
         ...
 
-    def post_search(self, *args, **kwargs):
+    def handle_post_search(self, *args, **kwargs):
         ...
 
-    def item_collection(self, *args, **kwargs):
+    def handle_collection_items(self, *args, **kwargs):
         ...
 
 
 class DummyTransactionsClient(core.BaseTransactionsClient):
     """Defines a pattern for implementing the STAC transaction extension."""
 
-    def create_item(self, *args, **kwargs):
+    def handle_create_item(self, *args, **kwargs):
         return "dummy response"
 
-    def update_item(self, *args, **kwargs):
+    def handle_update_item(self, *args, **kwargs):
         return "dummy response"
 
-    def delete_item(self, *args, **kwargs):
+    def handle_delete_item(self, *args, **kwargs):
         return "dummy response"
 
-    def create_collection(self, *args, **kwargs):
+    def handle_create_collection(self, *args, **kwargs):
         return "dummy response"
 
-    def update_collection(self, *args, **kwargs):
+    def handle_update_collection(self, *args, **kwargs):
         return "dummy response"
 
-    def delete_collection(self, *args, **kwargs):
+    def handle_delete_collection(self, *args, **kwargs):
         return "dummy response"
 
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,11 +1,12 @@
 from typing import List
 
-from fastapi import Depends, HTTPException, security, status, Request
+from fastapi import Depends, HTTPException, Request, security, status
 from starlette.testclient import TestClient
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.extensions.core import TokenPaginationExtension, TransactionExtension
-from stac_fastapi.types import config, core, stac as stac_types
+from stac_fastapi.types import config, core
+from stac_fastapi.types import stac as stac_types
 
 
 class TestRouteDependencies:


### PR DESCRIPTION
**Related Issue(s):** 

- [#432(comment)](https://github.com/stac-utils/stac-fastapi/issues/432#issuecomment-1210024475)

**Description:**

Demonstrates one approach for creating a clearer separation of concerns between the core `stac-fastapi` package and the backend packages like `stac-fastapi.pgstac`. This draft targets the landing page and collections endpoints to demonstrate the approach; if we decide to go this route, we should apply this to all other route handlers as well.

The general approach is as follows:

- Any methods on the `*BaseCoreClient` classes that are used directly as route handlers have been renamed with a `handle_` prefix. These will be concrete methods defined in this library responsible for parsing the request, calling the appropriate backend method(s), and constructing the response.
- New abstract methods have been created that must be implemented in the backend packages. These methods are all prefixed with `fetch_` and are responsible for fetching the appropriate objects from the database or other backend. These methods have well-defined, typed inputs rather than accepting arbitrary `**kwargs`.

This approach should make it easier to handle all of the logic around constructing links, conformance classes, and other API-layer concerns in this package, ensuring that responses are consistent across the different backends.

Some future TODOs:

- Having more consistent type annotations and type checking in this package would make it easier to ensure that backend applications are implementing methods correctly. This seems out of scope for this PR, but I can start implementing this once this and #450 have been resolved.
- We may want to go one step further and have the `fetch_` and `handle_` methods in separate classes or mixins. My preference for this draft was to focus on the functional changes and leave that kind of structural refactor to a later PR, but I can always experiment with changing the class structure if we decide we want that right away.

I will open a PR in the `stac-fastapi-pgstac` repo to demonstrate the corresponding changes in that backend.

**EDIT:** Note that this PR is against the `remove/backend-packages` branch instead of `master` to simplify the changes. Once #450 has been merged we can update this to use `master` as the base.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
