### PR TITLE
BUGFIX: invalid landing page link when `filter-extension` is enabled

### DIFF
--- a/stac_fastapi/api/tests/conftest.py
+++ b/stac_fastapi/api/tests/conftest.py
@@ -16,6 +16,7 @@ item_links = link_factory.ItemLinks("/", "test", "test").create_links()
 @pytest.fixture
 def _collection():
     return Collection(
+        type="Collection",
         id="test_collection",
         title="Test Collection",
         description="A test collection",

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -386,7 +386,6 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
                     "type": "application/schema+json",
                     "title": "Queryables",
                     "href": urljoin(base_url, "queryables"),
-                    "method": "GET",
                 }
             )
 


### PR DESCRIPTION
There was a unnecessary `method: "GET"` added to the queryable `link` in the landing page