### PR TITLE
Remove ceil on fastapi version

### DIFF
--- a/stac_fastapi/api/tests/test_api.py
+++ b/stac_fastapi/api/tests/test_api.py
@@ -34,12 +34,12 @@ class TestRouteDependencies:
                 ), "Unauthenticated requests should be rejected"
                 assert response.json() == {"detail": "Not authenticated"}
 
-                make_request = getattr(client, route["method"].lower())
                 path = route["path"].format(
                     collectionId="test_collection", itemId="test_item"
                 )
-                response = make_request(
-                    path,
+                response = client.request(
+                    method=route["method"].lower(),
+                    url=path,
                     auth=("bob", "dobbs"),
                     data='{"dummy": "payload"}',
                     headers={"content-type": "application/json"},

--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "fastapi>=0.73.0,<0.87",
+    "fastapi>=0.73.0",
     "attrs",
     "pydantic[dotenv]",
     "stac_pydantic==2.0.*",


### PR DESCRIPTION
**Description:**

It was added for some reason, but the reason appears to be lost in time (e.g. cb76e2e25e2fe7c285299bbc690133815432fd9f). I don't think this needs a changelog entry.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
