### PR TITLE
use same Limit object for collection_items and get_search request model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,11 @@
 
 ### Changed
 
-* add more openapi metadata in input models [#734](https://github.com/stac-utils/stac-fastapi/pull/734)
+* Add more openapi metadata in input models [#734](https://github.com/stac-utils/stac-fastapi/pull/734)
+* Use same `Limit` (capped to `10_000`) for `/items` and `GET - /search` input models ([#737](https://github.com/stac-utils/stac-fastapi/pull/737))
 
 ### Added
+
 * Add Free-text Extension ([#655](https://github.com/stac-utils/stac-fastapi/pull/655))
 * Add Collection-Search Extension ([#736](https://github.com/stac-utils/stac-fastapi/pull/736))
 

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -14,6 +14,7 @@ from stac_fastapi.types.search import (
     APIRequest,
     BaseSearchGetRequest,
     BaseSearchPostRequest,
+    Limit,
     _bbox_converter,
     _datetime_converter,
 )
@@ -113,7 +114,12 @@ class ItemCollectionUri(APIRequest):
     """Get item collection."""
 
     collection_id: Annotated[str, Path(description="Collection ID")] = attr.ib()
-    limit: Annotated[int, Query()] = attr.ib(default=10)
+    limit: Annotated[
+        Optional[Limit],
+        Query(
+            description="Limits the number of results that are included in each page of the response (capped to 10_000)."  # noqa: E501
+        ),
+    ] = attr.ib(default=10)
     bbox: Optional[BBox] = attr.ib(default=None, converter=_bbox_converter)
     datetime: Optional[DateTimeType] = attr.ib(
         default=None, converter=_datetime_converter

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -174,9 +174,9 @@ class BaseSearchGetRequest(APIRequest):
         default=None, converter=_datetime_converter
     )
     limit: Annotated[
-        Optional[int],
+        Optional[Limit],
         Query(
-            description="Limits the number of results that are included in each page of the response."  # noqa: E501
+            description="Limits the number of results that are included in each page of the response (capped to 10_000)."  # noqa: E501
         ),
     ] = attr.ib(default=10)
 
@@ -186,5 +186,5 @@ class BaseSearchPostRequest(Search):
 
     limit: Optional[Limit] = Field(
         10,
-        description="Limits the number of results that are included in each page of the response.",  # noqa: E501
+        description="Limits the number of results that are included in each page of the response (capped to 10_000).",  # noqa: E501
     )

--- a/stac_fastapi/types/tests/test_limit.py
+++ b/stac_fastapi/types/tests/test_limit.py
@@ -1,7 +1,9 @@
 import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
-from stac_fastapi.types.search import BaseSearchPostRequest
+from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest
 
 
 @pytest.mark.parametrize("value", [0, -1])
@@ -20,3 +22,34 @@ def test_limit(value):
 def test_limit_le(value):
     search = BaseSearchPostRequest(limit=value)
     assert search.limit == 10_000
+
+
+def test_limit_get_request():
+    """test GET model."""
+
+    app = FastAPI()
+
+    @app.get("/test")
+    def route(model=Depends(BaseSearchGetRequest)):
+        return model
+
+    with TestClient(app) as client:
+        resp = client.get(
+            "/test",
+            params={
+                "limit": 10,
+            },
+        )
+        assert resp.status_code == 200
+        response_dict = resp.json()
+        assert response_dict["limit"] == 10
+
+        resp = client.get(
+            "/test",
+            params={
+                "limit": 100_000,
+            },
+        )
+        assert resp.status_code == 200
+        response_dict = resp.json()
+        assert response_dict["limit"] == 10_000


### PR DESCRIPTION
ref #737 

Update /items and GET - /search request model to use the same `Limit` as in the POST - /search model