### PR TITLE
fix datetime validator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* BaseSearchGetRequest datetime validator str_to_interval not allowing GET /search requests with datetime = None ([#661](https://github.com/stac-utils/stac-fastapi/pull/661))
+
 ## [2.5.1] - 2024-04-18
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-* BaseSearchGetRequest datetime validator str_to_interval not allowing GET /search requests with datetime = None ([#661](https://github.com/stac-utils/stac-fastapi/pull/661))
+* BaseSearchGetRequest datetime validator str_to_interval not allowing GET /search requests with datetime = None ([#662](https://github.com/stac-utils/stac-fastapi/pull/662))
 
 ## [2.5.1] - 2024-04-18
 

--- a/stac_fastapi/types/stac_fastapi/types/rfc3339.py
+++ b/stac_fastapi/types/stac_fastapi/types/rfc3339.py
@@ -45,9 +45,7 @@ def rfc3339_str_to_datetime(s: str) -> datetime:
     return iso8601.parse_date(s)
 
 
-def str_to_interval(
-    interval: Optional[str]
-) -> Optional[DateTimeType]:
+def str_to_interval(interval: Optional[str]) -> Optional[DateTimeType]:
     """Extract a tuple of datetimes from an interval string.
 
     Interval strings are defined by
@@ -56,18 +54,19 @@ def str_to_interval(
     or end (but not both) to be open-ended with '..' or ''.
 
     Args:
-        interval (str or None): The interval string to convert to a tuple of datetime.datetime 
-        objects, or None if no datetime is specified.
+        interval (str or None): The interval string to convert to a tuple of
+        datetime.datetime objects, or None if no datetime is specified.
 
     Returns:
-        Optional[DateTimeType]: A tuple of datetime.datetime objects or None if input is None.
+        Optional[DateTimeType]: A tuple of datetime.datetime objects or None if
+        input is None.
 
     Raises:
         ValueError: If the string is not a valid interval string and not None.
     """
     if interval is None:
         return None
-    
+
     if not interval:
         raise ValueError("Empty interval string is invalid.")
 

--- a/stac_fastapi/types/stac_fastapi/types/rfc3339.py
+++ b/stac_fastapi/types/stac_fastapi/types/rfc3339.py
@@ -46,7 +46,7 @@ def rfc3339_str_to_datetime(s: str) -> datetime:
 
 
 def str_to_interval(
-    interval: str,
+    interval: Optional[str]
 ) -> Optional[DateTimeType]:
     """Extract a tuple of datetimes from an interval string.
 
@@ -56,12 +56,18 @@ def str_to_interval(
     or end (but not both) to be open-ended with '..' or ''.
 
     Args:
-        interval (str) : The interval string to convert to a :class:`datetime.datetime`
-        tuple.
+        interval (str or None): The interval string to convert to a tuple of datetime.datetime 
+        objects, or None if no datetime is specified.
+
+    Returns:
+        Optional[DateTimeType]: A tuple of datetime.datetime objects or None if input is None.
 
     Raises:
-        ValueError: If the string is not a valid interval string.
+        ValueError: If the string is not a valid interval string and not None.
     """
+    if interval is None:
+        return None
+    
     if not interval:
         raise ValueError("Empty interval string is invalid.")
 

--- a/stac_fastapi/types/tests/test_rfc3339.py
+++ b/stac_fastapi/types/tests/test_rfc3339.py
@@ -103,3 +103,7 @@ def test_now_functions() -> None:
     assert now1.tzinfo == timezone.utc
 
     rfc3339_str_to_datetime(now_to_rfc3339_str())
+
+def test_str_to_interval_with_none():
+    """Test that str_to_interval returns None when provided with None."""
+    assert str_to_interval(None) is None, "str_to_interval should return None when input is None"

--- a/stac_fastapi/types/tests/test_rfc3339.py
+++ b/stac_fastapi/types/tests/test_rfc3339.py
@@ -104,6 +104,9 @@ def test_now_functions() -> None:
 
     rfc3339_str_to_datetime(now_to_rfc3339_str())
 
+
 def test_str_to_interval_with_none():
     """Test that str_to_interval returns None when provided with None."""
-    assert str_to_interval(None) is None, "str_to_interval should return None when input is None"
+    assert (
+        str_to_interval(None) is None
+    ), "str_to_interval should return None when input is None"


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

The str_to_interval function is not allowing datetime = None values which is preventing GET /search requests from working if no datetime value is specified. ex. this request would fail: `http://localhost:8080/search?bbox=178,-73,180,-71`

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
