### PR TITLE
Add nginx service as second docker-compose stack

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Nginx service as second docker-compose stack to demonstrate proxy ([#503](https://github.com/stac-utils/stac-fastapi/pull/503))
 * Validation checks in CI using [stac-api-validator](github.com/stac-utils/stac-api-validator) ([#508](https://github.com/stac-utils/stac-fastapi/pull/508))
 * Required links to the sqlalchemy ItemCollection endpoint ([#508](https://github.com/stac-utils/stac-fastapi/pull/508))
 * Publication of docker images to GHCR ([#525](https://github.com/stac-utils/stac-fastapi/pull/525))

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ docker-run-sqlalchemy: image
 docker-run-pgstac: image
 	$(run_pgstac)
 
+.PHONY: docker-run-nginx-proxy
+docker-run-nginx-proxy:
+	docker-compose -f docker-compose.yml -f docker-compose.nginx.yml up
+
 .PHONY: docker-shell-sqlalchemy
 docker-shell-sqlalchemy:
 	$(run_sqlalchemy) /bin/bash

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD033 MD041 -->
+
 <p align="center">
   <img src="https://github.com/radiantearth/stac-site/raw/master/images/logo/stac-030-long.png" width=400>
   <p align="center">FastAPI implemention of the STAC API spec.</p>
@@ -101,7 +103,23 @@ The application will be started on <http://localhost:8080>.
 By default, the apps are run with uvicorn hot-reloading enabled. This can be turned off by changing the value
 of the `RELOAD` env var in docker-compose.yml to `false`.
 
-#### Note to Docker for Windows users
+### nginx proxy
+
+This repo includes an example nginx proxy service.
+To start:
+
+```shell
+make docker-run-nginx-proxy
+```
+
+The proxy will be started on <http://localhost>, with the pgstac app available at <http://localhost/api/v1/pgstac/> and the sqlalchemy app at <http://localhost/api/v1/sqlalchemy/>.
+If you need to customize the proxy port, use the `STAC_FASTAPI_NGINX_PORT` environment variable:
+
+```shell
+STAC_FASTAPI_NGINX_PORT=7822 make docker-run-nginx-proxy
+```
+
+### Note to Docker for Windows users
 
 You'll need to enable experimental features on Docker for Windows in order to run the docker-compose,
 due to the "--platform" flag that is required to allow the project to run on some Apple architectures.

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  nginx:
+    image: nginx
+    ports:
+      - ${STAC_FASTAPI_NGINX_PORT:-80}:80
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - app-pgstac
+      - app-sqlalchemy
+    command: [ "nginx-debug", "-g", "daemon off;" ]
+  app-pgstac:
+    environment:
+      - UVICORN_ROOT_PATH=/api/v1/pgstac
+  app-sqlalchemy:
+    environment:
+      - UVICORN_ROOT_PATH=/api/v1/sqlalchemy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,5 @@
 version: '3'
 services:
-  nginx:
-    image: nginx
-    ports:
-      - ${STAC_FASTAPI_NGINX_PORT:-80}:80
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf
-    depends_on:
-      - app-pgstac
-      - app-sqlalchemy
-    command: ["nginx-debug", "-g", "daemon off;"]
-
   app-sqlalchemy:
     container_name: stac-fastapi-sqlalchemy
     image: stac-utils/stac-fastapi
@@ -30,7 +19,6 @@ services:
       - POSTGRES_HOST_WRITER=database
       - POSTGRES_PORT=5432
       - WEB_CONCURRENCY=10
-      - UVICORN_ROOT_PATH=/api/v1/sqlalchemy
     ports:
       - "8081:8081"
     volumes:
@@ -62,7 +50,6 @@ services:
       - DB_MIN_CONN_SIZE=1
       - DB_MAX_CONN_SIZE=1
       - USE_API_HYDRATE=${USE_API_HYDRATE:-false}
-      - UVICORN_ROOT_PATH=/api/v1/pgstac
     ports:
       - "8082:8082"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,16 @@
 version: '3'
 services:
+  nginx:
+    image: nginx
+    ports:
+      - 80:80
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    depends_on:
+      - app-pgstac
+      - app-sqlalchemy
+    command: ["nginx-debug", "-g", "daemon off;"]
+
   app-sqlalchemy:
     container_name: stac-fastapi-sqlalchemy
     image: stac-utils/stac-fastapi
@@ -19,6 +30,7 @@ services:
       - POSTGRES_HOST_WRITER=database
       - POSTGRES_PORT=5432
       - WEB_CONCURRENCY=10
+      - UVICORN_ROOT_PATH=/api/v1/sqlalchemy
     ports:
       - "8081:8081"
     volumes:
@@ -50,6 +62,7 @@ services:
       - DB_MIN_CONN_SIZE=1
       - DB_MAX_CONN_SIZE=1
       - USE_API_HYDRATE=${USE_API_HYDRATE:-false}
+      - UVICORN_ROOT_PATH=/api/v1/pgstac
     ports:
       - "8082:8082"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   nginx:
     image: nginx
     ports:
-      - 80:80
+      - ${STAC_FASTAPI_NGINX_PORT:-80}:80
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
     depends_on:

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,29 @@
+events {}
+
+http {
+    server {
+        listen   80;
+
+        location /api/v1/pgstac {
+            rewrite ^/api/v1/pgstac(.*)$ $1 break;
+            proxy_pass http://app-pgstac:8082;
+            proxy_set_header HOST $host;
+            proxy_set_header Referer $http_referer;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /api/v1/sqlalchemy {
+            rewrite ^/api/v1/sqlalchemy(.*)$ $1 break;
+            proxy_pass http://app-sqlalchemy:8081;
+            proxy_set_header HOST $host;
+            proxy_set_header Referer $http_referer;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            proxy_redirect off;
+        }
+    }
+}

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py
@@ -88,6 +88,7 @@ def run():
             port=settings.app_port,
             log_level="info",
             reload=settings.reload,
+            root_path=os.getenv("UVICORN_ROOT_PATH", ""),
         )
     except ImportError:
         raise RuntimeError("Uvicorn must be installed in order to use command")

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/app.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/app.py
@@ -1,4 +1,6 @@
 """FastAPI application."""
+import os
+
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
 from stac_fastapi.extensions.core import (
@@ -55,6 +57,7 @@ def run():
             port=settings.app_port,
             log_level="info",
             reload=settings.reload,
+            root_path=os.getenv("UVICORN_ROOT_PATH", ""),
         )
     except ImportError:
         raise RuntimeError("Uvicorn must be installed in order to use command")


### PR DESCRIPTION
**Related Issue(s):** 

- #454
- #489
- #497

**Description:**
Adds a NGINX container to the docker-compose stack to help debug issues with root paths and link resolution when running the application behind a proxy; and to serve as a minimal reference example for how proxies should be configured.  The NGINX server runs on port `80` and proxies both backends behind the `/api/v1/pgstac` and `/api/v1/sqlalchemy` endpoints, root paths are set accordingly in each application.  I added the `UVICORN_ROOT_PATH` environment variable to expose uvicorn's root path argument without rewriting docker commands.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
