### PR TITLE
Handle x-forwarded-host header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Forward `x-forwarded-host` ([#586](https://github.com/stac-utils/stac-fastapi/pull/586))
+
 ## [2.4.8] - 2023-06-07
 
 ### Changed

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -103,6 +103,7 @@ class ProxyHeaderMiddleware:
                             # ignore ports that are not valid integers
                             pass
         else:
+            domain = self._get_header_value_by_name(scope, "x-forwarded-host", domain)
             proto = self._get_header_value_by_name(scope, "x-forwarded-proto", proto)
             port_str = self._get_header_value_by_name(scope, "x-forwarded-port", port)
             try:

--- a/stac_fastapi/api/tests/test_middleware.py
+++ b/stac_fastapi/api/tests/test_middleware.py
@@ -112,6 +112,14 @@ def test_replace_header_value_by_name(
             {
                 "scheme": "http",
                 "server": ["testserver", 80],
+                "headers": [(b"x-forwarded-host", b"test")],
+            },
+            ("http", "test", 80),
+        ),
+        (
+            {
+                "scheme": "http",
+                "server": ["testserver", 80],
                 "headers": [(b"x-forwarded-proto", b"https")],
             },
             ("https", "testserver", 80),
@@ -138,6 +146,7 @@ def test_replace_header_value_by_name(
                 "server": ["testserver", 80],
                 "headers": [
                     (b"forwarded", b"proto=https;host=test:1234"),
+                    (b"x-forwarded-host", b"another-test"),
                     (b"x-forwarded-port", b"1111"),
                     (b"x-forwarded-proto", b"https"),
                 ],


### PR DESCRIPTION
**Related Issue(s):**

- # https://github.com/stac-utils/stac-fastapi/issues/585

**Description:**
See issue
**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
