### PR TITLE
Increase wait timeout when loading the demo dataset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - ./stac_fastapi:/app/stac_fastapi
       - ./scripts:/app/scripts
     command: >
-      bash -c "./scripts/wait-for-it.sh app-sqlalchemy:8081 && cd stac_fastapi/sqlalchemy && alembic upgrade head && python /app/scripts/ingest_joplin.py http://app-sqlalchemy:8081"
+      bash -c "./scripts/wait-for-it.sh app-sqlalchemy:8081 -t 60 && cd stac_fastapi/sqlalchemy && alembic upgrade head && python /app/scripts/ingest_joplin.py http://app-sqlalchemy:8081"
     depends_on:
       - database
       - app-sqlalchemy
@@ -103,6 +103,8 @@ services:
       - ./scripts:/app/scripts
     command:
       - "./scripts/wait-for-it.sh"
+      - "-t"
+      - "60"
       - "app-pgstac:8082"
       - "--"
       - "python"


### PR DESCRIPTION
**Related Issue(s):** 
None

**Description:**
When running `make docker-run-all` (aka `docker-compose up`) on an Apple M1, I consistently run into timeout errors when loading the joplin demo data:

```
stac-fastapi-loadjoplin-pgstac-1      | wait-for-it.sh: timeout occurred after waiting 15 seconds for app-pgstac:8082
``` 

After overriding the default 15 second timeout to an unlimited wait time, I'm seeing max times of about 30 seconds. This PR sets a timeout of 60 seconds for loading the demo data.

**PR Checklist:**

- [x] Code is formatted and linted (run `pre-commit run --all-files`)
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
