### PR TITLE
update conformance and spec urls

### DIFF
--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -49,17 +49,20 @@ class TransactionExtension(ApiExtension):
         PUT /collections/{collection_id}/items
         DELETE /collections/{collection_id}/items
 
-    https://github.com/radiantearth/stac-api-spec/blob/master/ogcapi-features/extensions/transaction/README.md
+    https://github.com/stac-api-extensions/transaction
+    https://github.com/stac-api-extensions/collection-transaction
 
     Attributes:
         client: CRUD application logic
+
     """
 
     client: Union[AsyncBaseTransactionsClient, BaseTransactionsClient] = attr.ib()
     settings: ApiSettings = attr.ib()
     conformance_classes: List[str] = attr.ib(
         factory=lambda: [
-            "https://api.stacspec.org/v1.0.0-rc.3/ogcapi-features/extensions/transaction",
+            "https://api.stacspec.org/v1.0.0/ogcapi-features/extensions/transaction",
+            "https://api.stacspec.org/v1.0.0/collections/extensions/transaction",
         ]
     )
     schema_href: Optional[str] = attr.ib(default=None)
@@ -132,6 +135,11 @@ class TransactionExtension(ApiExtension):
             endpoint=create_async_endpoint(self.client.delete_item, ItemUri),
         )
 
+    def register_patch_item(self):
+        """Register patch item endpoint (PATCH
+        /collections/{collection_id}/items/{item_id})."""
+        raise NotImplementedError
+
     def register_create_collection(self):
         """Register create collection endpoint (POST /collections)."""
         self.router.add_api_route(
@@ -195,6 +203,10 @@ class TransactionExtension(ApiExtension):
             methods=["DELETE"],
             endpoint=create_async_endpoint(self.client.delete_collection, CollectionUri),
         )
+
+    def register_patch_collection(self):
+        """Register patch collection endpoint (PATCH /collections/{collection_id})."""
+        raise NotImplementedError
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.


### PR DESCRIPTION
This PR updates the conformance and spec URLs for the transaction extension.

The Transaction extension is now split in two extensions:
- https://github.com/stac-api-extensions/transaction
- https://github.com/stac-api-extensions/collection-transaction

note: I first thought about splitting the TransactionExtension class in two but it doesn't make much sense if we keep only one `Client` (BaseTransactionsClient). If we really wanted this we would need to also split the `BaseTransactionsClient` and thus have a lot of duplicated code. 