### PR TITLE
add items link to inferred link relations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Add `items` link to inferred link relations ([#634](https://github.com/stac-utils/stac-fastapi/issues/634))
+
 ## [2.4.9] - 2023-11-17
 
 ### Added

--- a/stac_fastapi/types/stac_fastapi/types/links.py
+++ b/stac_fastapi/types/stac_fastapi/types/links.py
@@ -10,7 +10,7 @@ from stac_pydantic.shared import MimeTypes
 # These can be inferred from the item/collection so they aren't included in the database
 # Instead they are dynamically generated when querying the database using the
 # classes defined below
-INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root"]
+INFERRED_LINK_RELS = ["self", "item", "parent", "collection", "root", "items"]
 
 
 def filter_links(links: List[Dict]) -> List[Dict]:


### PR DESCRIPTION
**Related Issue(s):**

- #634

**Description:**
Add `items` link to inferred link relations. The missing link causes duplication in some backends (eg. Elasticsearch).

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
