### PR TITLE
Refactor backend-specific clients to use a new `Backend` interface

### DIFF
--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/backend.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/backend.py
@@ -1,0 +1,95 @@
+"""Asynchronous backend for pgstac."""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import buildpg
+from asyncpg.exceptions import InvalidDatetimeFormatError
+from starlette.datastructures import State
+
+from stac_fastapi.types.backend import AsyncBackend
+from stac_fastapi.types.errors import InvalidQueryParameter
+from stac_fastapi.types.links import PaginationLinks
+from stac_fastapi.types.search import BaseSearchPostRequest
+from stac_fastapi.types.stac import Collection, ItemCollection
+
+
+class PgstacBackend(AsyncBackend):
+    """An asynchronous backend for pgstac."""
+
+    async def all_collections(state: State) -> List[Collection]:
+        """Get all collections."""
+        pool = state.readpool
+        async with pool.acquire() as conn:
+            collections = await conn.fetchval(
+                """
+                SELECT * FROM all_collections();
+                """
+            )
+        if collections is None:
+            return list()
+        else:
+            return [Collection(**collection) for collection in collections]
+
+    async def get_collection(state: State, collection_id: str) -> Optional[Collection]:
+        """Get a single collection."""
+        pool = state.readpool
+        async with pool.acquire() as conn:
+            q, p = buildpg.render(
+                """
+                SELECT * FROM get_collection(:id::text);
+                """,
+                id=collection_id,
+            )
+            collection = await conn.fetchval(q, *p)
+        if collection is None:
+            return None
+        else:
+            return Collection(**collection)
+
+    async def search_post(
+        state: State, search_request: BaseSearchPostRequest
+    ) -> Tuple[ItemCollection, PaginationLinks]:
+        """Search the database."""
+        items: Dict[str, Any]
+        req = search_request.json(exclude_none=True, by_alias=True)
+        pool = state.readpool
+        try:
+            async with pool.acquire() as conn:
+                q, p = buildpg.render(
+                    """
+                    SELECT * FROM search(:req::text::jsonb);
+                    """,
+                    req=req,
+                )
+                items = await conn.fetchval(q, *p)
+        except InvalidDatetimeFormatError:
+            raise InvalidQueryParameter(
+                f"Datetime parameter {search_request.datetime} is invalid."
+            )
+
+        def make_query_dict(name: str) -> Optional[Dict[str, str]]:
+            value = items.pop(name, None)
+            if value is None:
+                return None
+            else:
+                return {"token": f"{name}:{value}"}
+
+        next = make_query_dict("next")
+        prev = make_query_dict("prev")
+        pagination_links = PaginationLinks.from_dicts(next=next, prev=prev)
+
+        return (ItemCollection(**items), pagination_links)
+
+    async def get_base_item(
+        state: State, collection_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Get the base item from the database."""
+        pool = state.readpool
+        async with pool.acquire() as conn:
+            q, p = buildpg.render(
+                """
+                SELECT * FROM collection_base_item(:collection_id::text);
+                """,
+                collection_id=collection_id,
+            )
+            return await conn.fetchval(q, *p)

--- a/stac_fastapi/types/stac_fastapi/types/backend.py
+++ b/stac_fastapi/types/stac_fastapi/types/backend.py
@@ -1,0 +1,35 @@
+"""Storage backends for stac-fastapi.
+
+Backends are used to fetch data for a client. They intentionally have
+restrictive method signatures in order to enforce separation of responsibilities
+between backends and clients.
+"""
+
+from abc import ABC, abstractclassmethod
+from typing import List, Optional
+
+from starlette.datastructures import State
+
+from stac_fastapi.types.search import BaseSearchPostRequest
+from stac_fastapi.types.stac import Collection, ItemCollection
+
+
+class AsyncBackend(ABC):
+    """An asynchronous backend."""
+
+    @abstractclassmethod
+    async def all_collections(state: State) -> List[Collection]:
+        """Get all collections."""
+        ...
+
+    @abstractclassmethod
+    async def get_collection(state: State, collection_id: str) -> Optional[Collection]:
+        """Get a single collection by id."""
+        ...
+
+    @abstractclassmethod
+    async def search_post(
+        state: State, search: BaseSearchPostRequest
+    ) -> ItemCollection:
+        """Search the backend for items using a search POST request model."""
+        ...

--- a/stac_fastapi/types/stac_fastapi/types/links.py
+++ b/stac_fastapi/types/stac_fastapi/types/links.py
@@ -1,6 +1,6 @@
 """link helpers."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
 import attr
@@ -108,3 +108,39 @@ class ItemLinks(BaseLinks):
             self.root(),
         ]
         return links
+
+
+@attr.s
+class UnresolvedLink:
+    """An resolved link."""
+
+    query: Dict[str, str] = attr.ib()
+    extra_fields: Dict[str, Any] = attr.ib()
+
+    @classmethod
+    def from_opt_dict(
+        cls, maybe_query: Optional[Dict[str, str]]
+    ) -> Optional["UnresolvedLink"]:
+        """Create an unresolved link from an optional query dictionary."""
+        if maybe_query is None:
+            return None
+        else:
+            return UnresolvedLink(query=maybe_query, extra_fields={})
+
+
+@attr.s
+class PaginationLinks:
+    """Unresolved links for pagination."""
+
+    next: Optional[UnresolvedLink] = attr.ib()
+    prev: Optional[UnresolvedLink] = attr.ib()
+
+    @classmethod
+    def from_dicts(
+        cls, next: Optional[Dict[str, str]], prev: Optional[Dict[str, str]]
+    ) -> "PaginationLinks":
+        """Create a new PaginationLinks from two optional dictionaries of queries."""
+        return cls(
+            next=UnresolvedLink.from_opt_dict(next),
+            prev=UnresolvedLink.from_opt_dict(prev),
+        )


### PR DESCRIPTION
**Related Issue(s):** 

- Alternative solution to #453 and #472

**Description:**

This is a work-in-progress PR to demonstrate an alternative approach to decoupling backends from the API layer. Two main features:

- A new `Backend` interface that does the actual fetching from the database/data store
- A new `PaginationLinks` structure that allows a backend to provide "unresolved" pagination links, that are resolved at the client layer

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
