### PR TITLE
[pgstac] Fix ascending sort with missing (or duplicate) values

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       db_service:
-        image: ghcr.io/stac-utils/pgstac:v0.6.12
+        image: ghcr.io/stac-utils/pgstac:v0.6.13
         env:
           POSTGRES_USER: username
           POSTGRES_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
 
   database:
     container_name: stac-db
-    image: ghcr.io/stac-utils/pgstac:v0.6.12
+    image: ghcr.io/stac-utils/pgstac:v0.6.13
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #514 

**Description:**

In **pgstac**, there ascending sort is broken when there's missing or duplicate values in the sorted field. This is a WIP PR to  demonstrate the problem -- it will be updated with a fix once one is found. Requesting @bitner's eyes on this one (and @mmcfarland for his awareness). Tested against **pgstac** v0.6.13 (latest release).

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
