### PR TITLE
Avoid fstring in queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 * Default branch to **main** ([#544](https://github.com/stac-utils/stac-fastapi/pull/544))
 
+### Fixed
+
+* Use `V()` instead of f-strings for pgstac queries ([#554](https://github.com/stac-utils/stac-fastapi/pull/554))
+
 ## [2.4.4] - 2023-03-09
 
 ### Added

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
@@ -7,7 +7,7 @@ from typing import Dict, Generator, Union
 import attr
 import orjson
 from asyncpg import exceptions, pool
-from buildpg import asyncpg, render
+from buildpg import asyncpg, render, V
 from fastapi import FastAPI
 
 from stac_fastapi.types.errors import (
@@ -66,18 +66,20 @@ async def dbfunc(pool: pool, func: str, arg: Union[str, Dict]):
         if isinstance(arg, str):
             async with pool.acquire() as conn:
                 q, p = render(
-                    f"""
-                        SELECT * FROM {func}(:item::text);
-                        """,
+                    """
+                    SELECT * FROM :func(:item::text);
+                    """,
+                    func=V(func),
                     item=arg,
                 )
                 return await conn.fetchval(q, *p)
         else:
             async with pool.acquire() as conn:
                 q, p = render(
-                    f"""
-                        SELECT * FROM {func}(:item::text::jsonb);
-                        """,
+                    """
+                    SELECT * FROM :func(:item::text::jsonb);
+                    """,
+                    func=V(func),
                     item=json.dumps(arg),
                 )
                 return await conn.fetchval(q, *p)

--- a/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
+++ b/stac_fastapi/pgstac/stac_fastapi/pgstac/db.py
@@ -7,7 +7,7 @@ from typing import Dict, Generator, Union
 import attr
 import orjson
 from asyncpg import exceptions, pool
-from buildpg import asyncpg, render, V
+from buildpg import V, asyncpg, render
 from fastapi import FastAPI
 
 from stac_fastapi.types.errors import (


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

Use `V()` rather than an string for DB function calls.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
