### PR TITLE
Add tooling to make customization of DB Connection possible

### DIFF
--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
@@ -6,7 +6,7 @@ from typing import AsyncIterator, Callable, Dict, Generator, Literal, Union
 
 import attr
 import orjson
-from asyncpg import exceptions, Connection
+from asyncpg import Connection, exceptions
 from buildpg import V, asyncpg, render
 from fastapi import FastAPI, Request
 

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
@@ -1,14 +1,14 @@
 """Database connection handling."""
 
 import json
-from contextlib import contextmanager
-from typing import Dict, Generator, Union
+from contextlib import asynccontextmanager, contextmanager
+from typing import AsyncIterator, Callable, Dict, Generator, Literal, Union
 
 import attr
 import orjson
-from asyncpg import exceptions, pool
+from asyncpg import exceptions, Connection
 from buildpg import V, asyncpg, render
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 
 from stac_fastapi.types.errors import (
     ConflictError,
@@ -34,8 +34,11 @@ async def con_init(conn):
     )
 
 
-async def connect_to_db(app: FastAPI) -> None:
-    """Connect to Database."""
+ConnectionGetter = Callable[[Request, str], AsyncIterator[Connection]]
+
+
+async def connect_to_db(app: FastAPI, get_conn: ConnectionGetter = None) -> None:
+    """Create connection pools & connection retriever on application."""
     settings = app.state.settings
     if app.state.settings.testing:
         readpool = writepool = settings.testing_connection_string
@@ -45,6 +48,7 @@ async def connect_to_db(app: FastAPI) -> None:
     db = DB()
     app.state.readpool = await db.create_pool(readpool, settings)
     app.state.writepool = await db.create_pool(writepool, settings)
+    app.state.get_connection = get_conn if get_conn else get_connection
 
 
 async def close_db_connection(app: FastAPI) -> None:
@@ -53,7 +57,21 @@ async def close_db_connection(app: FastAPI) -> None:
     await app.state.writepool.close()
 
 
-async def dbfunc(pool: pool, func: str, arg: Union[str, Dict]):
+@asynccontextmanager
+async def get_connection(
+    request: Request,
+    readwrite: Literal["r", "w"] = "r",
+) -> AsyncIterator[Connection]:
+    """Retrieve connection from database conection pool."""
+    pool = (
+        request.app.state.writepool if readwrite == "w" else request.app.state.readpool
+    )
+    with translate_pgstac_errors():
+        async with pool.acquire() as conn:
+            yield conn
+
+
+async def dbfunc(conn: Connection, func: str, arg: Union[str, Dict]):
     """Wrap PLPGSQL Functions.
 
     Keyword arguments:
@@ -64,25 +82,23 @@ async def dbfunc(pool: pool, func: str, arg: Union[str, Dict]):
     """
     with translate_pgstac_errors():
         if isinstance(arg, str):
-            async with pool.acquire() as conn:
-                q, p = render(
-                    """
-                    SELECT * FROM :func(:item::text);
-                    """,
-                    func=V(func),
-                    item=arg,
-                )
-                return await conn.fetchval(q, *p)
+            q, p = render(
+                """
+                SELECT * FROM :func(:item::text);
+                """,
+                func=V(func),
+                item=arg,
+            )
+            return await conn.fetchval(q, *p)
         else:
-            async with pool.acquire() as conn:
-                q, p = render(
-                    """
-                    SELECT * FROM :func(:item::text::jsonb);
-                    """,
-                    func=V(func),
-                    item=json.dumps(arg),
-                )
-                return await conn.fetchval(q, *p)
+            q, p = render(
+                """
+                SELECT * FROM :func(:item::text::jsonb);
+                """,
+                func=V(func),
+                item=json.dumps(arg),
+            )
+            return await conn.fetchval(q, *p)
 
 
 @contextmanager

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
@@ -34,7 +34,7 @@ async def con_init(conn):
     )
 
 
-ConnectionGetter = Callable[[Request, str], AsyncIterator[Connection]]
+ConnectionGetter = Callable[[Request, Literal["r", "w"]], AsyncIterator[Connection]]
 
 
 async def connect_to_db(app: FastAPI, get_conn: ConnectionGetter = None) -> None:

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/transactions.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/transactions.py
@@ -5,14 +5,14 @@ from typing import Optional, Union
 
 import attr
 from buildpg import render
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from starlette.responses import JSONResponse, Response
 
 from stac_fastapi.extensions.third_party.bulk_transactions import (
     AsyncBaseBulkTransactionsClient,
     Items,
 )
-from stac_fastapi.pgstac.db import dbfunc, translate_pgstac_errors
+from stac_fastapi.pgstac.db import dbfunc
 from stac_fastapi.pgstac.models.links import CollectionLinks, ItemLinks
 from stac_fastapi.types import stac as stac_types
 from stac_fastapi.types.core import AsyncBaseTransactionsClient
@@ -26,7 +26,7 @@ class TransactionsClient(AsyncBaseTransactionsClient):
     """Transactions extension specific CRUD operations."""
 
     async def create_item(
-        self, collection_id: str, item: stac_types.Item, **kwargs
+        self, collection_id: str, item: stac_types.Item, request: Request, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Create item."""
         body_collection_id = item.get("collection")
@@ -36,9 +36,8 @@ class TransactionsClient(AsyncBaseTransactionsClient):
                 detail=f"Collection ID from path parameter ({collection_id}) does not match Collection ID from Item ({body_collection_id})",
             )
         item["collection"] = collection_id
-        request = kwargs["request"]
-        pool = request.app.state.writepool
-        await dbfunc(pool, "create_item", item)
+        async with request.app.state.get_connection(request, "w") as conn:
+            await dbfunc(conn, "create_item", item)
         item["links"] = await ItemLinks(
             collection_id=collection_id,
             item_id=item["id"],
@@ -47,7 +46,12 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         return stac_types.Item(**item)
 
     async def update_item(
-        self, collection_id: str, item_id: str, item: stac_types.Item, **kwargs
+        self,
+        request: Request,
+        collection_id: str,
+        item_id: str,
+        item: stac_types.Item,
+        **kwargs,
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Update item."""
         body_collection_id = item.get("collection")
@@ -63,9 +67,8 @@ class TransactionsClient(AsyncBaseTransactionsClient):
                 status_code=400,
                 detail=f"Item ID from path parameter ({item_id}) does not match Item ID from Item ({body_item_id})",
             )
-        request = kwargs["request"]
-        pool = request.app.state.writepool
-        await dbfunc(pool, "update_item", item)
+        async with request.app.state.get_connection(request, "w") as conn:
+            await dbfunc(conn, "update_item", item)
         item["links"] = await ItemLinks(
             collection_id=collection_id,
             item_id=item["id"],
@@ -74,12 +77,11 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         return stac_types.Item(**item)
 
     async def create_collection(
-        self, collection: stac_types.Collection, **kwargs
+        self, collection: stac_types.Collection, request: Request, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create collection."""
-        request = kwargs["request"]
-        pool = request.app.state.writepool
-        await dbfunc(pool, "create_collection", collection)
+        async with request.app.state.get_connection(request, "w") as conn:
+            await dbfunc(conn, "create_collection", collection)
         collection["links"] = await CollectionLinks(
             collection_id=collection["id"], request=request
         ).get_links(extra_links=collection.get("links"))
@@ -87,40 +89,35 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         return stac_types.Collection(**collection)
 
     async def update_collection(
-        self, collection: stac_types.Collection, **kwargs
+        self, collection: stac_types.Collection, request: Request, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Update collection."""
-        request = kwargs["request"]
-        pool = request.app.state.writepool
-        await dbfunc(pool, "update_collection", collection)
+        async with request.app.state.get_connection(request, "w") as conn:
+            await dbfunc(conn, "update_collection", collection)
         collection["links"] = await CollectionLinks(
             collection_id=collection["id"], request=request
         ).get_links(extra_links=collection.get("links"))
         return stac_types.Collection(**collection)
 
     async def delete_item(
-        self, item_id: str, collection_id: str, **kwargs
+        self, item_id: str, collection_id: str, request: Request, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete item."""
-        request = kwargs["request"]
-        pool = request.app.state.writepool
-        async with pool.acquire() as conn:
-            q, p = render(
-                "SELECT * FROM delete_item(:item::text, :collection::text);",
-                item=item_id,
-                collection=collection_id,
-            )
-            with translate_pgstac_errors():
-                await conn.fetchval(q, *p)
+        q, p = render(
+            "SELECT * FROM delete_item(:item::text, :collection::text);",
+            item=item_id,
+            collection=collection_id,
+        )
+        async with request.app.state.get_connection(request, "w") as conn:
+            await conn.fetchval(q, *p)
         return JSONResponse({"deleted item": item_id})
 
     async def delete_collection(
-        self, collection_id: str, **kwargs
+        self, collection_id: str, request: Request, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete collection."""
-        request = kwargs["request"]
-        pool = request.app.state.writepool
-        await dbfunc(pool, "delete_collection", collection_id)
+        async with request.app.state.get_connection(request, "w") as conn:
+            await dbfunc(conn, "delete_collection", collection_id)
         return JSONResponse({"deleted collection": collection_id})
 
 
@@ -128,12 +125,11 @@ class TransactionsClient(AsyncBaseTransactionsClient):
 class BulkTransactionsClient(AsyncBaseBulkTransactionsClient):
     """Postgres bulk transactions."""
 
-    async def bulk_item_insert(self, items: Items, **kwargs) -> str:
+    async def bulk_item_insert(self, items: Items, request: Request, **kwargs) -> str:
         """Bulk item insertion using pgstac."""
-        request = kwargs["request"]
-        pool = request.app.state.writepool
         items = list(items.items.values())
-        await dbfunc(pool, "create_items", items)
+        async with request.app.state.get_connection(request, "w") as conn:
+            await dbfunc(conn, "create_items", items)
 
         return_msg = f"Successfully added {len(items)} items."
         return return_msg

--- a/stac_fastapi/pgstac/tests/clients/test_postgres.py
+++ b/stac_fastapi/pgstac/tests/clients/test_postgres.py
@@ -6,9 +6,9 @@ from typing import Callable, Literal
 
 import pytest
 from fastapi import Request
-
 from stac_pydantic import Collection, Item
-from stac_fastapi.pgstac.db import connect_to_db, close_db_connection, get_connection
+
+from stac_fastapi.pgstac.db import close_db_connection, connect_to_db, get_connection
 
 # from tests.conftest import MockStarletteRequest
 logger = logging.getLogger(__name__)

--- a/stac_fastapi/pgstac/tests/clients/test_postgres.py
+++ b/stac_fastapi/pgstac/tests/clients/test_postgres.py
@@ -1,10 +1,17 @@
+import logging
 import uuid
+from contextlib import asynccontextmanager
 from copy import deepcopy
-from typing import Callable
+from typing import Callable, Literal
+
+import pytest
+from fastapi import Request
 
 from stac_pydantic import Collection, Item
+from stac_fastapi.pgstac.db import connect_to_db, close_db_connection, get_connection
 
 # from tests.conftest import MockStarletteRequest
+logger = logging.getLogger(__name__)
 
 
 async def test_create_collection(app_client, load_test_data: Callable):
@@ -170,3 +177,33 @@ async def test_create_bulk_items(
 
 #     for item in fc.features:
 #         assert item.collection == coll.id
+
+
+@asynccontextmanager
+async def custom_get_connection(
+    request: Request,
+    readwrite: Literal["r", "w"],
+):
+    """An example of customizing the connection getter"""
+    async with get_connection(request, readwrite) as conn:
+        await conn.execute("SELECT set_config('api.test', 'added-config', false)")
+        yield conn
+
+
+class TestDbConnect:
+    @pytest.fixture
+    async def app(self, api_client):
+        logger.warn("Customizing app setup")
+        await connect_to_db(api_client.app, custom_get_connection)
+        yield api_client.app
+        await close_db_connection(api_client.app)
+
+    async def test_db_setup(self, api_client, app_client):
+        @api_client.app.get(f"{api_client.router.prefix}/db-test")
+        async def example_view(request: Request):
+            async with request.app.state.get_connection(request, "r") as conn:
+                return await conn.fetchval("SELECT current_setting('api.test', true)")
+
+        response = await app_client.get("/db-test")
+        assert response.status_code is 200
+        assert response.json() == "added-config"

--- a/stac_fastapi/pgstac/tests/clients/test_postgres.py
+++ b/stac_fastapi/pgstac/tests/clients/test_postgres.py
@@ -208,5 +208,5 @@ class TestDbConnect:
                 return await conn.fetchval("SELECT current_setting('api.test', true)")
 
         response = await app_client.get("/db-test")
-        assert response.status_code is 200
+        assert response.status_code == 200
         assert response.json() == "added-config"

--- a/stac_fastapi/pgstac/tests/clients/test_postgres.py
+++ b/stac_fastapi/pgstac/tests/clients/test_postgres.py
@@ -193,7 +193,10 @@ async def custom_get_connection(
 class TestDbConnect:
     @pytest.fixture
     async def app(self, api_client):
-        logger.warn("Customizing app setup")
+        """
+        app fixture override to setup app with a customized db connection getter
+        """
+        logger.debug("Customizing app setup")
         await connect_to_db(api_client.app, custom_get_connection)
         yield api_client.app
         await close_db_connection(api_client.app)


### PR DESCRIPTION
**Description:**

This PR updates the way in which the pgSTAC extension connects with its underlying database.  This was done to support the possibility of users running custom connection setup/teardown steps for each request.  This allows us to do something like the following when setting up a pgSTAC-based STAC API:

```diff
diff --git a/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py b/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py
index 8a33424..1033f11 100644
--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/app.py
@@ -6,8 +6,14 @@ If the variable is not set, enables all extensions.
 """
 
 import os
+from contextlib import asynccontextmanager
+from typing import Literal
 
+from asyncpg import exceptions, Connection
+from buildpg import render
+from fastapi import HTTPException, Request
 from fastapi.responses import ORJSONResponse
+from fastapi.security import HTTPBasic
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
@@ -22,7 +28,7 @@ from stac_fastapi.extensions.core import (
 from stac_fastapi.extensions.third_party import BulkTransactionExtension
 from stac_fastapi.pgstac.config import Settings
 from stac_fastapi.pgstac.core import CoreCrudClient
-from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
+from stac_fastapi.pgstac.db import close_db_connection, connect_to_db, get_connection
 from stac_fastapi.pgstac.extensions import QueryExtension
 from stac_fastapi.pgstac.extensions.filter import FiltersClient
 from stac_fastapi.pgstac.transactions import BulkTransactionsClient, TransactionsClient
@@ -65,10 +71,57 @@ api = StacApi(
 app = api.app
 
 
+auth = HTTPBasic()
+
+
+async def set_db_user(conn: Connection, request: Request) -> None:
+    # Require & parse basic auth
+    credentials = await auth(request)
+
+    # Validate credentials...
+    q, p = render(
+        f"""
+        SELECT authenticate_user(:username::text, :password::text)
+        """,
+        username=credentials.username,
+        password=credentials.password,
+    )
+    try:
+        await conn.execute(q, *p)
+    except exceptions.RaiseError as e:
+        raise HTTPException(status_code=401, detail="Bad credentials") from e
+
+    # Set user in DB...
+    q, p = render(
+        f"""
+        SELECT set_config('api.username', :username::text, false)
+        """,
+        username=credentials.username,
+    )
+    await conn.execute(q, *p)
+
+
+@asynccontextmanager
+async def custom_get_connection(
+    request: Request,
+    readwrite: Literal["r", "w"],
+):
+    """An example of customizing the connection getter"""
+    async with get_connection(request, readwrite) as conn:
+        if readwrite == "w":
+            await set_db_user(conn, request)
+
+        # Simple demo to validate we now know who is authenticated
+        current_user = await conn.fetchval("SELECT current_setting('api.username', true)")
+        print(f"Running DB command as {current_user!r}")
+        
+        yield conn
+
+
 @app.on_event("startup")
 async def startup_event():
     """Connect to database on startup."""
-    await connect_to_db(app)
+    await connect_to_db(app, custom_get_connection)
 
 
 @app.on_event("shutdown")
```

**PR Checklist:**

- [ ] Code is formatted and linted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/master/CHANGES.md).
