### PR TITLE
Correct path in register_update_item docstring

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 * Allow url encoded values for `query` in GET requests ([#504](https://github.com/stac-utils/stac-fastapi/pull/504))
+* Fix path in `register_update_item` docstring ([507](https://github.com/stac-utils/stac-fastapi/pull/507))
 
 ## [2.4.3]
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -73,7 +73,7 @@ class TransactionExtension(ApiExtension):
         )
 
     def register_update_item(self):
-        """Register update item endpoint (PUT /collections/{collection_id}/items)."""
+        """Register update item endpoint (PUT /collections/{collection_id}/items/{item_id})."""
         self.router.add_api_route(
             name="Update Item",
             path="/collections/{collection_id}/items/{item_id}",


### PR DESCRIPTION
**Description:**

The docstring for the transaction extension's `register_update_item` function lists an incomplete path:

>(PUT /collections/{collection_id}/items)

vs

`"/collections/{collection_id}/items/{item_id}"`

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
