### PR TITLE
refactor: enhance assert bbox length with descriptive message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- added descriptive message to `types.search.str2bbox` length assert
+
 ## [5.0.2] - 2025-01-30
 
 ### Fixed

--- a/stac_fastapi/types/stac_fastapi/types/search.py
+++ b/stac_fastapi/types/stac_fastapi/types/search.py
@@ -35,7 +35,7 @@ def str2bbox(x: str) -> Optional[BBox]:
     """Convert string to BBox based on , delimiter."""
     if x:
         t = tuple(float(v) for v in str2list(x))
-        assert len(t) == 4
+        assert len(t) == 4, f"BBox '{x}' must have 4 values."
         return t
 
     return None


### PR DESCRIPTION
**Description:**

Adds a descriptive message to `types.search.str2bbox` length assert

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
