### PR TITLE
CQL2-JSON filter conformance class link

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Forward `x-forwarded-host` ([#586](https://github.com/stac-utils/stac-fastapi/pull/586))
+* Add CQL2-json to filter conformance class ([#611](https://github.com/stac-utils/stac-fastapi/issues/611))
 
 ## [2.4.8] - 2023-06-07
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -57,7 +57,7 @@ class FilterExtension(ApiExtension):
         GET /queryables
         GET /collections/{collection_id}/queryables
 
-    https://github.com/radiantearth/stac-api-spec/blob/master/fragments/filter/README.md
+    https://github.com/stac-api-extensions/filter/blob/main/README.md
 
     Attributes:
         client: Queryables endpoint logic
@@ -76,6 +76,7 @@ class FilterExtension(ApiExtension):
             FilterConformanceClasses.FEATURES_FILTER,
             FilterConformanceClasses.ITEM_SEARCH_FILTER,
             FilterConformanceClasses.BASIC_CQL2,
+            FilterConformanceClasses.CQL2_JSON,
             FilterConformanceClasses.CQL2_TEXT,
         ]
     )


### PR DESCRIPTION
**Related Issue(s):**

- #611 
- https://github.com/stac-utils/stac-fastapi-elasticsearch/issues/159

**Description:**

The CQL2-JSON filter conformance link was not being advertised. There was also a broken link in the comments that was fixed. 

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
