### PR TITLE
Queryables 404 for non-existent collection ids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,13 +5,16 @@
 ### Added
 
 * Add support in pgstac backend for /queryables and /collections/{collection_id}/queryables endpoints with functions exposed in pgstac 0.6.8
-* Update pgstac requirement to 0.6.8
+* Update pgstac requirement to 0.6.10
 
 ### Changed
 
 ### Removed
 
 ### Fixed
+
+* Fix pgstac backend for /queryables endpoint to return 404 for non-existent collections [#482](https://github.com/stac-utils/stac-fastapi/pull/482)
+
 
 ## [2.4.2]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
 
   database:
     container_name: stac-db
-    image: ghcr.io/stac-utils/pgstac:v0.6.8
+    image: ghcr.io/stac-utils/pgstac:v0.6.10
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/extensions/filter.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/extensions/filter.py
@@ -6,6 +6,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 
 from stac_fastapi.types.core import AsyncBaseFiltersClient
+from stac_fastapi.types.errors import NotFoundError
 
 
 class FiltersClient(AsyncBaseFiltersClient):
@@ -32,6 +33,9 @@ class FiltersClient(AsyncBaseFiltersClient):
                 collection=collection_id,
             )
             queryables = await conn.fetchval(q, *p)
+            if not queryables:
+                raise NotFoundError(f"Collection {collection_id} not found")
+
             queryables["$id"] = str(request.url)
             headers = {"Content-Type": "application/schema+json"}
             return JSONResponse(queryables, headers=headers)

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -415,3 +415,11 @@ async def test_collection_queryables(load_test_data, app_client, load_test_colle
     assert "properties" in q
     assert "id" in q["properties"]
     assert "eo:cloud_cover" in q["properties"]
+
+
+@pytest.mark.asyncio
+async def test_bad_collection_queryables(
+    load_test_data, app_client, load_test_collection
+):
+    resp = await app_client.get("/collections/bad-collection/queryables")
+    assert resp.status_code == 404


### PR DESCRIPTION
**Related Issue(s):** 

- #481 
- https://github.com/stac-utils/pgstac/pull/145

**Description:**
Return a not-found response if pgstac does not return a queryable object when passed a non-existing collection id.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
