### PR TITLE
keep datetime as string type in GET Request models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## Changed
+
+* use `string` type instead of python `datetime.datetime` for datetime parameter in `BaseSearchGetRequest`, `ItemCollectionUri` and `BaseCollectionSearchGetRequest` GET models
+
 ## [3.0.5] - 2025-01-10
 
 ### Removed

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -1,5 +1,6 @@
 """Api request/response models."""
 
+from datetime import datetime as dt
 from typing import List, Optional, Type, Union
 
 import attr
@@ -9,14 +10,13 @@ from stac_pydantic.shared import BBox
 from typing_extensions import Annotated
 
 from stac_fastapi.types.extension import ApiExtension
-from stac_fastapi.types.rfc3339 import DateTimeType
+from stac_fastapi.types.rfc3339 import str_to_interval
 from stac_fastapi.types.search import (
     APIRequest,
     BaseSearchGetRequest,
     BaseSearchPostRequest,
     Limit,
     _bbox_converter,
-    _datetime_converter,
 )
 
 try:
@@ -121,9 +121,40 @@ class ItemCollectionUri(APIRequest):
         ),
     ] = attr.ib(default=10)
     bbox: Optional[BBox] = attr.ib(default=None, converter=_bbox_converter)
-    datetime: Optional[DateTimeType] = attr.ib(
-        default=None, converter=_datetime_converter
-    )
+    datetime: Annotated[
+        Optional[str],
+        Query(
+            description="""Only return items that have a temporal property that intersects this value.\n
+Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.""",  # noqa: E501
+            openapi_examples={
+                "datetime": {"value": "2018-02-12T23:20:50Z"},
+                "closed-interval": {"value": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"},
+                "open-interval-from": {"value": "2018-02-12T00:00:00Z/.."},
+                "open-interval-to": {"value": "../2018-03-18T12:31:12Z"},
+            },
+        ),
+    ] = attr.ib(default=None)
+
+    @datetime.validator
+    def validate_datetime(self, attribute, value):
+        """Validate Datetime."""
+        _ = str_to_interval(value)
+
+    @property
+    def start_date(self) -> Optional[dt]:
+        """Start Date."""
+        if self.datetime is None:
+            return self.datetime
+        interval = str_to_interval(self.datetime)
+        return interval if isinstance(interval, dt) else interval[0]
+
+    @property
+    def end_date(self) -> Optional[dt]:
+        """End Date."""
+        if self.datetime is None:
+            return self.datetime
+        interval = str_to_interval(self.datetime)
+        return interval[1] if isinstance(interval, tuple) else None
 
 
 class GeoJSONResponse(JSONResponse):

--- a/stac_fastapi/api/stac_fastapi/api/models.py
+++ b/stac_fastapi/api/stac_fastapi/api/models.py
@@ -1,6 +1,5 @@
 """Api request/response models."""
 
-from datetime import datetime as dt
 from typing import List, Optional, Type, Union
 
 import attr
@@ -10,13 +9,15 @@ from stac_pydantic.shared import BBox
 from typing_extensions import Annotated
 
 from stac_fastapi.types.extension import ApiExtension
-from stac_fastapi.types.rfc3339 import str_to_interval
 from stac_fastapi.types.search import (
     APIRequest,
     BaseSearchGetRequest,
     BaseSearchPostRequest,
+    DatetimeMixin,
+    DateTimeQueryType,
     Limit,
     _bbox_converter,
+    _validate_datetime,
 )
 
 try:
@@ -110,7 +111,7 @@ class EmptyRequest(APIRequest):
 
 
 @attr.s
-class ItemCollectionUri(APIRequest):
+class ItemCollectionUri(APIRequest, DatetimeMixin):
     """Get item collection."""
 
     collection_id: Annotated[str, Path(description="Collection ID")] = attr.ib()
@@ -121,40 +122,7 @@ class ItemCollectionUri(APIRequest):
         ),
     ] = attr.ib(default=10)
     bbox: Optional[BBox] = attr.ib(default=None, converter=_bbox_converter)
-    datetime: Annotated[
-        Optional[str],
-        Query(
-            description="""Only return items that have a temporal property that intersects this value.\n
-Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.""",  # noqa: E501
-            openapi_examples={
-                "datetime": {"value": "2018-02-12T23:20:50Z"},
-                "closed-interval": {"value": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"},
-                "open-interval-from": {"value": "2018-02-12T00:00:00Z/.."},
-                "open-interval-to": {"value": "../2018-03-18T12:31:12Z"},
-            },
-        ),
-    ] = attr.ib(default=None)
-
-    @datetime.validator
-    def validate_datetime(self, attribute, value):
-        """Validate Datetime."""
-        _ = str_to_interval(value)
-
-    @property
-    def start_date(self) -> Optional[dt]:
-        """Start Date."""
-        if self.datetime is None:
-            return self.datetime
-        interval = str_to_interval(self.datetime)
-        return interval if isinstance(interval, dt) else interval[0]
-
-    @property
-    def end_date(self) -> Optional[dt]:
-        """End Date."""
-        if self.datetime is None:
-            return self.datetime
-        interval = str_to_interval(self.datetime)
-        return interval[1] if isinstance(interval, tuple) else None
+    datetime: DateTimeQueryType = attr.ib(default=None, validator=_validate_datetime)
 
 
 class GeoJSONResponse(JSONResponse):

--- a/stac_fastapi/api/tests/test_models.py
+++ b/stac_fastapi/api/tests/test_models.py
@@ -39,8 +39,19 @@ def test_create_get_request_model():
     assert d.microsecond == 10
     assert not model.end_date
 
+    model = request_model(
+        datetime="2020-01-01T00:00:00.00001Z/2020-01-02T00:00:00.00001Z",
+    )
+    assert model.start_date
+    assert model.end_date
+
+    # invalid datetime format
     with pytest.raises(HTTPException):
         request_model(datetime="yo")
+
+    # Wrong order
+    with pytest.raises(HTTPException):
+        request_model(datetime="2020-01-02T00:00:00.00001Z/2020-01-01T00:00:00.00001Z")
 
     app = FastAPI()
 
@@ -92,6 +103,9 @@ def test_create_post_request_model(filter_val, passes):
         assert model.filter_crs == "epsg:4326"
         assert model.filter == filter_val
         assert model.datetime == "2020-01-01T00:00:00.00001Z"
+
+    with pytest.raises(ValidationError):
+        request_model(datetime="yo")
 
 
 @pytest.mark.parametrize(

--- a/stac_fastapi/api/tests/test_models.py
+++ b/stac_fastapi/api/tests/test_models.py
@@ -35,8 +35,9 @@ def test_create_get_request_model():
 
     assert model.collections == ["test1", "test2"]
     assert model.filter_crs == "epsg:4326"
-    d = model.datetime
+    d = model.start_date
     assert d.microsecond == 10
+    assert not model.end_date
 
     with pytest.raises(HTTPException):
         request_model(datetime="yo")

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
@@ -69,12 +69,14 @@ class BaseCollectionSearchPostRequest(BaseModel):
     """Collection-Search POST model."""
 
     bbox: Optional[BBox] = Field(
+        default=None,
         description="Only return items intersecting this bounding box. Mutually exclusive with **intersects**.",  # noqa: E501
         json_schema_extra={
             "example": [-175.05, -85.05, 175.05, 85.05],
         },
     )
     datetime: Optional[str] = Field(
+        default=None,
         description="""Only return items that have a temporal property that intersects this value.\n
 Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.""",  # noqa: E501
         json_schema_extra={

--- a/stac_fastapi/extensions/tests/test_collection_search.py
+++ b/stac_fastapi/extensions/tests/test_collection_search.py
@@ -120,10 +120,7 @@ def test_collection_search_extension_default():
         assert response.is_success, response.json()
         response_dict = response.json()
         assert [-175.05, -85.05, 175.05, 85.05] == response_dict["bbox"]
-        assert [
-            "2020-06-13T13:00:00+00:00",
-            "2020-06-13T14:00:00+00:00",
-        ] == response_dict["datetime"]
+        assert "2020-06-13T13:00:00Z/2020-06-13T14:00:00Z" == response_dict["datetime"]
         assert 100 == response_dict["limit"]
 
 
@@ -211,10 +208,7 @@ def test_collection_search_extension_models():
         assert response.is_success, response.json()
         response_dict = response.json()
         assert [-175.05, -85.05, 175.05, 85.05] == response_dict["bbox"]
-        assert [
-            "2020-06-13T13:00:00+00:00",
-            "2020-06-13T14:00:00+00:00",
-        ] == response_dict["datetime"]
+        assert "2020-06-13T13:00:00Z/2020-06-13T14:00:00Z" == response_dict["datetime"]
         assert 100 == response_dict["limit"]
         assert ["EO", "Earth Observation"] == response_dict["q"]
         assert "id='item_id' AND collection='collection_id'" == response_dict["filter"]

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -19,7 +19,6 @@ from stac_fastapi.types.config import ApiSettings
 from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.requests import get_base_url
-from stac_fastapi.types.rfc3339 import DateTimeType
 from stac_fastapi.types.search import BaseSearchPostRequest
 
 __all__ = [
@@ -497,7 +496,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         ids: Optional[List[str]] = None,
         bbox: Optional[BBox] = None,
         intersects: Optional[Geometry] = None,
-        datetime: Optional[DateTimeType] = None,
+        datetime: Optional[str] = None,
         limit: Optional[int] = 10,
         **kwargs,
     ) -> stac.ItemCollection:
@@ -555,7 +554,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
         self,
         collection_id: str,
         bbox: Optional[BBox] = None,
-        datetime: Optional[DateTimeType] = None,
+        datetime: Optional[str] = None,
         limit: int = 10,
         token: str = None,
         **kwargs,
@@ -733,7 +732,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         ids: Optional[List[str]] = None,
         bbox: Optional[BBox] = None,
         intersects: Optional[Geometry] = None,
-        datetime: Optional[DateTimeType] = None,
+        datetime: Optional[str] = None,
         limit: Optional[int] = 10,
         **kwargs,
     ) -> stac.ItemCollection:
@@ -791,7 +790,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
         self,
         collection_id: str,
         bbox: Optional[BBox] = None,
-        datetime: Optional[DateTimeType] = None,
+        datetime: Optional[str] = None,
         limit: int = 10,
         token: str = None,
         **kwargs,

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -93,16 +93,6 @@ NumType = Union[float, int]
 Limit = Annotated[PositiveInt, AfterValidator(crop)]
 
 
-@attr.s
-class APIRequest:
-    """Generic API Request base class."""
-
-    def kwargs(self) -> Dict:
-        """Transform api request params into format which matches the signature of the
-        endpoint."""
-        return self.__dict__
-
-
 DateTimeQueryType = Annotated[
     Optional[str],
     Query(
@@ -116,6 +106,16 @@ Either a date-time or an interval, open or closed. Date and time expressions adh
         },
     ),
 ]
+
+
+@attr.s
+class APIRequest:
+    """Generic API Request base class."""
+
+    def kwargs(self) -> Dict:
+        """Transform api request params into format which matches the signature of the
+        endpoint."""
+        return self.__dict__
 
 
 @attr.s

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -12,7 +12,7 @@ from stac_pydantic.api import Search
 from stac_pydantic.shared import BBox
 from typing_extensions import Annotated
 
-from stac_fastapi.types.rfc3339 import str_to_interval
+from stac_fastapi.types.rfc3339 import DateTimeType, str_to_interval
 
 
 def crop(v: PositiveInt) -> PositiveInt:
@@ -124,21 +124,27 @@ class DatetimeMixin:
 
     datetime: DateTimeQueryType = attr.ib(default=None, validator=_validate_datetime)
 
+    def parse_datetime(self) -> Optional[DateTimeType]:
+        """Return Datetime objects."""
+        return str_to_interval(self.datetime)
+
     @property
     def start_date(self) -> Optional[dt]:
         """Start Date."""
-        if self.datetime is None:
-            return self.datetime
-        interval = str_to_interval(self.datetime)
-        return interval if isinstance(interval, dt) else interval[0]
+        parsed = self.parse_datetime()
+        if parsed is None:
+            return None
+
+        return parsed[0] if isinstance(parsed, tuple) else parsed
 
     @property
     def end_date(self) -> Optional[dt]:
         """End Date."""
-        if self.datetime is None:
-            return self.datetime
-        interval = str_to_interval(self.datetime)
-        return interval[1] if isinstance(interval, tuple) else None
+        parsed = self.parse_datetime()
+        if parsed is None:
+            return None
+
+        return parsed[1] if isinstance(parsed, tuple) else None
 
 
 @attr.s

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -1,7 +1,7 @@
 """stac_fastapi.types.search module.
 
 """
-
+from datetime import datetime as dt
 from typing import Dict, List, Optional, Union
 
 import attr
@@ -12,7 +12,7 @@ from stac_pydantic.api import Search
 from stac_pydantic.shared import BBox
 from typing_extensions import Annotated
 
-from stac_fastapi.types.rfc3339 import DateTimeType, str_to_interval
+from stac_fastapi.types.rfc3339 import str_to_interval
 
 
 def crop(v: PositiveInt) -> PositiveInt:
@@ -81,24 +81,6 @@ def _bbox_converter(
     ] = None,
 ) -> Optional[BBox]:
     return str2bbox(val)
-
-
-def _datetime_converter(
-    val: Annotated[
-        Optional[str],
-        Query(
-            description="""Only return items that have a temporal property that intersects this value.\n
-Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.""",  # noqa: E501
-            openapi_examples={
-                "datetime": {"value": "2018-02-12T23:20:50Z"},
-                "closed-interval": {"value": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"},
-                "open-interval-from": {"value": "2018-02-12T00:00:00Z/.."},
-                "open-interval-to": {"value": "../2018-03-18T12:31:12Z"},
-            },
-        ),
-    ] = None,
-):
-    return str_to_interval(val)
 
 
 # Be careful: https://github.com/samuelcolvin/pydantic/issues/1423#issuecomment-642797287
@@ -170,15 +152,46 @@ class BaseSearchGetRequest(APIRequest):
             },
         ),
     ] = attr.ib(default=None)
-    datetime: Optional[DateTimeType] = attr.ib(
-        default=None, converter=_datetime_converter
-    )
+    datetime: Annotated[
+        Optional[str],
+        Query(
+            description="""Only return items that have a temporal property that intersects this value.\n
+Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.""",  # noqa: E501
+            openapi_examples={
+                "datetime": {"value": "2018-02-12T23:20:50Z"},
+                "closed-interval": {"value": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"},
+                "open-interval-from": {"value": "2018-02-12T00:00:00Z/.."},
+                "open-interval-to": {"value": "../2018-03-18T12:31:12Z"},
+            },
+        ),
+    ] = attr.ib(default=None)
     limit: Annotated[
         Optional[Limit],
         Query(
             description="Limits the number of results that are included in each page of the response (capped to 10_000)."  # noqa: E501
         ),
     ] = attr.ib(default=10)
+
+    @datetime.validator
+    def validate_datetime(self, attribute, value):
+        """Validate Datetime."""
+        _ = str_to_interval(value)
+
+    @property
+    def start_date(self) -> Optional[dt]:
+        """Start Date."""
+        if self.datetime is None:
+            return self.datetime
+        interval = str_to_interval(self.datetime)
+        return interval if isinstance(interval, dt) else interval[0]
+
+    @property
+    def end_date(self) -> Optional[dt]:
+        """End Date."""
+        if self.datetime is None:
+            return self.datetime
+        interval = str_to_interval(self.datetime)
+        return interval[1] if isinstance(interval, tuple) else None
 
 
 class BaseSearchPostRequest(Search):


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi/issues/778

**Description:**

This PR change the `type` for the datetime parameter in GET request for `/search`, `/collection` and `/items` endpoints.

with this change, The GET and POST request models behave similarly by setting type for `string`. 