### PR TITLE
Remove the Filter Extension dependency from Aggregation Extension requests

### DIFF
--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
@@ -4,21 +4,17 @@ from typing import List, Optional, Union
 
 import attr
 
-from stac_fastapi.extensions.core.filter.request import (
-    FilterExtensionGetRequest,
-    FilterExtensionPostRequest,
-)
 from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest, str2list
 
 
 @attr.s
-class AggregationExtensionGetRequest(BaseSearchGetRequest, FilterExtensionGetRequest):
+class AggregationExtensionGetRequest(BaseSearchGetRequest):
     """Aggregation Extension GET request model."""
 
     aggregations: Optional[str] = attr.ib(default=None, converter=str2list)
 
 
-class AggregationExtensionPostRequest(BaseSearchPostRequest, FilterExtensionPostRequest):
+class AggregationExtensionPostRequest(BaseSearchPostRequest):
     """Aggregation Extension POST request model."""
 
     aggregations: Optional[List[str]] = attr.ib(default=None)

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
@@ -8,17 +8,17 @@ from stac_fastapi.extensions.core.filter.request import (
     FilterExtensionGetRequest,
     FilterExtensionPostRequest,
 )
-from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest
+from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest, str2list
 
 
 @attr.s
 class AggregationExtensionGetRequest(BaseSearchGetRequest, FilterExtensionGetRequest):
     """Aggregation Extension GET request model."""
 
-    aggregations: Optional[str] = attr.ib(default=None)
+    aggregations: Optional[str] = attr.ib(default=None, converter=str2list)
 
 
 class AggregationExtensionPostRequest(BaseSearchPostRequest, FilterExtensionPostRequest):
     """Aggregation Extension POST request model."""
 
-    aggregations: Optional[Union[str, List[str]]] = attr.ib(default=None)
+    aggregations: Optional[List[str]] = attr.ib(default=None)

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/aggregation/request.py
@@ -1,10 +1,14 @@
 """Request model for the Aggregation extension."""
 
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import attr
 
-from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest, str2list
+from stac_fastapi.types.search import (
+    BaseSearchGetRequest,
+    BaseSearchPostRequest,
+    str2list,
+)
 
 
 @attr.s


### PR DESCRIPTION
**Related Issue(s):**

- #715 

**Description:**
- Removes the Filter Extension depenency from `AggregationExtensionPostRequest` and `AggregationExtensionGetRequest`. This can be done in the implementations.
- Improve the `aggregations` typing.

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
