### PR TITLE
Add 'servers' and 'description' in OpenAPI

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -334,7 +334,11 @@ class StacApi:
             return self.app.openapi_schema
 
         openapi_schema = get_openapi(
-            title=self.title, version=self.api_version, routes=self.app.routes
+            title=self.title,
+            version=self.api_version,
+            description=self.description,
+            routes=self.app.routes,
+            servers=self.app.servers,
         )
 
         self.app.openapi_schema = openapi_schema


### PR DESCRIPTION
**Related Issue(s):** 
- #454

**Description:**
Add the `servers` and `description` fields to the custom OpenAPI. The `servers` field is especially useful to allow running the application behind a reverse proxy and using the `root_path` setting in FastAPI.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
