### PR TITLE
Align fields extension behavior with extension suggestions

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -155,7 +155,7 @@ jobs:
           cache: pip
           cache-dependency-path: stac_fastapi/pgstac/setup.cfg
       - name: Install stac-fastapi and stac-api-validator
-        run: pip install ./stac_fastapi/api ./stac_fastapi/types ./stac_fastapi/${{ matrix.backend }}[server] stac-api-validator==0.4.1
+        run: pip install ./stac_fastapi/api ./stac_fastapi/types ./stac_fastapi/extensions ./stac_fastapi/${{ matrix.backend }}[server] stac-api-validator==0.4.1
       - name: Run migration
         if: ${{ matrix.backend == 'sqlalchemy' }}
         run: cd stac_fastapi/sqlalchemy && alembic upgrade head

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 * Updated CI to test against [pgstac v0.6.12](https://github.com/stac-utils/pgstac/releases/tag/v0.6.12) ([#511](https://github.com/stac-utils/stac-fastapi/pull/511))
 * Reworked `update_openapi` and added a test for it ([#523](https://github.com/stac-utils/stac-fastapi/pull/523))
 * Limit values above 10,000 are now replaced with 10,000 instead of returning a 400 error ([#526](https://github.com/stac-utils/stac-fastapi/pull/526))
+* Default field include and exclude behavior ([#527](https://github.com/stac-utils/stac-fastapi/pull/527))
 
 ### Removed
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
@@ -43,6 +43,7 @@ class FieldsExtension(ApiExtension):
             "assets",
             "properties.datetime",
             "collection",
+            "stac_extensions",
         }
     )
     schema_href: Optional[str] = attr.ib(default=None)

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/request.py
@@ -69,4 +69,4 @@ class FieldsExtensionGetRequest(APIRequest):
 class FieldsExtensionPostRequest(BaseModel):
     """Additional fields and schema for the POST request."""
 
-    fields: Optional[PostFieldsExtension] = Field(PostFieldsExtension())
+    fields: Optional[PostFieldsExtension] = Field(None)

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/core.py
@@ -183,12 +183,16 @@ class CoreCrudClient(AsyncBaseCoreClient):
         prev: Optional[str] = items.pop("prev", None)
         collection = ItemCollection(**items)
 
-        exclude = search_request.fields.exclude
-        if exclude and len(exclude) == 0:
+        if search_request.fields is None:
             exclude = None
-        include = search_request.fields.include
-        if include and len(include) == 0:
             include = None
+        else:
+            exclude = search_request.fields.exclude
+            if exclude and len(exclude) == 0:
+                exclude = None
+            include = search_request.fields.include
+            if include and len(include) == 0:
+                include = None
 
         async def _add_item_links(
             feature: Item,
@@ -204,8 +208,8 @@ class CoreCrudClient(AsyncBaseCoreClient):
             item_id = feature.get("id") or item_id
 
             if (
-                search_request.fields.exclude is None
-                or "links" not in search_request.fields.exclude
+                exclude is None
+                or "links" not in exclude
                 and all([collection_id, item_id])
             ):
                 feature["links"] = await ItemLinks(

--- a/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
+++ b/stac_fastapi/sqlalchemy/stac_fastapi/sqlalchemy/core.py
@@ -481,7 +481,10 @@ class CoreCrudClient(PaginationTokenClient, BaseCoreClient):
                 )
 
             # Use pydantic includes/excludes syntax to implement fields extension
-            if self.extension_is_enabled("FieldsExtension"):
+            if (
+                self.extension_is_enabled("FieldsExtension")
+                and search_request.fields is not None
+            ):
                 if search_request.query is not None:
                     query_include: Set[str] = set(
                         [

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from urllib.parse import quote_plus
 
 import orjson
+import pytest
 
 from ..conftest import MockStarletteRequest
 
@@ -136,6 +137,10 @@ def test_app_context_extension(load_test_data, app_client, postgres_transactions
     assert resp_json["context"]["returned"] == resp_json["context"]["matched"] == 1
 
 
+@pytest.mark.skip(
+    reason="I think this test is invalid -- why should we "
+    "filter fields if we provide `collections`?"
+)
 def test_app_fields_extension(load_test_data, app_client, postgres_transactions):
     item = load_test_data("test_item.json")
     postgres_transactions.create_item(

--- a/stac_fastapi/sqlalchemy/tests/api/test_api.py
+++ b/stac_fastapi/sqlalchemy/tests/api/test_api.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from urllib.parse import quote_plus
 
 import orjson
-import pytest
 
 from ..conftest import MockStarletteRequest
 
@@ -135,22 +134,6 @@ def test_app_context_extension(load_test_data, app_client, postgres_transactions
     resp_json = resp.json()
     assert "context" in resp_json
     assert resp_json["context"]["returned"] == resp_json["context"]["matched"] == 1
-
-
-@pytest.mark.skip(
-    reason="I think this test is invalid -- why should we "
-    "filter fields if we provide `collections`?"
-)
-def test_app_fields_extension(load_test_data, app_client, postgres_transactions):
-    item = load_test_data("test_item.json")
-    postgres_transactions.create_item(
-        item["collection"], item, request=MockStarletteRequest
-    )
-
-    resp = app_client.get("/search", params={"collections": ["test-collection"]})
-    assert resp.status_code == 200
-    resp_json = resp.json()
-    assert list(resp_json["features"][0]["properties"]) == ["datetime"]
 
 
 def test_app_query_extension_gt(load_test_data, app_client, postgres_transactions):


### PR DESCRIPTION
**Related Issue(s):** 

- Closes alternate solution #524
- Closes #395

This is one of two PRs that would fix #395; the other is #524. We should merge one and close the other (should happen automatically thanks to closing keywords).

**Description:**

This PR updates both backends to (mostly) follow the recommended field extension semantics, as laid out in https://github.com/stac-api-extensions/fields#includeexclude-semantics. In particular:

- Any `include` fields are merged with the default include set
- An empty `fields` attribute will return the default include set
- If a field is both included and excluded, it is included in the response (this is a change from previous behavior)
- We include `stac_version` in the default includes to ensure valid STAC items
  - This is incorrect in the recommendations, and will be updated by https://github.com/stac-api-extensions/fields/pull/4)
- **In a deviation from the recommended semantics**, we keep `collection` and `stac_extensions`, as (in this author's opinion) these are valuable and cheap

The recommendations are encapsulated in a `into_recommended` method, where the set operations are performed: https://github.com/stac-utils/stac-fastapi/compare/issues/395-align-include-with-suggestions?expand=1#diff-b9d01a5a656ba2bdee8dd6eb5462bf1b1602b01bceaafb431cff8c38969815d5R61-R76.

I've also updated the fields extension default to be `None`, which allows for detection of an empty fields attribute (e.g. `?fields=`). This was required to enable item 1 in https://github.com/stac-api-extensions/fields#includeexclude-semantics.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
