### PR TITLE
raise RuntimeError if middleware stack has already been created when initialiazing StacApi

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -478,6 +478,9 @@ class StacApi:
         self.app.openapi = self.customize_openapi
 
         # add middlewares
+        if self.middlewares and self.app.middleware_stack is not None:
+            raise RuntimeError("Cannot add middleware after an application has started")
+
         for middleware in self.middlewares:
             self.app.user_middleware.insert(0, middleware)
 


### PR DESCRIPTION
continuation of #721 