### PR TITLE
Update pgstac to v0.6.12

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,27 +1,30 @@
 name: stac-fastapi
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10"]
     timeout-minutes: 10
 
     services:
       db_service:
-        image: bitner/pgstac:0.2.7
+        image: ghcr.io/stac-utils/pgstac:v0.6.12
         env:
           POSTGRES_USER: username
           POSTGRES_PASSWORD: password
           POSTGRES_DB: postgis
           POSTGRES_HOST: localhost
           POSTGRES_PORT: 5432
+          PGUSER: username
+          PGPASSWORD: password
+          PGDATABASE: postgis
           ALLOW_IP_RANGE: 0.0.0.0/0
         # Set health checks to wait until postgres has started
         options: >-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+* Updated CI to test against [pgstac v0.6.12](https://github.com/stac-utils/pgstac/releases/tag/v0.6.12) ([#511](https://github.com/stac-utils/stac-fastapi/pull/511))
+
 ### Removed
 
 ### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,7 @@ services:
       - ./scripts:/app/scripts
     depends_on:
       - database
-    command:
-      bash -c "./scripts/wait-for-it.sh database:5432 && python -m stac_fastapi.sqlalchemy.app"
+    command: bash -c "./scripts/wait-for-it.sh database:5432 && python -m stac_fastapi.sqlalchemy.app"
 
   app-pgstac:
     container_name: stac-fastapi-pgstac
@@ -58,12 +57,11 @@ services:
       - ./scripts:/app/scripts
     depends_on:
       - database
-    command:
-      bash -c "./scripts/wait-for-it.sh database:5432 && python -m stac_fastapi.pgstac.app"
+    command: bash -c "./scripts/wait-for-it.sh database:5432 && python -m stac_fastapi.pgstac.app"
 
   database:
     container_name: stac-db
-    image: ghcr.io/stac-utils/pgstac:v0.6.10
+    image: ghcr.io/stac-utils/pgstac:v0.6.12
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
**Related Issue(s):** 

- Might unblock #500

**Description:**

We have a floating v0.6.* dependency in code, but our CI contains deps on (two different) older pgstac versions. This commit updates those references to point to https://github.com/stac-utils/pgstac/releases/tag/v0.6.12, and contains some sidecar yaml linting.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
