### PR TITLE
pin minimal version for fastapi-slim

### DIFF
--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "fastapi-slim",
+    "fastapi-slim>=0.111.0",
     "attrs>=23.2.0",
     "pydantic-settings>=2",
     "stac_pydantic~=3.1",


### PR DESCRIPTION
fastapi-slim has only 2 version `0.1.0` and `0.111.0`. The first one is an empty shell, and was creating some issue when we wanted to upgrade the planetary-computer (for some reason pip-compile was selection `0.1.0` version).