### PR TITLE
Fix Github Pages deploy

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -10,6 +10,7 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "**.py"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -27,12 +28,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e \
-            stac_fastapi/api \
-            stac_fastapi/types \
-            stac_fastapi/extensions \
-          python -m pip install mkdocs mkdocs-material pdocs
+          pip install --upgrade pip
+          pip install \
+            stac_fastapi/api[docs] \
+            stac_fastapi/types[docs] \
+            stac_fastapi/extensions[docs] \
 
       - name: update API docs
         run: |


### PR DESCRIPTION
**Description:**

Our "publish docs" CI step failed after #555. This fixes that up, hopefully. We can't know until we merge with **main**, but we add `workflow_dispatch` so we can trigger this publish step manually _after_ this is merged (e.g. from a second fixup PR). Doesn't need a CHANGELOG entry or documentation.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
