### PR TITLE
Removed `cql2-text` in supported `filter-lang` for `FilterExtensionPostRequest` model

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+* Removed `cql2-text` in supported `filter-lang` for `FilterExtensionPostRequest` model (as per specification)
+
 ## [3.0.2] - 2024-09-20
 
 ### Added

--- a/stac_fastapi/api/tests/test_app.py
+++ b/stac_fastapi/api/tests/test_app.py
@@ -191,7 +191,7 @@ def test_filter_extension(validate, TestCoreClient, item_dict):
                 "collections": ["test"],
                 "filter": {},
                 "filter-crs": "EPSG:4326",
-                "filter-lang": "cql2-text",
+                "filter-lang": "cql2-json",
             },
         )
 

--- a/stac_fastapi/api/tests/test_models.py
+++ b/stac_fastapi/api/tests/test_models.py
@@ -63,7 +63,7 @@ def test_create_get_request_model():
 
 @pytest.mark.parametrize(
     "filter,passes",
-    [(None, True), ({"test": "test"}, True), ("test==test", False), ([], False)],
+    [(None, True), ({"test": "test"}, True), ([], False)],
 )
 def test_create_post_request_model(filter, passes):
     request_model = create_post_request_model(
@@ -82,7 +82,7 @@ def test_create_post_request_model(filter, passes):
             datetime="2020-01-01T00:00:00Z",
             limit=10,
             filter=filter,
-            **{"filter-crs": "epsg:4326", "filter-lang": "cql2-text"},
+            **{"filter-crs": "epsg:4326", "filter-lang": "cql2-json"},
         )
 
         assert model.collections == ["test1", "test2"]

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
@@ -70,7 +70,7 @@ class FilterExtensionPostRequest(BaseModel):
         default=None,
         description="The coordinate reference system (CRS) used by spatial literals in the 'filter' value. Default is `http://www.opengis.net/def/crs/OGC/1.3/CRS84`",  # noqa: E501
     )
-    filter_lang: Optional[FilterLang] = Field(
+    filter_lang: Optional[Literal["cql-json", "cql2-json"]] = Field(
         alias="filter-lang",
         default="cql2-json",
         description="The CQL filter encoding that the 'filter' value uses.",

--- a/stac_fastapi/extensions/tests/test_filter.py
+++ b/stac_fastapi/extensions/tests/test_filter.py
@@ -62,12 +62,12 @@ def test_search_filter_post_filter_lang_default(client: TestClient):
 
 def test_search_filter_post_filter_lang_non_default(client: TestClient):
     """Test search POST endpoint with filter ext."""
-    filter_lang_value = "cql2-text"
+    filter_lang_value = "cql-json"
     response = client.post(
         "/search",
         json={
             "collections": ["test"],
-            "filter": {"op": "=", "args": [{"property": "test_property"}, "test-value"]},
+            "filter": {"eq": [{"property": "test_property"}, "test-value"]},
             "filter-lang": filter_lang_value,
         },
     )


### PR DESCRIPTION
ref https://github.com/stac-utils/stac-fastapi-pgstac/pull/149#issuecomment-2372161690

> If both are advertised as being supported, it is only required that both be supported for GET query parameters, and that only that CQL2 JSON be supported for POST JSON requests. It is recommended that clients use CQL2 Text in GET requests and CQL2 JSON in POST requests.

cc @hrodmn
