### PR TITLE
use Collection Pydantic model in PutCollection transaction

### DIFF
--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -10,7 +10,6 @@ from starlette.responses import JSONResponse, Response
 
 from stac_fastapi.api.models import CollectionUri, ItemUri
 from stac_fastapi.api.routes import create_async_endpoint
-from stac_fastapi.types import stac
 from stac_fastapi.types.config import ApiSettings
 from stac_fastapi.types.core import AsyncBaseTransactionsClient, BaseTransactionsClient
 from stac_fastapi.types.extension import ApiExtension
@@ -34,7 +33,7 @@ class PutItem(ItemUri):
 class PutCollection(CollectionUri):
     """Update Collection."""
 
-    collection: stac.Collection = attr.ib(default=Body(None))
+    collection: Collection = attr.ib(default=Body(None))
 
 
 @attr.s

--- a/stac_fastapi/extensions/tests/test_transaction.py
+++ b/stac_fastapi/extensions/tests/test_transaction.py
@@ -2,6 +2,7 @@ import json
 from typing import Iterator, Union
 
 import pytest
+from stac_pydantic import Collection
 from stac_pydantic.item import Item
 from stac_pydantic.item_collection import ItemCollection
 from starlette.testclient import TestClient
@@ -10,7 +11,6 @@ from stac_fastapi.api.app import StacApi
 from stac_fastapi.extensions.core import TransactionExtension
 from stac_fastapi.types.config import ApiSettings
 from stac_fastapi.types.core import BaseCoreClient, BaseTransactionsClient
-from stac_fastapi.types.stac import Collection
 
 
 class DummyCoreClient(BaseCoreClient):
@@ -56,7 +56,7 @@ class DummyTransactionsClient(BaseTransactionsClient):
         return {"type": collection.type}
 
     def update_collection(self, collection_id: str, collection: Collection, **kwargs):
-        return {"path_collection_id": collection_id, "type": collection["type"]}
+        return {"path_collection_id": collection_id, "type": collection.type}
 
     def delete_collection(self, collection_id: str, **kwargs):
         return {"path_collection_id": collection_id}

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -38,7 +38,7 @@ class BaseTransactionsClient(abc.ABC):
         collection_id: str,
         item: Union[Item, ItemCollection],
         **kwargs,
-    ) -> Optional[Union[Item, Response, None]]:
+    ) -> Optional[Union[stac.Item, Response, None]]:
         """Create a new item.
 
         Called with `POST /collections/{collection_id}/items`.
@@ -55,7 +55,7 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def update_item(
         self, collection_id: str, item_id: str, item: Item, **kwargs
-    ) -> Optional[Union[Item, Response]]:
+    ) -> Optional[Union[stac.Item, Response]]:
         """Perform a complete update on an existing item.
 
         Called with `PUT /collections/{collection_id}/items`. It is expected
@@ -75,7 +75,7 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def delete_item(
         self, item_id: str, collection_id: str, **kwargs
-    ) -> Optional[Union[Item, Response]]:
+    ) -> Optional[Union[stac.Item, Response]]:
         """Delete an item from a collection.
 
         Called with `DELETE /collections/{collection_id}/items/{item_id}`
@@ -92,7 +92,7 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def create_collection(
         self, collection: Collection, **kwargs
-    ) -> Optional[Union[Collection, Response]]:
+    ) -> Optional[Union[stac.Collection, Response]]:
         """Create a new collection.
 
         Called with `POST /collections`.
@@ -108,7 +108,7 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def update_collection(
         self, collection_id: str, collection: Collection, **kwargs
-    ) -> Optional[Union[Collection, Response]]:
+    ) -> Optional[Union[stac.Collection, Response]]:
         """Perform a complete update on an existing collection.
 
         Called with `PUT /collections/{collection_id}`. It is expected that this
@@ -128,7 +128,7 @@ class BaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     def delete_collection(
         self, collection_id: str, **kwargs
-    ) -> Optional[Union[Collection, Response]]:
+    ) -> Optional[Union[stac.Collection, Response]]:
         """Delete a collection.
 
         Called with `DELETE /collections/{collection_id}`
@@ -152,7 +152,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         collection_id: str,
         item: Union[Item, ItemCollection],
         **kwargs,
-    ) -> Optional[Union[Item, Response, None]]:
+    ) -> Optional[Union[stac.Item, Response, None]]:
         """Create a new item.
 
         Called with `POST /collections/{collection_id}/items`.
@@ -169,7 +169,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def update_item(
         self, collection_id: str, item_id: str, item: Item, **kwargs
-    ) -> Optional[Union[Item, Response]]:
+    ) -> Optional[Union[stac.Item, Response]]:
         """Perform a complete update on an existing item.
 
         Called with `PUT /collections/{collection_id}/items`. It is expected
@@ -188,7 +188,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def delete_item(
         self, item_id: str, collection_id: str, **kwargs
-    ) -> Optional[Union[Item, Response]]:
+    ) -> Optional[Union[stac.Item, Response]]:
         """Delete an item from a collection.
 
         Called with `DELETE /collections/{collection_id}/items/{item_id}`
@@ -205,7 +205,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def create_collection(
         self, collection: Collection, **kwargs
-    ) -> Optional[Union[Collection, Response]]:
+    ) -> Optional[Union[stac.Collection, Response]]:
         """Create a new collection.
 
         Called with `POST /collections`.
@@ -221,7 +221,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def update_collection(
         self, collection_id: str, collection: Collection, **kwargs
-    ) -> Optional[Union[Collection, Response]]:
+    ) -> Optional[Union[stac.Collection, Response]]:
         """Perform a complete update on an existing collection.
 
         Called with `PUT /collections/{collection_id}`. It is expected that this item
@@ -241,7 +241,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def delete_collection(
         self, collection_id: str, **kwargs
-    ) -> Optional[Union[Collection, Response]]:
+    ) -> Optional[Union[stac.Collection, Response]]:
         """Delete a collection.
 
         Called with `DELETE /collections/{collection_id}`


### PR DESCRIPTION
Not sure why this was not in #625 

Note: we should add a note in the changelog that transaction endpoint now have Pydantic Model instead of TypedDict as input (https://github.com/stac-utils/stac-fastapi-pgstac/pull/108#issuecomment-2080119937)