### PR TITLE
remove warning to `from_extensions` method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Removed
+
+* Remove `warnings` in `CollectionSearchExtension.from_extensions()` methods when passing `unknown` extensions
+
 ## [3.0.4] - 2025-01-08
 
 ### Removed

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/collection_search.py
@@ -1,6 +1,5 @@
 """Collection-Search extension."""
 
-import warnings
 from enum import Enum
 from typing import List, Optional, Union
 
@@ -79,7 +78,7 @@ class CollectionSearchExtension(ApiExtension):
         schema_href: Optional[str] = None,
     ) -> "CollectionSearchExtension":
         """Create CollectionSearchExtension object from extensions."""
-        supported_extensions = {
+        known_extension_conformances = {
             "FreeTextExtension": ConformanceClasses.FREETEXT,
             "FreeTextAdvancedExtension": ConformanceClasses.FREETEXT,
             "QueryExtension": ConformanceClasses.QUERY,
@@ -92,13 +91,7 @@ class CollectionSearchExtension(ApiExtension):
             ConformanceClasses.BASIS,
         ]
         for ext in extensions:
-            conf = supported_extensions.get(ext.__class__.__name__, None)
-            if not conf:
-                warnings.warn(
-                    f"Conformance class for `{ext.__class__.__name__}` extension not found.",  # noqa: E501
-                    UserWarning,
-                )
-            else:
+            if conf := known_extension_conformances.get(ext.__class__.__name__, None):
                 conformance_classes.append(conf)
 
         get_request_model = create_request_model(
@@ -187,7 +180,7 @@ class CollectionSearchPostExtension(CollectionSearchExtension):
         router: Optional[APIRouter] = None,
     ) -> "CollectionSearchPostExtension":
         """Create CollectionSearchPostExtension object from extensions."""
-        supported_extensions = {
+        known_extension_conformances = {
             "FreeTextExtension": ConformanceClasses.FREETEXT,
             "FreeTextAdvancedExtension": ConformanceClasses.FREETEXT,
             "QueryExtension": ConformanceClasses.QUERY,
@@ -200,13 +193,7 @@ class CollectionSearchPostExtension(CollectionSearchExtension):
             ConformanceClasses.BASIS,
         ]
         for ext in extensions:
-            conf = supported_extensions.get(ext.__class__.__name__, None)
-            if not conf:
-                warnings.warn(
-                    f"Conformance class for `{ext.__class__.__name__}` extension not found.",  # noqa: E501
-                    UserWarning,
-                )
-            else:
+            if conf := known_extension_conformances.get(ext.__class__.__name__, None):
                 conformance_classes.append(conf)
 
         get_request_model = create_request_model(

--- a/stac_fastapi/extensions/tests/test_collection_search.py
+++ b/stac_fastapi/extensions/tests/test_collection_search.py
@@ -476,35 +476,36 @@ def test_from_extensions_methods(extensions):
 
 
 def test_from_extensions_methods_invalid():
-    """Should raise warnings for invalid extensions."""
+    """Should also work with unknown extensions."""
     extensions = [
         AggregationExtension(),
     ]
-    with pytest.warns((UserWarning)):
-        ext = CollectionSearchExtension.from_extensions(
-            extensions,
-        )
+    ext = CollectionSearchExtension.from_extensions(
+        extensions,
+    )
+
     collection_search = ext.GET()
     assert collection_search.__class__.__name__ == "CollectionsGetRequest"
     assert hasattr(collection_search, "bbox")
     assert hasattr(collection_search, "datetime")
     assert hasattr(collection_search, "limit")
+    assert hasattr(collection_search, "aggregations")
     assert ext.conformance_classes == [
         ConformanceClasses.COLLECTIONSEARCH,
         ConformanceClasses.BASIS,
     ]
 
-    with pytest.warns((UserWarning)):
-        ext = CollectionSearchPostExtension.from_extensions(
-            extensions,
-            client=DummyPostClient(),
-            settings=ApiSettings(),
-        )
+    ext = CollectionSearchPostExtension.from_extensions(
+        extensions,
+        client=DummyPostClient(),
+        settings=ApiSettings(),
+    )
     collection_search = ext.POST()
     assert collection_search.__class__.__name__ == "CollectionsPostRequest"
     assert hasattr(collection_search, "bbox")
     assert hasattr(collection_search, "datetime")
     assert hasattr(collection_search, "limit")
+    assert hasattr(collection_search, "aggregations")
     assert ext.conformance_classes == [
         ConformanceClasses.COLLECTIONSEARCH,
         ConformanceClasses.BASIS,


### PR DESCRIPTION
Some extensions could be `valid` but without conformances classe (https://github.com/stac-api-extensions/collection-search/issues/19) so there is no real need to raise a warning here