### PR TITLE
Remove links from default include list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 * Updated CI to test against [pgstac v0.6.12](https://github.com/stac-utils/pgstac/releases/tag/v0.6.12) ([#511](https://github.com/stac-utils/stac-fastapi/pull/511))
 * Reworked `update_openapi` and added a test for it ([#523](https://github.com/stac-utils/stac-fastapi/pull/523))
 * Limit values above 10,000 are now replaced with 10,000 instead of returning a 400 error ([#526](https://github.com/stac-utils/stac-fastapi/pull/526))
+* Links are no longer part of the default include list ([#524](https://github.com/stac-utils/stac-fastapi/pull/524))
 
 ### Removed
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
@@ -39,7 +39,6 @@ class FieldsExtension(ApiExtension):
             "stac_version",
             "geometry",
             "bbox",
-            "links",
             "assets",
             "properties.datetime",
             "collection",

--- a/stac_fastapi/pgstac/tests/resources/test_item.py
+++ b/stac_fastapi/pgstac/tests/resources/test_item.py
@@ -1200,11 +1200,22 @@ async def test_field_extension_exclude_links(
     assert "links" not in resp_json["features"][0]
 
 
+async def test_field_extension_include_but_not_links(
+    app_client, load_test_item, load_test_collection
+):
+    # https://github.com/stac-utils/stac-fastapi/issues/395
+    body = {"fields": {"include": ["properties.eo:cloud_cover"]}}
+    resp = await app_client.post("/search", json=body)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert "links" not in resp_json["features"][0]
+
+
 async def test_field_extension_include_only_non_existant_field(
     app_client, load_test_item, load_test_collection
 ):
-    """Including only a non-existant field should return the full item"""
-    body = {"fields": {"include": ["non_existant_field"]}}
+    """Including only a non-existent field should return the full item"""
+    body = {"fields": {"include": ["non_existent_field"]}}
 
     resp = await app_client.post("/search", json=body)
     assert resp.status_code == 200

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -481,7 +481,9 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                 )
 
             # Use pydantic includes/excludes syntax to implement fields extension
-            if self.extension_is_enabled("FieldsExtension"):
+            if self.extension_is_enabled("FieldsExtension") and (
+                search_request.fields.include or search_request.fields.exclude
+            ):
                 if search_request.query is not None:
                     query_include: Set[str] = set(
                         [

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -142,7 +142,13 @@ def test_app_fields_extension(load_test_data, app_client, postgres_transactions)
         item["collection"], item, request=MockStarletteRequest
     )
 
-    resp = app_client.get("/search", params={"collections": ["test-collection"]})
+    resp = app_client.post(
+        "/search",
+        json={
+            "collections": ["test-collection"],
+            "fields": {"include": ["datetime"]},
+        },
+    )
     assert resp.status_code == 200
     resp_json = resp.json()
     assert list(resp_json["features"][0]["properties"]) == ["datetime"]

--- a/stac_fastapi/sqlalchemy/tests/resources/test_item.py
+++ b/stac_fastapi/sqlalchemy/tests/resources/test_item.py
@@ -879,6 +879,20 @@ def test_field_extension_exclude_default_includes(app_client, load_test_data):
     assert "geometry" not in resp_json["features"][0]
 
 
+def test_field_extension_include_but_not_links(app_client, load_test_data):
+    # https://github.com/stac-utils/stac-fastapi/issues/395
+    test_item = load_test_data("test_item.json")
+    resp = app_client.post(
+        f"/collections/{test_item['collection']}/items", json=test_item
+    )
+    assert resp.status_code == 200
+    body = {"fields": {"include": ["properties.eo:cloud_cover"]}}
+    resp = app_client.post("/search", json=body)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert "links" not in resp_json["features"][0]
+
+
 def test_search_intersects_and_bbox(app_client):
     """Test POST search intersects and bbox are mutually exclusive (core)"""
     bbox = [-118, 34, -117, 35]


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #395 
- Closes alternate solution #527 

This is one of two PRs that would fix https://github.com/stac-utils/stac-fastapi/issues/395; the other is https://github.com/stac-utils/stac-fastapi/pull/527. We should merge one and close the other.

**Description:**

The [fields extension](https://github.com/stac-api-extensions/fields) is used to include/exclude fields on items returned by `/search` (and `/collections/{cid}/items`). If a field is not present in `include` or `exclude`, the extension does not specify whether that field should be present on the response items (though it does [provide guidance](https://github.com/stac-api-extensions/fields#includeexclude-semantics)). Currently, `links` is included by default, even if it is not present in the `include` list. This PR changes that behavior to **exclude `links` by default** if there is an `include` list.

**sqlalchemy** uses `FieldsExtension.default_includes`, so its fix was pretty easy
-- I did have to add an explicit include+exclude check to the search function to ensure the fields extension was applied _only if_ either `include` or `exclude` was set. **pgstac** was a little trickier, because it doesn't use the `default_includes` list.

I did modify one existing test -- `test_app_fields_extension` in the **sqlalchemy** tests was assuming fields would be stripped just by providing a `collections` parameter to the query, which I think is incorrect -- I added an explicit `include` field to the test.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
