### PR TITLE
move response class in route definitions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
 * Fix response model validation ([#625](https://github.com/stac-utils/stac-fastapi/pull/625))
 * Use status code 201 for Item/Collection creation ([#625](https://github.com/stac-utils/stac-fastapi/pull/625))
 * Replace Black with Ruff Format ([#625](https://github.com/stac-utils/stac-fastapi/pull/625))
+* add `response_class` in the route definitions for `FilterExtension`
 
 ## [2.5.5.post1] - 2024-04-25
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/filter.py
@@ -97,16 +97,30 @@ class FilterExtension(ApiExtension):
             name="Queryables",
             path="/queryables",
             methods=["GET"],
-            endpoint=create_async_endpoint(
-                self.client.get_queryables, EmptyRequest, self.response_class
-            ),
+            responses={
+                200: {
+                    "content": {
+                        "application/schema+json": {},
+                    },
+                    # TODO: add output model in stac-pydantic
+                },
+            },
+            response_class=self.response_class,
+            endpoint=create_async_endpoint(self.client.get_queryables, EmptyRequest),
         )
         self.router.add_api_route(
             name="Collection Queryables",
             path="/collections/{collection_id}/queryables",
             methods=["GET"],
-            endpoint=create_async_endpoint(
-                self.client.get_queryables, CollectionUri, self.response_class
-            ),
+            responses={
+                200: {
+                    "content": {
+                        "application/schema+json": {},
+                    },
+                    # TODO: add output model in stac-pydantic
+                },
+            },
+            response_class=self.response_class,
+            endpoint=create_async_endpoint(self.client.get_queryables, CollectionUri),
         )
         app.include_router(self.router, tags=["Filter Extension"])


### PR DESCRIPTION
`response_class` in `create_async_endpoint` is deprecated

Note: we should add the `Queryable` output model in stac-pydantic