### PR TITLE
Update to API v1.0.0, and also update extension versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,7 +135,7 @@
 * Make item geometry and bbox nullable in sqlalchemy backend. ([#398](https://github.com/stac-utils/stac-fastapi/pull/398))
 * Transactions Extension update Item endpoint Item is now `/collections/{collection_id}/items/{item_id}` instead of
   `/collections/{collection_id}/items` to align with [STAC API
-  spec](https://github.com/radiantearth/stac-api-spec/tree/main/ogcapi-features/extensions/transaction#methods) ([#425](https://github.com/stac-utils/stac-fastapi/pull/425))
+  spec](https://github.com/stac-api-extensions/transaction#methods) ([#425](https://github.com/stac-utils/stac-fastapi/pull/425))
 
 ### Removed
 

--- a/stac_fastapi/api/stac_fastapi/api/config.py
+++ b/stac_fastapi/api/stac_fastapi/api/config.py
@@ -8,7 +8,7 @@ import enum
 class ApiExtensions(enum.Enum):
     """Enumeration of available stac api extensions.
 
-    Ref: https://github.com/radiantearth/stac-api-spec/tree/master/extensions
+    Ref: https://github.com/stac-api-extensions
     """
 
     context = "context"

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
@@ -14,14 +14,14 @@ class ContextExtension(ApiExtension):
     The Context extension adds a JSON object to ItemCollection responses (`/search`,
     `/collections/{collection_id}/items`) which includes the number of items matched,
     returned, and the limit requested.
-    https://github.com/radiantearth/stac-api-spec/blob/master/item-search/README.md#context
+    https://github.com/stac-api-extensions/context
     """
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.1/item-search#context"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.2/item-search#context"]
     )
     schema_href: Optional[str] = attr.ib(
-        default="https://raw.githubusercontent.com/radiantearth/stac-api-spec/v1.0.0-rc.1/fragments/context/json-schema/schema.json"
+        default="https://raw.githubusercontent.com/stac-api-extensions/context/v1.0.0-rc.2/json-schema/schema.json"
     )
 
     def register(self, app: FastAPI) -> None:

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
@@ -20,7 +20,7 @@ class FieldsExtension(ApiExtension):
     the Fields extension allows the API to return potentially invalid responses
     by excluding fields which are required by the STAC spec, such as geometry.
 
-    https://github.com/radiantearth/stac-api-spec/blob/master/item-search/README.md#fields
+    https://github.com/stac-api-extensions/fields
 
     Attributes:
         default_includes (set): defines the default set of included fields.
@@ -32,7 +32,7 @@ class FieldsExtension(ApiExtension):
     POST = FieldsExtensionPostRequest
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.1/item-search#fields"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.3/item-search#fields"]
     )
     default_includes: Set[str] = attr.ib(
         factory=lambda: {

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -19,14 +19,14 @@ class FilterConformanceClasses(str, Enum):
     """Conformance classes for the Filter extension.
 
     See
-    https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1/fragments/filter
+    https://github.com/stac-api-extensions/filter
     """
 
     FILTER = "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter"
     FEATURES_FILTER = (
         "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter"
     )
-    ITEM_SEARCH_FILTER = "https://api.stacspec.org/v1.0.0-rc.1/item-search#filter"
+    ITEM_SEARCH_FILTER = "https://api.stacspec.org/v1.0.0-rc.2/item-search#filter"
     CQL2_TEXT = "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text"
     CQL2_JSON = "http://www.opengis.net/spec/cql2/1.0/conf/cql2-json"
     BASIC_CQL2 = "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2"

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
@@ -13,7 +13,7 @@ class FilterLang(str, Enum):
     """Choices for filter-lang value in a POST request.
 
     Based on
-    https://github.com/radiantearth/stac-api-spec/tree/master/fragments/filter#queryables
+    https://github.com/stac-api-extensions/filter#queryables
 
     Note the addition of cql2-json, which is used by the pgstac backend,
     but is not included in the spec above.

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/query/query.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/query/query.py
@@ -23,7 +23,7 @@ class QueryExtension(ApiExtension):
     POST = QueryExtensionPostRequest
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.1/item-search#query"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.2/item-search#query"]
     )
     schema_href: Optional[str] = attr.ib(default=None)
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/sort/sort.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/sort/sort.py
@@ -15,14 +15,14 @@ class SortExtension(ApiExtension):
 
     The Sort extension adds the `sortby` parameter to the `/search` endpoint, allowing the
     caller to specify the sort order of the returned items.
-    https://github.com/radiantearth/stac-api-spec/blob/master/item-search/README.md#sort
+    https://github.com/stac-api-extensions/sort
     """
 
     GET = SortExtensionGetRequest
     POST = SortExtensionPostRequest
 
     conformance_classes: List[str] = attr.ib(
-        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.1/item-search#sort"]
+        factory=lambda: ["https://api.stacspec.org/v1.0.0-rc.2/item-search#sort"]
     )
     schema_href: Optional[str] = attr.ib(default=None)
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -53,7 +53,7 @@ class TransactionExtension(ApiExtension):
     settings: ApiSettings = attr.ib()
     conformance_classes: List[str] = attr.ib(
         factory=lambda: [
-            "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features/extensions/transaction",
+            "https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features/extensions/transaction",
             "http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/simpletx",
         ]
     )

--- a/stac_fastapi/types/stac_fastapi/types/conformance.py
+++ b/stac_fastapi/types/stac_fastapi/types/conformance.py
@@ -5,10 +5,10 @@ from enum import Enum
 class STACConformanceClasses(str, Enum):
     """Conformance classes for the STAC API spec."""
 
-    CORE = "https://api.stacspec.org/v1.0.0-rc.1/core"
-    OGC_API_FEAT = "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features"
-    COLLECTIONS = "https://api.stacspec.org/v1.0.0-rc.1/collections"
-    ITEM_SEARCH = "https://api.stacspec.org/v1.0.0-rc.1/item-search"
+    CORE = "https://api.stacspec.org/v1.0.0/core"
+    OGC_API_FEAT = "https://api.stacspec.org/v1.0.0/ogcapi-features"
+    COLLECTIONS = "https://api.stacspec.org/v1.0.0/collections"
+    ITEM_SEARCH = "https://api.stacspec.org/v1.0.0/item-search"
 
 
 class OAFConformanceClasses(str, Enum):

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -760,7 +760,7 @@ class BaseFiltersClient(abc.ABC):
 
         This base implementation returns a blank queryable schema. This is not allowed
         under OGC CQL but it is allowed by the STAC API Filter Extension
-        https://github.com/radiantearth/stac-api-spec/tree/master/fragments/filter#queryables
+        https://github.com/stac-api-extensions/filter#queryables
         """
         return {
             "$schema": "https://json-schema.org/draft/2019-09/schema",


### PR DESCRIPTION
**Related Issue(s):**

- Closes #566 

**Description:**

I've updated the core versions to v1.0.0, and each extension version to its latest. I've also updated the docs to point to the new extension locations after the breakout from the main repo.

To check validity, I spun up a **stac-fastapi-pgstac** instance that included this branch. I also had to use a patched version of **stac-api-validator** because of https://github.com/stac-utils/stac-api-validator/pull/365. Before this PR, **stac-api-validator** reports:

```text
INFO:stac_api_validator.validations:Validating STAC API - Core conformance class.
INFO:stac_api_validator.validations:Validating STAC API - Collections conformance class.
INFO:stac_api_validator.validations:Validating STAC API - Features conformance class.
Warnings:

- STAC API Specification <https://api.stacspec.org/v1.0.0/> is the latest version, but API advertises an older version or older versions.
- [Collections] : GET <http://localhost:8082/collections/joplin> has these stac-check recommendations: A STAC collection should contain a summaries field,It is recommended to store information like eo:bands in summaries,,Links in catalogs and collections should always have a 'title' field,
- [Collections] : GET <http://localhost:8082/collections/joplin> has these stac-check recommendations: A STAC collection should contain a summaries field,It is recommended to store information like eo:bands in summaries,,Links in catalogs and collections should always have a 'title' field,
Errors: none
```

After this PR:

```text
INFO:stac_api_validator.validations:Validating STAC API - Core conformance class.
INFO:stac_api_validator.validations:Validating STAC API - Collections conformance class.
INFO:stac_api_validator.validations:Validating STAC API - Features conformance class.
Warnings:

- [Collections] : GET <http://localhost:8082/collections/joplin> has these stac-check recommendations: A STAC collection should contain a summaries field,It is recommended to store information like eo:bands in summaries,,Links in catalogs and collections should always have a 'title' field,
- [Collections] : GET <http://localhost:8082/collections/joplin> has these stac-check recommendations: A STAC collection should contain a summaries field,It is recommended to store information like eo:bands in summaries,,Links in catalogs and collections should always have a 'title' field,
Errors: none
```



**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
