### PR TITLE
Allow url encoded queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+* Allow url encoded values for `query` in GET requests ([#504](https://github.com/stac-utils/stac-fastapi/pull/504))
+
 ## [2.4.3]
 
 ### Added
@@ -21,7 +23,6 @@
 ### Removed
 
 ### Fixed
-
 
 ## [2.4.2]
 

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -2,7 +2,7 @@
 import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
-from urllib.parse import urljoin
+from urllib.parse import unquote_plus, urljoin
 
 import attr
 import orjson
@@ -372,7 +372,7 @@ class CoreCrudClient(AsyncBaseCoreClient):
             "bbox": bbox,
             "limit": limit,
             "token": token,
-            "query": orjson.loads(query) if query else query,
+            "query": orjson.loads(unquote_plus(query)) if query else query,
         }
 
         if filter:

--- a/stac_fastapi/pgstac/tests/api/test_api.py
+++ b/stac_fastapi/pgstac/tests/api/test_api.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
+from urllib.parse import quote_plus
 
+import orjson
 import pytest
 
 STAC_CORE_ROUTES = [
@@ -98,6 +100,12 @@ async def test_app_query_extension(load_test_data, app_client, load_test_collect
 
     params = {"query": {"proj:epsg": {"eq": item["properties"]["proj:epsg"]}}}
     resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 1
+
+    params["query"] = quote_plus(orjson.dumps(params["query"]))
+    resp = await app_client.get("/search", params=params)
     assert resp.status_code == 200
     resp_json = resp.json()
     assert len(resp_json["features"]) == 1

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -4,7 +4,7 @@ import logging
 import operator
 from datetime import datetime
 from typing import List, Optional, Set, Type, Union
-from urllib.parse import urlencode, urljoin
+from urllib.parse import unquote_plus, urlencode, urljoin
 
 import attr
 import geoalchemy2 as ga
@@ -243,7 +243,7 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
             "bbox": bbox,
             "limit": limit,
             "token": token,
-            "query": json.loads(query) if query else query,
+            "query": json.loads(unquote_plus(query)) if query else query,
         }
 
         if datetime:

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -1,4 +1,7 @@
 from datetime import datetime, timedelta
+from urllib.parse import quote_plus
+
+import orjson
 
 from ..conftest import MockStarletteRequest
 
@@ -146,6 +149,12 @@ def test_app_query_extension_gt(load_test_data, app_client, postgres_transaction
 
     params = {"query": {"proj:epsg": {"gt": test_item["properties"]["proj:epsg"]}}}
     resp = app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 0
+
+    params["query"] = quote_plus(orjson.dumps(params["query"]))
+    resp = app_client.get("/search", params=params)
     assert resp.status_code == 200
     resp_json = resp.json()
     assert len(resp_json["features"]) == 0


### PR DESCRIPTION
**Related Issue(s):** 

- Discovered in https://github.com/stac-utils/pystac-client/pull/362

**Description:**

Currently `query` in GET requests does not support url-encoded values. This fixes for both backends.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
