### PR TITLE
Update context.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-* Fixed warnings in ..... ([#660](https://github.com/stac-utils/stac-fastapi/pull/660))
+* Fixed warnings.warn deprecation syntax for response class and the context extension ([#660](https://github.com/stac-utils/stac-fastapi/pull/660))
 
 ## [2.5.0] - 2024-04-12
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.5.1] - 2024-04-18
+
+### Fixed
+
+* Fixed calls to `.warn()` from typos (`.warm()` and `.warns()`)
+
 ## [2.5.0] - 2024-04-12
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,9 @@
 
 ## [Unreleased]
 
-## [2.5.1] - 2024-04-18
-
 ### Fixed
 
-* Fixed calls to `.warn()` from typos (`.warm()` and `.warns()`)
+* Fixed warnings in ..... ([#660](https://github.com/stac-utils/stac-fastapi/pull/660))
 
 ## [2.5.0] - 2024-04-12
 

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -45,7 +45,7 @@ def create_async_endpoint(
     """
 
     if response_class:
-        warnings.warns(
+        warnings.warn(
             "`response_class` option is deprecated, please set the Response class directly in the endpoint.",  # noqa: E501
             DeprecationWarning,
         )

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/context.py
@@ -28,7 +28,7 @@ class ContextExtension(ApiExtension):
 
     def __attrs_post_init__(self):
         """init."""
-        warnings.warm(
+        warnings.warn(
             "The ContextExtension is deprecated and will be removed in 3.0.",
             DeprecationWarning,
             stacklevel=1,


### PR DESCRIPTION
typo in warning, "warm" insteand of "warn"

**Related Issue(s):**

- #

**Description:**

Typo in warning call. Currently is `warnings.warm()` instead of `warnings.warn()`

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
