### PR TITLE
#711 changed default filter language

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - TBD
 
+### Fixed
+
+* Updated default filter language in filter extension's POST search request model to match the extension's documentation [#711](https://github.com/stac-utils/stac-fastapi/issues/711)
+
 ## [3.0.0a3] - 2024-06-13
 
 ### Added

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
@@ -24,4 +24,4 @@ class FilterExtensionPostRequest(BaseModel):
 
     filter: Optional[Dict[str, Any]] = None
     filter_crs: Optional[str] = Field(alias="filter-crs", default=None)
-    filter_lang: Optional[FilterLang] = Field(alias="filter-lang", default="cql-json")
+    filter_lang: Optional[FilterLang] = Field(alias="filter-lang", default="cql2-json")

--- a/stac_fastapi/extensions/tests/test_filter.py
+++ b/stac_fastapi/extensions/tests/test_filter.py
@@ -1,0 +1,75 @@
+from typing import Iterator
+
+import pytest
+from starlette.testclient import TestClient
+
+from stac_fastapi.api.app import StacApi
+from stac_fastapi.api.models import create_get_request_model, create_post_request_model
+from stac_fastapi.extensions.core import FilterExtension
+from stac_fastapi.types.config import ApiSettings
+from stac_fastapi.types.core import BaseCoreClient
+
+
+class DummyCoreClient(BaseCoreClient):
+    def all_collections(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_collection(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_item(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_search(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def post_search(self, *args, **kwargs):
+        return args[0].model_dump()
+
+    def item_collection(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    settings = ApiSettings()
+    extensions = [FilterExtension()]
+    api = StacApi(
+        settings=settings,
+        client=DummyCoreClient(),
+        extensions=extensions,
+        search_get_request_model=create_get_request_model(extensions),
+        search_post_request_model=create_post_request_model(extensions),
+    )
+    with TestClient(api.app) as client:
+        yield client
+
+
+def test_search_filter_post_filter_lang_default(client: TestClient):
+    """Test search POST endpoint with filter ext."""
+    response = client.post(
+        "/search",
+        json={
+            "collections": ["test"],
+            "filter": {"op": "=", "args": [{"property": "test_property"}, "test-value"]},
+        },
+    )
+    assert response.is_success, response.json()
+    response_dict = response.json()
+    assert response_dict["filter_lang"] == "cql2-json"
+
+
+def test_search_filter_post_filter_lang_non_default(client: TestClient):
+    """Test search POST endpoint with filter ext."""
+    filter_lang_value = "cql2-text"
+    response = client.post(
+        "/search",
+        json={
+            "collections": ["test"],
+            "filter": {"op": "=", "args": [{"property": "test_property"}, "test-value"]},
+            "filter-lang": filter_lang_value,
+        },
+    )
+    assert response.is_success, response.json()
+    response_dict = response.json()
+    assert response_dict["filter_lang"] == filter_lang_value


### PR DESCRIPTION
**Related Issue(s):**

- #711 

**Description:**
Updated default filter language in filter extension's POST search request model to match the extension's documentation.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
