### PR TITLE
deprecate Fields default-includes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,9 @@
 ### Changed
 
 * Added option for default route dependencies `*` can be used for `path` or `method` to match all allowed route. ([#705](https://github.com/stac-utils/stac-fastapi/pull/705))
-* moved `AsyncBaseFiltersClient` and `BaseFiltersClient` classes in `stac_fastapi.extensions.core.filter.client` submodule ([#704](https://github.com/stac-utils/stac-fastapi/pull/704))
+* Moved `AsyncBaseFiltersClient` and `BaseFiltersClient` classes in `stac_fastapi.extensions.core.filter.client` submodule ([#704](https://github.com/stac-utils/stac-fastapi/pull/704))
+* Removed `default_includes` from `stac_fastapi.types.config.ApiSettings` ([#706](https://github.com/stac-utils/stac-fastapi/pull/706))
+* Deprecated *Fields* extension `PostFieldsExtension.filter_fields` property ([#706](https://github.com/stac-utils/stac-fastapi/pull/706))
 
 ## [3.0.0a2] - 2024-05-31
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -458,10 +458,6 @@ class StacApi:
         self.client.title = self.title
         self.client.description = self.description
 
-        fields_ext = self.get_extension(FieldsExtension)
-        if fields_ext:
-            self.settings.default_includes = fields_ext.default_includes
-
         Settings.set(self.settings)
         self.app.state.settings = self.settings
 

--- a/stac_fastapi/api/tests/test_api.py
+++ b/stac_fastapi/api/tests/test_api.py
@@ -2,7 +2,10 @@ from fastapi import Depends, HTTPException, security, status
 from starlette.testclient import TestClient
 
 from stac_fastapi.api.app import StacApi
-from stac_fastapi.extensions.core import TokenPaginationExtension, TransactionExtension
+from stac_fastapi.extensions.core import (
+    TokenPaginationExtension,
+    TransactionExtension,
+)
 from stac_fastapi.types import config, core
 
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/fields.py
@@ -1,6 +1,6 @@
 """Fields extension."""
 
-from typing import List, Optional, Set
+from typing import List, Optional
 
 import attr
 from fastapi import FastAPI
@@ -34,19 +34,6 @@ class FieldsExtension(ApiExtension):
 
     conformance_classes: List[str] = attr.ib(
         factory=lambda: ["https://api.stacspec.org/v1.0.0/item-search#fields"]
-    )
-    default_includes: Set[str] = attr.ib(
-        factory=lambda: {
-            "id",
-            "type",
-            "stac_version",
-            "geometry",
-            "bbox",
-            "links",
-            "assets",
-            "properties.datetime",
-            "collection",
-        }
     )
     schema_href: Optional[str] = attr.ib(default=None)
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/fields/request.py
@@ -1,11 +1,11 @@
 """Request models for the fields extension."""
 
+import warnings
 from typing import Dict, Optional, Set
 
 import attr
 from pydantic import BaseModel, Field
 
-from stac_fastapi.types.config import Settings
 from stac_fastapi.types.search import APIRequest, str2list
 
 
@@ -39,6 +39,7 @@ class PostFieldsExtension(BaseModel):
                         field_dict[parent].add(key)
             else:
                 field_dict[field] = ...  # type:ignore
+
         return field_dict
 
     @property
@@ -49,10 +50,17 @@ class PostFieldsExtension(BaseModel):
         the included and excluded fields passed to the API
         Ref: https://pydantic-docs.helpmanual.io/usage/exporting_models/#advanced-include-and-exclude
         """
+        warnings.warn(
+            """The `PostFieldsExtension.filter_fields`
+            method is deprecated and will be removed in 3.0.""",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
         # Always include default_includes, even if they
         # exist in the exclude list.
         include = (self.include or set()) - (self.exclude or set())
-        include |= Settings.get().default_includes or set()
+        include |= set()
 
         return {
             "include": self._get_field_dict(include),

--- a/stac_fastapi/types/stac_fastapi/types/config.py
+++ b/stac_fastapi/types/stac_fastapi/types/config.py
@@ -1,6 +1,6 @@
 """stac_fastapi.types.config module."""
 
-from typing import Optional, Set
+from typing import Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -18,10 +18,6 @@ class ApiSettings(BaseSettings):
             set of fields which are usually in `item.properties` but are indexed
             as distinct columns in the database.
     """
-
-    # TODO: Remove `default_includes` attribute so we can use
-    # `pydantic.BaseSettings` instead
-    default_includes: Optional[Set[str]] = None
 
     stac_fastapi_title: str = "stac-fastapi"
     stac_fastapi_description: str = "stac-fastapi"


### PR DESCRIPTION
ref: https://github.com/stac-utils/stac-fastapi/issues/642, https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/issues/217


This PR does:
- removes `default_includes` from the APISettings
- removes `default_includes` attribute from `FieldsExtension` (this was in fact creating a circular dependency between the Extension and the APISettings 🤯)
-  add deprecation warning for `PostFieldsExtension.filter_fields` this should be implemented by each backend (as stac-fastapi-pgstac already does) 