### PR TITLE
Allow specifying insert method for bulk transactions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Forward `x-forwarded-host` ([#586](https://github.com/stac-utils/stac-fastapi/pull/586))
 * Add CQL2-json to filter conformance class ([#611](https://github.com/stac-utils/stac-fastapi/issues/611))
+* Add `method` parameter to Bulk Transactions extension in order to support upserting bulk data ([#614](https://github.com/stac-utils/stac-fastapi/pull/614))
 
 ## [2.4.8] - 2023-06-07
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -1,5 +1,6 @@
 """Bulk transactions extension."""
 import abc
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 import attr
@@ -9,6 +10,13 @@ from pydantic import BaseModel
 from stac_fastapi.api.models import create_request_model
 from stac_fastapi.api.routes import create_async_endpoint
 from stac_fastapi.types.extension import ApiExtension
+
+
+class BulkTransactionMethod(str, Enum):
+    """Bulk Transaction Methods."""
+
+    INSERT = "insert"
+    UPSERT = "upsert"
 
 
 class Items(BaseModel):
@@ -36,13 +44,18 @@ class BaseBulkTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     def bulk_item_insert(
-        self, items: Items, chunk_size: Optional[int] = None, **kwargs
+        self,
+        items: Items,
+        chunk_size: Optional[int] = None,
+        method: BulkTransactionMethod = BulkTransactionMethod.INSERT,
+        **kwargs,
     ) -> str:
         """Bulk creation of items.
 
         Args:
             items: list of items.
             chunk_size: number of items processed at a time.
+            method: method for inserting data into the database.
 
         Returns:
             Message indicating the status of the insert.

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -23,6 +23,7 @@ class Items(BaseModel):
     """A group of STAC Item objects, in the form of a dictionary from Item.id -> Item."""
 
     items: Dict[str, Any]
+    method: BulkTransactionMethod = BulkTransactionMethod.INSERT
 
     def __iter__(self):
         """Return an iterable of STAC Item objects."""
@@ -47,7 +48,6 @@ class BaseBulkTransactionsClient(abc.ABC):
         self,
         items: Items,
         chunk_size: Optional[int] = None,
-        method: BulkTransactionMethod = BulkTransactionMethod.INSERT,
         **kwargs,
     ) -> str:
         """Bulk creation of items.
@@ -71,7 +71,6 @@ class AsyncBaseBulkTransactionsClient(abc.ABC):
     async def bulk_item_insert(
         self,
         items: Items,
-        method: BulkTransactionMethod = BulkTransactionMethod.INSERT,
         **kwargs,
     ) -> str:
         """Bulk creation of items.

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -55,7 +55,6 @@ class BaseBulkTransactionsClient(abc.ABC):
         Args:
             items: list of items.
             chunk_size: number of items processed at a time.
-            method: method for inserting data into the database.
 
         Returns:
             Message indicating the status of the insert.
@@ -94,11 +93,19 @@ class BulkTransactionExtension(ApiExtension):
     attribute  "items", that has a value that is an object with a group of
     attributes that are the ids of each Item, and the value is the Item entity.
 
+    Optionally, clients can specify a "method" attribute that is either "insert"
+    or "upsert". If "insert", then the items will be inserted if they do not
+    exist, and an error will be returned if they do. If "upsert", then the items
+    will be inserted if they do not exist, and updated if they do. This defaults
+    to "insert".
+
         {
-        "items": {
-            "id1": { "type": "Feature", ... },
-            "id2": { "type": "Feature", ... },
-            "id3": { "type": "Feature", ... }
+            "items": {
+                "id1": { "type": "Feature", ... },
+                "id2": { "type": "Feature", ... },
+                "id3": { "type": "Feature", ... }
+            },
+            "method": "insert"
         }
     """
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/third_party/bulk_transactions.py
@@ -68,7 +68,12 @@ class AsyncBaseBulkTransactionsClient(abc.ABC):
     """BulkTransactionsClient."""
 
     @abc.abstractmethod
-    async def bulk_item_insert(self, items: Items, **kwargs) -> str:
+    async def bulk_item_insert(
+        self,
+        items: Items,
+        method: BulkTransactionMethod = BulkTransactionMethod.INSERT,
+        **kwargs,
+    ) -> str:
         """Bulk creation of items.
 
         Args:


### PR DESCRIPTION
**Description:**
We have started adopting the bulk transactions extension for loading data into our pgstac backend, but are blocked by the fact that we occasionally need to re-ingest an updated item. The `bulk_item_insert` route does not provide a means of specifying alternate data loading methods (e.g. upsert, delsert, etc) and [stac-fastapi-pgstac only supports inserts via the `create_items` function](https://github.com/stac-utils/stac-fastapi-pgstac/blob/0159cdb83304a968bb8d3f2f4ad4043bdbfe2619/stac_fastapi/pgstac/transactions.py#L185). In the event of a conflict, it returns a ConflictError with no details regarding which of the bulk items caused the conflict, which makes it difficult to correct the issue.

In this PR, I propose adding an optional parameter to the request object for the bulk_item_insert route. This `method` parameter will allow clients to specify the use of `upsert` rather than the default `insert` behavior. I have created a [separate PR on stac-fastapi-pgstac](https://github.com/stac-utils/stac-fastapi-pgstac/pull/64) to support conditionally using the `upsert_items` function.

This change should not impact any stac-fastapi backends which do not support alternate loading methods, since they will ignore the optional param.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
