### PR TITLE
Add 3.11 to test matrix

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10']
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
     timeout-minutes: 10
 
     services:


### PR DESCRIPTION
The package manifests specify support for any version 3.8>= but 3.11 is missing from the test matrix.

This will run the tests on Python 3.11