### PR TITLE
add stac-api-version in landing page response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 * Add `numberMatched` and `numberReturned` properties in `types.stac.ItemCollection` model
 * Add `numberMatched` and `numberReturned` properties in `types.stac.Collections` model
+* add `stac_api_version` in Landing page response
 
 ## Changed
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -10,6 +10,7 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.params import Depends
 from stac_pydantic import api
 from stac_pydantic.api.collections import Collections
+from stac_pydantic.api.version import STAC_API_VERSION
 from stac_pydantic.shared import MimeTypes
 from stac_pydantic.version import STAC_VERSION
 from starlette.middleware import Middleware
@@ -94,6 +95,7 @@ class StacApi:
         )
     )
     stac_version: str = attr.ib(default=STAC_VERSION)
+    stac_api_version: str = attr.ib(default=STAC_API_VERSION)
     description: str = attr.ib(
         default=attr.Factory(
             lambda self: self.settings.stac_fastapi_description, takes_self=True
@@ -442,6 +444,7 @@ class StacApi:
         # inject settings
         self.client.extensions = self.extensions
         self.client.stac_version = self.stac_version
+        self.client.stac_api_version = self.stac_api_version
         self.client.title = self.title
         self.client.description = self.description
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -8,6 +8,7 @@ import attr
 from fastapi import Request
 from geojson_pydantic.geometries import Geometry
 from stac_pydantic import Collection, Item, ItemCollection
+from stac_pydantic.api.version import STAC_API_VERSION
 from stac_pydantic.links import Relations
 from stac_pydantic.shared import BBox, MimeTypes
 from stac_pydantic.version import STAC_VERSION
@@ -269,6 +270,7 @@ class LandingPageMixin(abc.ABC):
     """Create a STAC landing page (GET /)."""
 
     stac_version: str = attr.ib(default=STAC_VERSION)
+    stac_api_version: str = attr.ib(default=STAC_API_VERSION)
     landing_page_id: str = attr.ib(default=api_settings.stac_fastapi_landing_id)
     title: str = attr.ib(default=api_settings.stac_fastapi_title)
     description: str = attr.ib(default=api_settings.stac_fastapi_description)
@@ -285,6 +287,7 @@ class LandingPageMixin(abc.ABC):
             title=self.title,
             description=self.description,
             stac_version=self.stac_version,
+            stac_api_version=self.stac_api_version,
             conformsTo=conformance_classes,
             links=[
                 {

--- a/stac_fastapi/types/stac_fastapi/types/stac.py
+++ b/stac_fastapi/types/stac_fastapi/types/stac.py
@@ -32,6 +32,7 @@ class Catalog(TypedDict, total=False):
 class LandingPage(Catalog, total=False):
     """STAC Landing Page."""
 
+    stac_api_version: str
     conformsTo: List[str]
 
 


### PR DESCRIPTION
closes #761 

This PR adds a `stac_api_version` attribute in the `stac.LandingPage` model, returned by `/` endpoint.

**This is not in the specification**, in fact it's not clear to me what is in the specification for the landing page response! 

```json
{
  "type": "Catalog",
  "id": "stac-fastapi",
  "title": "stac-fastapi",
  "description": "stac-fastapi",
  "stac_version": "1.0.0",
  "stac_api_version": "1.0.0",
  "conformsTo": [
    ...
  ],
  "links": [
    ...
  ],
  "stac_extensions": []
}
```

The pydantic model from stac-pydantic, allows extra attribute so this addition should not `break` any thing, and I don't think we need to add this in the model as well. It will be specific to stac-fastapi applications