### PR TITLE
return more information when pydantic raise validation error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 ## Changed
 
 * use `stac_pydantic.version.STAC_VERSION` instead of `stac_pydantic.api.version.STAC_API_VERSION` as application `stac_version`
+* Return more informations from pydantic validation errors
 
 ## [3.0.3] - 2024-10-09
 

--- a/stac_fastapi/api/stac_fastapi/api/errors.py
+++ b/stac_fastapi/api/stac_fastapi/api/errors.py
@@ -4,6 +4,7 @@ import logging
 from typing import Callable, Dict, Type, TypedDict
 
 from fastapi import FastAPI
+from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError, ResponseValidationError
 from starlette import status
 from starlette.requests import Request
@@ -88,7 +89,7 @@ def add_exception_handlers(
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
         return JSONResponse(
-            content=ErrorResponse(code=exc.__class__.__name__, description=str(exc)),
+            content=jsonable_encoder({"detail": exc.errors(), "body": exc.body}),
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 


### PR DESCRIPTION
ref https://github.com/stac-utils/stac-fastapi/issues/750

```
>> httpx -m POST http://127.0.0.1:8000/search -j '{"limit": "yo"}' 
{
    "detail": [
        {
            "type": "int_parsing",
            "loc": [
                "body",
                "limit"
            ],
            "msg": "Input should be a valid integer, unable to parse string as an integer",
            "input": "yo"
        }
    ],
    "body": {
        "limit": "yo"
    }
}

>> httpx -m GET http://127.0.0.1:8000/search\?limit\=yo
{
    "detail": [
        {
            "type": "int_parsing",
            "loc": [
                "query",
                "limit"
            ],
            "msg": "Input should be a valid integer, unable to parse string as an integer",
            "input": "yo"
        }
    ],
    "body": null
}
```

@drnextgis is that better ?