### PR TITLE
use literal instead of Enum for FilterLang

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] - TBD
+
+## Changed
+
+* replace Enum with `Literal` for `FilterLang`
+
 ## [3.0.0a0] - 2024-05-06
 
 ### Added
@@ -7,7 +13,7 @@
 * Add enhanced middleware configuration to the StacApi class, enabling specific middleware options and dynamic addition post-application initialization. ([#442](https://github.com/stac-utils/stac-fastapi/pull/442))
 * Add Response Model to OpenAPI, even if model validation is turned off ([#625](https://github.com/stac-utils/stac-fastapi/pull/625))
 
-## Changes
+## Changed
 
 * Update to pydantic v2 and stac_pydantic v3 ([#625](https://github.com/stac-utils/stac-fastapi/pull/625))
 * Removed internal Search and Operator Types in favor of stac_pydantic Types ([#625](https://github.com/stac-utils/stac-fastapi/pull/625))

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
@@ -1,27 +1,13 @@
 """Filter extension request models."""
 
-from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Literal, Optional
 
 import attr
 from pydantic import BaseModel, Field
 
 from stac_fastapi.types.search import APIRequest
 
-
-class FilterLang(str, Enum):
-    """Choices for filter-lang value in a POST request.
-
-    Based on
-    https://github.com/stac-api-extensions/filter#queryables
-
-    Note the addition of cql2-json, which is used by the pgstac backend,
-    but is not included in the spec above.
-    """
-
-    cql_json = "cql-json"
-    cql2_json = "cql2-json"
-    cql2_text = "cql2-text"
+FilterLang = Literal["cql-json", "cql2-json", "cql2-text"]
 
 
 @attr.s


### PR DESCRIPTION
This change is to avoid warning message from Pydantic when serializing Search Model.
