### PR TITLE
apply datetime converter in ItemCollection endpoint model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+* Apply datetime converter in ItemCollection endpoint model ([#667](https://github.com/stac-utils/stac-fastapi/pull/667))
+
 ## [2.5.2] - 2024-04-19
 
 ### Fixed

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -16,6 +16,7 @@ from stac_fastapi.types.search import (
     BaseSearchGetRequest,
     BaseSearchPostRequest,
     str2bbox,
+    str_to_interval,
 )
 
 
@@ -127,7 +128,7 @@ class ItemCollectionUri(CollectionUri):
 
     limit: int = attr.ib(default=10)
     bbox: Optional[BBox] = attr.ib(default=None, converter=str2bbox)
-    datetime: Optional[DateTimeType] = attr.ib(default=None)
+    datetime: Optional[DateTimeType] = attr.ib(default=None, converter=str_to_interval)
 
 
 class POSTTokenPagination(BaseModel):


### PR DESCRIPTION
**Related Issue(s):**
N/A

**Description:**
Right now, the datetime converter is only applied in the `BaseSearchGetRequest` model, but not in the `ItemCollectionUri` model. This PR adds the converter to the last one, aligning the parameter handling.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
