### PR TITLE
return Sorted conformances classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- sort conformance classes
+
 ## [4.0.0] - 2025-01-17
 
 ### Changed

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -350,7 +350,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
             extension_classes = getattr(extension, "conformance_classes", [])
             base_conformance_classes.extend(extension_classes)
 
-        return list(set(base_conformance_classes))
+        return sorted(list(set(base_conformance_classes)))
 
     def extension_is_enabled(self, extension: str) -> bool:
         """Check if an api extension is enabled."""
@@ -581,7 +581,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
             extension_classes = getattr(extension, "conformance_classes", [])
             conformance_classes.extend(extension_classes)
 
-        return list(set(conformance_classes))
+        return sorted(list(set(conformance_classes)))
 
     def extension_is_enabled(self, extension: str) -> bool:
         """Check if an api extension is enabled."""


### PR DESCRIPTION
IMO this helps a bit visually


```
# before
{
    "conformsTo": [
        "https://api.stacspec.org/v1.0.0/item-search",
        "https://api.stacspec.org/v1.0.0-rc.2/item-search#context",
        "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
        "https://api.stacspec.org/v1.0.0/core",
        "https://api.stacspec.org/v1.0.0/item-search#query",
        "https://api.stacspec.org/v1.0.0/ogcapi-features",
        "http://www.opengis.net/spec/cql2/1.0/conf/cql2-json",
        "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
        "https://api.stacspec.org/v1.0.0/item-search#sort",
        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
        "https://api.stacspec.org/v1.0.0-rc.2/item-search#filter",
        "https://api.stacspec.org/v1.0.0/item-search#fields",
        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
        "https://api.stacspec.org/v1.0.0/collections",
        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter"
    ]
}

# with this PR 
{
    "conformsTo": [
        "http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2",
        "http://www.opengis.net/spec/cql2/1.0/conf/cql2-json",
        "http://www.opengis.net/spec/cql2/1.0/conf/cql2-text",
        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
        "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
        "https://api.stacspec.org/v1.0.0-rc.2/item-search#context",
        "https://api.stacspec.org/v1.0.0-rc.2/item-search#filter",
        "https://api.stacspec.org/v1.0.0/collections",
        "https://api.stacspec.org/v1.0.0/core",
        "https://api.stacspec.org/v1.0.0/item-search",
        "https://api.stacspec.org/v1.0.0/item-search#fields",
        "https://api.stacspec.org/v1.0.0/item-search#query",
        "https://api.stacspec.org/v1.0.0/item-search#sort",
        "https://api.stacspec.org/v1.0.0/ogcapi-features"
    ]
}
```
