### PR TITLE
Update request body types for Transaction Extension spec and client

### DIFF
--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -18,7 +18,9 @@ from stac_fastapi.types.extension import ApiExtension
 class PostItem(CollectionUri):
     """Create Item."""
 
-    item: stac_types.Item = attr.ib(default=Body(None))
+    item: Union[stac_types.Item, stac_types.ItemCollection] = attr.ib(
+        default=Body(None)
+    )
 
 
 @attr.s

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -28,18 +28,21 @@ class BaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def create_item(
-        self, collection_id: str, item: stac_types.Item, **kwargs
-    ) -> Optional[Union[stac_types.Item, Response]]:
+        self,
+        collection_id: str,
+        item: Union[stac_types.Item, stac_types.ItemCollection],
+        **kwargs,
+    ) -> Optional[Union[stac_types.Item, Response, None]]:
         """Create a new item.
 
         Called with `POST /collections/{collection_id}/items`.
 
         Args:
-            item: the item
+            item: the item or item collection
             collection_id: the id of the collection from the resource path
 
         Returns:
-            The item that was created.
+            The item that was created or None if item collection.
 
         """
         ...
@@ -138,17 +141,21 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def create_item(
-        self, collection_id: str, item: stac_types.Item, **kwargs
-    ) -> Optional[Union[stac_types.Item, Response]]:
+        self,
+        collection_id: str,
+        item: Union[stac_types.Item, stac_types.ItemCollection],
+        **kwargs,
+    ) -> Optional[Union[stac_types.Item, Response, None]]:
         """Create a new item.
 
         Called with `POST /collections/{collection_id}/items`.
 
         Args:
-            item: the item
+            item: the item or item collection
+            collection_id: the id of the collection from the resource path
 
         Returns:
-            The item that was created.
+            The item that was created or None if item collection.
 
         """
         ...

--- a/stac_fastapi/types/stac_fastapi/types/stac.py
+++ b/stac_fastapi/types/stac_fastapi/types/stac.py
@@ -1,6 +1,6 @@
 """STAC types."""
 import sys
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 # Avoids a Pydantic error:
 # TypeError: You should use `typing_extensions.TypedDict` instead of `typing.TypedDict` with Python < 3.9.2.
@@ -58,7 +58,7 @@ class Collection(Catalog, total=False):
 class Item(TypedDict, total=False):
     """STAC Item."""
 
-    type: str
+    type: Literal["Feature"]
     stac_version: str
     stac_extensions: Optional[List[str]]
     id: str
@@ -73,7 +73,7 @@ class Item(TypedDict, total=False):
 class ItemCollection(TypedDict, total=False):
     """STAC Item Collection."""
 
-    type: str
+    type: Literal["FeatureCollection"]
     features: List[Item]
     links: List[Dict[str, Any]]
     context: Optional[Dict[str, int]]


### PR DESCRIPTION
**Description:**

A POST against an items endpoint should accept an Item or ItemCollection

https://github.com/radiantearth/stac-api-spec/blob/master/ogcapi-features/extensions/transaction/README.md#methods

Added literal values to the stac_types `type` attribute in order to allow fastapi a discriminator value for parsing the request body to the correct TypedDict. Without this change, ItemCollections were parsed as Items and lost the `features` attribute.

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
