### PR TITLE
Improve logging of pgSTAC tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ run_pgstac = docker-compose run --rm \
 				-e APP_PORT=${APP_PORT} \
 				app-pgstac
 
+LOG_LEVEL ?= warning
+
 .PHONY: image
 image:
 	docker-compose build
@@ -44,15 +46,15 @@ docker-shell-pgstac:
 
 .PHONY: test-sqlalchemy
 test-sqlalchemy: run-joplin-sqlalchemy
-	$(run_sqlalchemy) /bin/bash -c 'export && ./scripts/wait-for-it.sh database:5432 && cd /app/stac_fastapi/sqlalchemy/tests/ && pytest -vvv'
+	$(run_sqlalchemy) /bin/bash -c 'export && ./scripts/wait-for-it.sh database:5432 && cd /app/stac_fastapi/sqlalchemy/tests/ && pytest -vvv --log-cli-level $(LOG_LEVEL)'
 
 .PHONY: test-pgstac
 test-pgstac:
-	$(run_pgstac) /bin/bash -c 'export && ./scripts/wait-for-it.sh database:5432 && cd /app/stac_fastapi/pgstac/tests/ && pytest -vvv'
+	$(run_pgstac) /bin/bash -c 'export && ./scripts/wait-for-it.sh database:5432 && cd /app/stac_fastapi/pgstac/tests/ && pytest -vvv --log-cli-level $(LOG_LEVEL)'
 
 .PHONY: test-api
 test-api:
-	$(run_sqlalchemy) /bin/bash -c 'cd /app/stac_fastapi/api && pytest -svvv'
+	$(run_sqlalchemy) /bin/bash -c 'cd /app/stac_fastapi/api && pytest -svvv --log-cli-level $(LOG_LEVEL)'
 
 .PHONY: run-database
 run-database:

--- a/stac_fastapi/pgstac/tests/conftest.py
+++ b/stac_fastapi/pgstac/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import os
 import time
 from typing import Callable, Dict
@@ -33,6 +34,8 @@ from stac_fastapi.pgstac.extensions.filter import FiltersClient
 from stac_fastapi.pgstac.transactions import BulkTransactionsClient, TransactionsClient
 from stac_fastapi.pgstac.types.search import PgstacSearch
 
+logger = logging.getLogger(__name__)
+
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
 settings = Settings(testing=True)
@@ -46,7 +49,7 @@ def event_loop():
 
 @pytest.fixture(scope="session")
 async def pg():
-    print(f"Connecting to write database {settings.writer_connection_string}")
+    logger.info(f"Connecting to write database {settings.writer_connection_string}")
     os.environ["orig_postgres_dbname"] = settings.postgres_dbname
     conn = await asyncpg.connect(dsn=settings.writer_connection_string)
     try:
@@ -64,21 +67,20 @@ async def pg():
             "ALTER DATABASE pgstactestdb SET search_path to pgstac, public;"
         )
     await conn.close()
-    print("migrating...")
+    logger.info("migrating...")
     os.environ["postgres_dbname"] = "pgstactestdb"
     conn = await asyncpg.connect(dsn=settings.testing_connection_string)
-    val = await conn.fetchval("SELECT true")
-    print(val)
+    await conn.execute("SELECT true")
     await conn.close()
     db = PgstacDB(dsn=settings.testing_connection_string)
     migrator = Migrate(db)
     version = migrator.run_migration()
     db.close()
-    print(f"PGStac Migrated to {version}")
+    logger.info(f"PGStac Migrated to {version}")
 
     yield settings.testing_connection_string
 
-    print("Getting rid of test database")
+    logger.info("Getting rid of test database")
     os.environ["postgres_dbname"] = os.environ["orig_postgres_dbname"]
     conn = await asyncpg.connect(dsn=settings.writer_connection_string)
     try:
@@ -94,9 +96,9 @@ async def pg():
 
 @pytest.fixture(autouse=True)
 async def pgstac(pg):
-    print(f"{os.environ['postgres_dbname']}")
+    logger.info(f"{os.environ['postgres_dbname']}")
     yield
-    print("Truncating Data")
+    logger.info("Truncating Data")
     conn = await asyncpg.connect(dsn=settings.testing_connection_string)
     await conn.execute(
         """
@@ -107,7 +109,7 @@ async def pgstac(pg):
     with PgstacDB(dsn=settings.testing_connection_string) as db:
         migrator = Migrate(db)
         version = migrator.run_migration()
-    print(f"PGStac Migrated to {version}")
+    logger.info(f"PGStac Migrated to {version}")
 
 
 # Run all the tests that use the api_client in both db hydrate and api hydrate mode
@@ -126,7 +128,7 @@ def api_client(request, pg):
     api_settings.openapi_url = prefix + api_settings.openapi_url
     api_settings.docs_url = prefix + api_settings.docs_url
 
-    print(
+    logger.info(
         "creating client with settings, hydrate: {}, router prefix: '{}'".format(
             api_settings.use_api_hydrate, prefix
         )
@@ -159,7 +161,7 @@ def api_client(request, pg):
 
 @pytest.fixture(scope="function")
 async def app(api_client):
-    print("Creating app Fixture")
+    logger.info("Creating app Fixture")
     time.time()
     app = api_client.app
     await connect_to_db(app)
@@ -168,12 +170,12 @@ async def app(api_client):
 
     await close_db_connection(app)
 
-    print("Closed Pools.")
+    logger.info("Closed Pools.")
 
 
 @pytest.fixture(scope="function")
 async def app_client(app):
-    print("creating app_client")
+    logger.info("creating app_client")
 
     base_url = "http://test"
     if app.state.router_prefix != "":


### PR DESCRIPTION
**Description:**

An attempt to clean up the logging within the codebase to avoid unnecessary print statements generated during tests unless a higher `LOG_LEVEL` environment variable is set.

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
