### PR TITLE
deprecate post_request_model in `BaseCoreClient` and `AsyncBaseCoreClient`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,8 +15,9 @@
 
 ## Changed
 
-* use `stac_pydantic.version.STAC_VERSION` instead of `stac_pydantic.api.version.STAC_API_VERSION` as application `stac_version`
+* Use `stac_pydantic.version.STAC_VERSION` instead of `stac_pydantic.api.version.STAC_API_VERSION` as application `stac_version`
 * Return more informations from pydantic validation errors
+* Add deprecation notice for `post_request_model` attribute in `BaseCoreClient` and `AsyncBaseCoreClient`
 
 ## [3.0.3] - 2024-10-09
 

--- a/stac_fastapi/api/tests/test_app.py
+++ b/stac_fastapi/api/tests/test_app.py
@@ -165,13 +165,11 @@ def test_filter_extension(validate, TestCoreClient, item_dict):
                 type="FeatureCollection", features=[stac.Item(**item_dict)]
             )
 
-    post_request_model = create_post_request_model([FilterExtension()])
-
     test_app = app.StacApi(
         settings=ApiSettings(enable_response_models=validate),
-        client=FilterClient(post_request_model=post_request_model),
+        client=FilterClient(),
         search_get_request_model=create_get_request_model([FilterExtension()]),
-        search_post_request_model=post_request_model,
+        search_post_request_model=create_post_request_model([FilterExtension()]),
         extensions=[FilterExtension()],
     )
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -1,6 +1,7 @@
 """Base clients."""
 
 import abc
+import warnings
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urljoin
 
@@ -341,7 +342,20 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         factory=lambda: BASE_CONFORMANCE_CLASSES
     )
     extensions: List[ApiExtension] = attr.ib(default=attr.Factory(list))
-    post_request_model = attr.ib(default=BaseSearchPostRequest)
+    post_request_model = attr.ib(default=None)
+
+    @post_request_model.validator
+    def _deprecate_post_model(self, attribute, value):
+        """Check and raise warning if `post_request_model` is set."""
+        if value is not None:
+            warnings.warn(
+                "`post_request_model` attribute is deprecated and will be removed in 3.1",
+                DeprecationWarning,
+            )
+
+    def __attrs_post_init__(self):
+        """Set default value for post_request_model."""
+        self.post_request_model = self.post_request_model or BaseSearchPostRequest
 
     def conformance_classes(self) -> List[str]:
         """Generate conformance classes by adding extension conformance to base
@@ -573,7 +587,20 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         factory=lambda: BASE_CONFORMANCE_CLASSES
     )
     extensions: List[ApiExtension] = attr.ib(default=attr.Factory(list))
-    post_request_model = attr.ib(default=BaseSearchPostRequest)
+    post_request_model = attr.ib(default=None)
+
+    @post_request_model.validator
+    def _deprecate_post_model(self, attribute, value):
+        """Check and raise warning if `post_request_model` is set."""
+        if value is not None:
+            warnings.warn(
+                "`post_request_model` attribute is deprecated and will be removed in 3.1",
+                DeprecationWarning,
+            )
+
+    def __attrs_post_init__(self):
+        """Set default value for post_request_model."""
+        self.post_request_model = self.post_request_model or BaseSearchPostRequest
 
     def conformance_classes(self) -> List[str]:
         """Generate conformance classes by adding extension conformance to base


### PR DESCRIPTION
ref https://github.com/stac-utils/stac-fastapi/issues/753

The attribute is not use in any abstract method. It's up to the backend Client to add desired attributes 