### PR TITLE
Locked pygeoif==0.7

### DIFF
--- a/stac_fastapi/pgstac/setup.py
+++ b/stac_fastapi/pgstac/setup.py
@@ -18,6 +18,7 @@ install_requires = [
     "brotli_asgi",
     "pygeofilter>=0.1,<0.2",
     "pypgstac==0.6.*",
+    "pygeoif==0.7",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
**Related Issue(s):** 

- No longer working after pygeoif released version 1.0.0

**Description:**

Just yesterday (29 Sep 2022) pygeoif released version 1.0.0
All other version before 0.7 (May 4, 2017) were PRE-RELEASE so pip didn't install them.
Version 1.0.0 throws the following error:
![image](https://user-images.githubusercontent.com/17437897/193254190-278f9ccf-4e69-49d9-946a-9324367080a1.png)
The issue is fixed for now by locking the pygeoif to version 0.7
![image](https://user-images.githubusercontent.com/17437897/193254311-845f4eca-5eef-4a1e-9d94-de0bca533544.png)




**PR Checklist:**

- [ x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ x] Tests pass (run `make test`)
- [ x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
