### PR TITLE
Ceil pydantic below 2

### DIFF
--- a/stac_fastapi/api/setup.py
+++ b/stac_fastapi/api/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 install_requires = [
     "attrs",
-    "pydantic[dotenv]",
+    "pydantic[dotenv]<2",
     "stac_pydantic==2.0.*",
     "brotli_asgi",
     "stac-fastapi.types",

--- a/stac_fastapi/extensions/setup.py
+++ b/stac_fastapi/extensions/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 install_requires = [
     "attrs",
-    "pydantic[dotenv]",
+    "pydantic[dotenv]<2",
     "stac_pydantic==2.0.*",
     "stac-fastapi.types",
     "stac-fastapi.api",

--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as f:
 install_requires = [
     "fastapi>=0.73.0",
     "attrs",
-    "pydantic[dotenv]",
+    "pydantic[dotenv]<2",
     "stac_pydantic==2.0.*",
     "pystac==1.*",
     "iso8601>=1.0.2,<2.1.0",


### PR DESCRIPTION
**Related Issue(s):**

- Closes #592 
- I've opened #593 to capture the removal of this ceiling

**Description:**

Doesn't need a changelog.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
