### PR TITLE
remove middleware stack building to avoid conflict with exception handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 ### Removed
 
 * Removed the Filter Extension depenency from `AggregationExtensionPostRequest` and `AggregationExtensionGetRequest` [#716](https://github.com/stac-utils/stac-fastapi/pull/716)
+* Removed `add_middleware` method in `StacApi` object and let starlette handle the middleware stack creation [721](https://github.com/stac-utils/stac-fastapi/pull/721)
 
 ## [3.0.0a3] - 2024-06-13
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -439,11 +439,6 @@ class StacApi:
         """
         return add_route_dependencies(self.app.router.routes, scopes, dependencies)
 
-    def add_middleware(self, middleware: Middleware):
-        """Add a middleware class to the application."""
-        self.app.user_middleware.insert(0, middleware)
-        self.app.middleware_stack = self.app.build_middleware_stack()
-
     def __attrs_post_init__(self):
         """Post-init hook.
 
@@ -484,7 +479,7 @@ class StacApi:
 
         # add middlewares
         for middleware in self.middlewares:
-            self.add_middleware(middleware)
+            self.app.user_middleware.insert(0, middleware)
 
         # customize route dependencies
         for scopes, dependencies in self.route_dependencies:


### PR DESCRIPTION
closes #719 
closes #720 

This PR removes the `middleware` stack building and the `add_middleware` method to avoid conflict with the error handler `middleware` created by starlette later.

the middleware stack will be created by starlette on the first app call 