### PR TITLE
Fixing images used in docker composes files

### DIFF
--- a/docker/docker-compose.pgstac.yml
+++ b/docker/docker-compose.pgstac.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   stac-fastapi-pgstac:
-    image: ghcr.io/stac-utils/stac-fastapi:latest-pgstac
+    image: ghcr.io/stac-utils/stac-fastapi:main-pgstac
     platform: linux/amd64
     environment:
       - APP_HOST=0.0.0.0

--- a/docker/docker-compose.sqlalchemy.yml
+++ b/docker/docker-compose.sqlalchemy.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   stac-fastapi-sqlalchemy:
-    image: ghcr.io/stac-utils/stac-fastapi:latest-sqlalchemy
+    image: ghcr.io/stac-utils/stac-fastapi:main-sqlalchemy
     platform: linux/amd64
     environment:
       - APP_HOST=0.0.0.0
@@ -32,7 +32,7 @@ services:
     command: postgres -N 500
 
   migrate:
-    image: ghcr.io/stac-utils/stac-fastapi:latest-sqlalchemy
+    image: ghcr.io/stac-utils/stac-fastapi:main-sqlalchemy
     command: bash -c "cd /app && alembic upgrade head"
     environment:
       - POSTGRES_USER=username


### PR DESCRIPTION
There are reference to `latest-pgstac` and `latest-sqlalchemy` which are now `main-*`