### PR TITLE
Ensure items endpoint is geojson

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 ### Fixed
 
 * Fix pgstac backend for /queryables endpoint to return 404 for non-existent collections [#482](https://github.com/stac-utils/stac-fastapi/pull/482)
-
+* /collection/{collection_id}/items endpoints now return geojson media type [#488](https://github.com/stac-utils/stac-fastapi/pull/488)
 
 ## [2.4.2]
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -273,12 +273,12 @@ class StacApi:
             response_model=ItemCollection
             if self.settings.enable_response_models
             else None,
-            response_class=self.response_class,
+            response_class=GeoJSONResponse,
             response_model_exclude_unset=True,
             response_model_exclude_none=True,
             methods=["GET"],
             endpoint=create_async_endpoint(
-                self.client.item_collection, request_model, self.response_class
+                self.client.item_collection, request_model, GeoJSONResponse
             ),
         )
 

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -43,6 +43,12 @@ async def test_get_queryables_content_type(app_client, load_test_collection):
     assert resp.headers["content-type"] == "application/schema+json"
 
 
+async def test_get_features_content_type(app_client, load_test_collection):
+    coll = load_test_collection
+    resp = await app_client.get(f"collections/{coll.id}/items")
+    assert resp.headers["content-type"] == "application/geo+json"
+
+
 async def test_api_headers(app_client):
     resp = await app_client.get("/api")
     assert (

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -434,3 +434,9 @@ def test_app_search_response_duplicate_forwarded_headers(
     for feature in resp.json()["features"]:
         for link in feature["links"]:
             assert link["href"].startswith("https://testserver:1234/")
+
+
+async def test_get_features_content_type(app_client, load_test_data):
+    item = load_test_data("test_item.json")
+    resp = await app_client.get(f"collections/{item['collection']}/items")
+    assert resp.headers["content-type"] == "application/geo+json"


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #484

**Description:**

Use GeoJSON media type for `/collection/{collection_id}/items` endpoint. Includes tests for both backends.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
