### PR TITLE
switch to mkdocstring

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -33,13 +33,5 @@ jobs:
             stac_fastapi/api[docs] \
             stac_fastapi/extensions[docs] \
 
-      - name: update API docs
-        run: |
-          pdocs as_markdown \
-            --output_dir docs/src/api/ \
-            --exclude_source \
-            --overwrite \
-            stac_fastapi
-
       - name: Deploy docs
         run: mkdocs gh-deploy --force -f docs/mkdocs.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,13 +36,6 @@ To manually deploy docs (note you should never need to do this because GitHub
 Actions deploys automatically for new commits.):
 
 ```bash
-Create API documentations
-$ pdocs as_markdown \
-  --output_dir docs/src/api/ \
-  --exclude_source \
-  --overwrite \
-  stac_fastapi
-
 # deploy
 $ mkdocs gh-deploy -f docs/mkdocs.yml
 ```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,24 +30,39 @@ nav:
           - models: api/stac_fastapi/api/models.md
           - openapi: api/stac_fastapi/api/openapi.md
           - routes: api/stac_fastapi/api/routes.md
-          - version: api/stac_fastapi/api/version.md
       - stac_fastapi.extensions:
           - module: api/stac_fastapi/extensions/index.md
           - core:
               - module: api/stac_fastapi/extensions/core/index.md
-              - context: api/stac_fastapi/extensions/core/context.md
-              - free_text:
-                - module: api/stac_fastapi/extensions/core/free_text/index.md
-                - free_text: api/stac_fastapi/extensions/core/free_text/free_text.md
-                - request: api/stac_fastapi/extensions/core/free_text/request.md
-              - filter:
-                  - module: api/stac_fastapi/extensions/core/filter/index.md
-                  - filter: api/stac_fastapi/extensions/core/filter/filter.md
-                  - request: api/stac_fastapi/extensions/core/filter/request.md
+              - aggregation:
+                - module: api/stac_fastapi/extensions/core/aggregation/index.md
+                - aggregation: api/stac_fastapi/extensions/core/aggregation/aggregation.md
+                - client: api/stac_fastapi/extensions/core/aggregation/client.md
+                - request: api/stac_fastapi/extensions/core/aggregation/request.md
+                - types: api/stac_fastapi/extensions/core/aggregation/types.md
+              - collection_search:
+                - module: api/stac_fastapi/extensions/core/collection_search/index.md
+                - collection_search: api/stac_fastapi/extensions/core/collection_search/collection_search.md
+                - client: api/stac_fastapi/extensions/core/collection_search/client.md
+                - request: api/stac_fastapi/extensions/core/collection_search/request.md
               - fields:
                   - module: api/stac_fastapi/extensions/core/fields/index.md
                   - fields: api/stac_fastapi/extensions/core/fields/fields.md
                   - request: api/stac_fastapi/extensions/core/fields/request.md
+              - filter:
+                  - module: api/stac_fastapi/extensions/core/filter/index.md
+                  - filter: api/stac_fastapi/extensions/core/filter/filter.md
+                  - request: api/stac_fastapi/extensions/core/filter/request.md
+              - free_text:
+                - module: api/stac_fastapi/extensions/core/free_text/index.md
+                - free_text: api/stac_fastapi/extensions/core/free_text/free_text.md
+                - request: api/stac_fastapi/extensions/core/free_text/request.md
+              - pagination:
+                  - module: api/stac_fastapi/extensions/core/pagination/index.md
+                  - pagination: api/stac_fastapi/extensions/core/pagination/pagination.md
+                  - offset_pagination: api/stac_fastapi/extensions/core/pagination/offset_pagination.md
+                  - token_pagination: api/stac_fastapi/extensions/core/pagination/token_pagination.md
+                  - request: api/stac_fastapi/extensions/core/pagination/request.md
               - query:
                   - module: api/stac_fastapi/extensions/core/query/index.md
                   - query: api/stac_fastapi/extensions/core/query/query.md
@@ -57,14 +72,9 @@ nav:
                   - request: api/stac_fastapi/extensions/core/sort/request.md
                   - sort: api/stac_fastapi/extensions/core/sort/sort.md
               - transaction: api/stac_fastapi/extensions/core/transaction.md
-              - pagination:
-                  - module: api/stac_fastapi/extensions/core/pagination/index.md
-                  - pagination: api/stac_fastapi/extensions/core/pagination/pagination.md
-                  - token_pagination: api/stac_fastapi/extensions/core/pagination/token_pagination.md
-              - version: api/stac_fastapi/extensions/version.md
           - third_party:
+              - module: api/stac_fastapi/extensions/third_party/index.md
               - bulk_transactions: api/stac_fastapi/extensions/third_party/bulk_transactions.md
-              - index: api/stac_fastapi/extensions/third_party/index.md
       - stac_fastapi.types:
           - module: api/stac_fastapi/types/index.md
           - config: api/stac_fastapi/types/config.md
@@ -77,7 +87,6 @@ nav:
           - rfc3339: api/stac_fastapi/types/rfc3339.md
           - search: api/stac_fastapi/types/search.md
           - stac: api/stac_fastapi/types/stac.md
-          - version: api/stac_fastapi/types/version.md
   - Migration Guides:
     - v2.5 -> v3.0: migrations/v3.0.0.md
     - v3.0 -> v4.0: migrations/v4.0.0.md
@@ -87,6 +96,29 @@ nav:
 
 plugins:
   - search
+  - mkdocstrings:
+      enable_inventory: true
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_section_style: list
+            docstring_style: google
+            line_length: 100
+            separate_signature: true
+            show_root_heading: true
+            show_signature_annotations: true
+            show_source: false
+            show_symbol_type_toc: true
+            signature_crossrefs: true
+            extensions:
+              - griffe_inherited_docstrings
+          inventories:
+            - https://docs.python.org/3/objects.inv
+            - https://docs.pydantic.dev/latest/objects.inv
+            - https://fastapi.tiangolo.com/objects.inv
+            - https://www.starlette.io/objects.inv
+            - https://www.attrs.org/en/stable/objects.inv
 
 # Theme
 theme:

--- a/docs/src/api/stac_fastapi/api/app.md
+++ b/docs/src/api/stac_fastapi/api/app.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.api.app
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/api/config.md
+++ b/docs/src/api/stac_fastapi/api/config.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.api.config
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/api/errors.md
+++ b/docs/src/api/stac_fastapi/api/errors.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.api.errors
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/api/index.md
+++ b/docs/src/api/stac_fastapi/api/index.md
@@ -1,0 +1,14 @@
+# Module stac_fastapi.api
+
+Api submodule.
+
+## Sub-modules
+
+* [stac_fastapi.api.app](app.md)
+* [stac_fastapi.api.config](config.md)
+* [stac_fastapi.api.errors](errors.md)
+* [stac_fastapi.api.middleware](middleware.md)
+* [stac_fastapi.api.models](models.md)
+* [stac_fastapi.api.openapi](openapi.md)
+* [stac_fastapi.api.routes](routes.md)
+

--- a/docs/src/api/stac_fastapi/api/middleware.md
+++ b/docs/src/api/stac_fastapi/api/middleware.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.api.middleware
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/api/models.md
+++ b/docs/src/api/stac_fastapi/api/models.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.api.models
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/api/openapi.md
+++ b/docs/src/api/stac_fastapi/api/openapi.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.api.openapi
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/api/routes.md
+++ b/docs/src/api/stac_fastapi/api/routes.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.api.routes
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/aggregation/aggregation.md
+++ b/docs/src/api/stac_fastapi/extensions/core/aggregation/aggregation.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.extensions.core.aggregation.aggregation
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/aggregation/client.md
+++ b/docs/src/api/stac_fastapi/extensions/core/aggregation/client.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.extensions.core.aggregation.client
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/aggregation/index.md
+++ b/docs/src/api/stac_fastapi/extensions/core/aggregation/index.md
@@ -1,0 +1,10 @@
+# Module stac_fastapi.extensions.core.aggregation
+
+Aggregation Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core.aggregation.aggregation](aggregation.md)
+* [stac_fastapi.extensions.core.aggregation.client](client.md)
+* [stac_fastapi.extensions.core.aggregation.request](request.md)
+* [stac_fastapi.extensions.core.aggregation.types](types.md)

--- a/docs/src/api/stac_fastapi/extensions/core/aggregation/request.md
+++ b/docs/src/api/stac_fastapi/extensions/core/aggregation/request.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.extensions.core.aggregation.request
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/aggregation/types.md
+++ b/docs/src/api/stac_fastapi/extensions/core/aggregation/types.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.extensions.core.aggregation.types
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/collection_search/client.md
+++ b/docs/src/api/stac_fastapi/extensions/core/collection_search/client.md
@@ -1,0 +1,4 @@
+
+::: stac_fastapi.extensions.core.collection_search.client
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/collection_search/collection_search.md
+++ b/docs/src/api/stac_fastapi/extensions/core/collection_search/collection_search.md
@@ -1,0 +1,5 @@
+
+
+::: stac_fastapi.extensions.core.collection_search.collection_search
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/collection_search/index.md
+++ b/docs/src/api/stac_fastapi/extensions/core/collection_search/index.md
@@ -1,0 +1,9 @@
+# Module stac_fastapi.extensions.core.collection_search
+
+Collection-Search Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core.collection_search.collection_search](collection_search.md)
+* [stac_fastapi.extensions.core.collection_search.client](client.md)
+* [stac_fastapi.extensions.core.collection_search.request](request.md)

--- a/docs/src/api/stac_fastapi/extensions/core/collection_search/request.md
+++ b/docs/src/api/stac_fastapi/extensions/core/collection_search/request.md
@@ -1,0 +1,6 @@
+
+
+
+::: stac_fastapi.extensions.core.collection_search.request
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/fields/fields.md
+++ b/docs/src/api/stac_fastapi/extensions/core/fields/fields.md
@@ -1,0 +1,5 @@
+
+
+::: stac_fastapi.extensions.core.fields.fields
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/fields/index.md
+++ b/docs/src/api/stac_fastapi/extensions/core/fields/index.md
@@ -1,0 +1,8 @@
+# Module stac_fastapi.extensions.core.fields
+
+Fields Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core.fields.fields](fields.md)
+* [stac_fastapi.extensions.core.fields.request](request.md)

--- a/docs/src/api/stac_fastapi/extensions/core/fields/request.md
+++ b/docs/src/api/stac_fastapi/extensions/core/fields/request.md
@@ -1,0 +1,6 @@
+
+
+
+::: stac_fastapi.extensions.core.fields.request
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/filter/filter.md
+++ b/docs/src/api/stac_fastapi/extensions/core/filter/filter.md
@@ -1,0 +1,5 @@
+
+
+::: stac_fastapi.extensions.core.filter.filter
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/filter/index.md
+++ b/docs/src/api/stac_fastapi/extensions/core/filter/index.md
@@ -1,0 +1,8 @@
+# Module stac_fastapi.extensions.core.filter
+
+Filter Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core.filter.filter](filter.md)
+* [stac_fastapi.extensions.core.filter.request](request.md)

--- a/docs/src/api/stac_fastapi/extensions/core/filter/request.md
+++ b/docs/src/api/stac_fastapi/extensions/core/filter/request.md
@@ -1,0 +1,6 @@
+
+
+
+::: stac_fastapi.extensions.core.filter.request
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/free_text/free_text.md
+++ b/docs/src/api/stac_fastapi/extensions/core/free_text/free_text.md
@@ -1,0 +1,5 @@
+
+
+::: stac_fastapi.extensions.core.free_text.free_text
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/free_text/index.md
+++ b/docs/src/api/stac_fastapi/extensions/core/free_text/index.md
@@ -1,0 +1,8 @@
+# Module stac_fastapi.extensions.core.free_text
+
+Free-Text Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core.free_text.free_text](free_text.md)
+* [stac_fastapi.extensions.core.free_text.request](request.md)

--- a/docs/src/api/stac_fastapi/extensions/core/free_text/request.md
+++ b/docs/src/api/stac_fastapi/extensions/core/free_text/request.md
@@ -1,0 +1,6 @@
+
+
+
+::: stac_fastapi.extensions.core.free_text.request
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/index.md
+++ b/docs/src/api/stac_fastapi/extensions/core/index.md
@@ -1,0 +1,13 @@
+# Module stac_fastapi.extensions
+
+Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core.fields](fields/index.md)
+* [stac_fastapi.extensions.core.filter](filter/index.md)
+* [stac_fastapi.extensions.core.free_text](free_text/index.md)
+* [stac_fastapi.extensions.core.pagination](pagination/index.md)
+* [stac_fastapi.extensions.core.query](query/index.md)
+* [stac_fastapi.extensions.core.sort](sort/index.md)
+* [stac_fastapi.extensions.core.transaction](transaction.md)

--- a/docs/src/api/stac_fastapi/extensions/core/pagination/index.md
+++ b/docs/src/api/stac_fastapi/extensions/core/pagination/index.md
@@ -1,0 +1,10 @@
+# Module stac_fastapi.extensions.core.pagination
+
+Pagination Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core.pagination.pagination](pagination.md)
+* [stac_fastapi.extensions.core.pagination.offset_pagination](offset_pagination.md)
+* [stac_fastapi.extensions.core.pagination.token_pagination](token_pagination.md)
+* [stac_fastapi.extensions.core.pagination.request](request.md)

--- a/docs/src/api/stac_fastapi/extensions/core/pagination/offset_pagination.md
+++ b/docs/src/api/stac_fastapi/extensions/core/pagination/offset_pagination.md
@@ -1,0 +1,5 @@
+
+
+::: stac_fastapi.extensions.core.pagination.offset_pagination
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/pagination/pagination.md
+++ b/docs/src/api/stac_fastapi/extensions/core/pagination/pagination.md
@@ -1,0 +1,5 @@
+
+
+::: stac_fastapi.extensions.core.pagination.pagination
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/pagination/request.md
+++ b/docs/src/api/stac_fastapi/extensions/core/pagination/request.md
@@ -1,0 +1,6 @@
+
+
+
+::: stac_fastapi.extensions.core.pagination.request
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/pagination/token_pagination.md
+++ b/docs/src/api/stac_fastapi/extensions/core/pagination/token_pagination.md
@@ -1,0 +1,5 @@
+
+
+::: stac_fastapi.extensions.core.pagination.token_pagination
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/query/index.md
+++ b/docs/src/api/stac_fastapi/extensions/core/query/index.md
@@ -1,0 +1,8 @@
+# Module stac_fastapi.extensions.core.query
+
+Query Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core.query.query](query.md)
+* [stac_fastapi.extensions.core.query.request](request.md)

--- a/docs/src/api/stac_fastapi/extensions/core/query/query.md
+++ b/docs/src/api/stac_fastapi/extensions/core/query/query.md
@@ -1,0 +1,5 @@
+
+
+::: stac_fastapi.extensions.core.query.query
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/query/request.md
+++ b/docs/src/api/stac_fastapi/extensions/core/query/request.md
@@ -1,0 +1,6 @@
+
+
+
+::: stac_fastapi.extensions.core.query.request
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/sort/index.md
+++ b/docs/src/api/stac_fastapi/extensions/core/sort/index.md
@@ -1,0 +1,8 @@
+# Module stac_fastapi.extensions.core.sort
+
+Sort Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core.sort.sort](sort.md)
+* [stac_fastapi.extensions.core.sort.request](request.md)

--- a/docs/src/api/stac_fastapi/extensions/core/sort/request.md
+++ b/docs/src/api/stac_fastapi/extensions/core/sort/request.md
@@ -1,0 +1,6 @@
+
+
+
+::: stac_fastapi.extensions.core.sort.request
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/sort/sort.md
+++ b/docs/src/api/stac_fastapi/extensions/core/sort/sort.md
@@ -1,0 +1,5 @@
+
+
+::: stac_fastapi.extensions.core.sort.sort
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/core/transaction.md
+++ b/docs/src/api/stac_fastapi/extensions/core/transaction.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.extensions.core.transaction
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/index.md
+++ b/docs/src/api/stac_fastapi/extensions/index.md
@@ -1,0 +1,8 @@
+# Module stac_fastapi.extensions
+
+Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.core](core/index.md)
+* [stac_fastapi.extensions.third_party](third_party/index.md)

--- a/docs/src/api/stac_fastapi/extensions/third_party/bulk_transactions.md
+++ b/docs/src/api/stac_fastapi/extensions/third_party/bulk_transactions.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.extensions.third_party.bulk_transactions
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/extensions/third_party/index.md
+++ b/docs/src/api/stac_fastapi/extensions/third_party/index.md
@@ -1,0 +1,7 @@
+# Module stac_fastapi.extensions.third_party
+
+Third Party Extensions submodule.
+
+## Sub-modules
+
+* [stac_fastapi.extensions.third_party.bulk_transactions](bulk_transactions.md)

--- a/docs/src/api/stac_fastapi/index.md
+++ b/docs/src/api/stac_fastapi/index.md
@@ -1,0 +1,8 @@
+# Namespace stac_fastapi
+
+## Sub-modules
+
+* [stac_fastapi.api](api/index.md)
+* [stac_fastapi.extensions](extensions/index.md)
+* [stac_fastapi.types](types/index.md)
+

--- a/docs/src/api/stac_fastapi/types/config.md
+++ b/docs/src/api/stac_fastapi/types/config.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.config
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/types/conformance.md
+++ b/docs/src/api/stac_fastapi/types/conformance.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.conformance
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/types/core.md
+++ b/docs/src/api/stac_fastapi/types/core.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.core
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/types/errors.md
+++ b/docs/src/api/stac_fastapi/types/errors.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.errors
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/types/extension.md
+++ b/docs/src/api/stac_fastapi/types/extension.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.extension
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/types/index.md
+++ b/docs/src/api/stac_fastapi/types/index.md
@@ -1,0 +1,16 @@
+# Module stac_fastapi.types
+
+Types submodule.
+
+## Sub-modules
+
+* [stac_fastapi.types.config](config.md)
+* [stac_fastapi.types.conformance](conformance.md)
+* [stac_fastapi.types.core](core.md)
+* [stac_fastapi.types.errors](errors.md)
+* [stac_fastapi.types.extension](extension.md)
+* [stac_fastapi.types.links](links.md)
+* [stac_fastapi.types.requests](requests.md)
+* [stac_fastapi.types.rfc3339](rfc3339.md)
+* [stac_fastapi.types.search](search.md)
+* [stac_fastapi.types.stac](stac.md)

--- a/docs/src/api/stac_fastapi/types/links.md
+++ b/docs/src/api/stac_fastapi/types/links.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.links
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/types/requests.md
+++ b/docs/src/api/stac_fastapi/types/requests.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.requests
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/types/rfc3339.md
+++ b/docs/src/api/stac_fastapi/types/rfc3339.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.rfc3339
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/types/search.md
+++ b/docs/src/api/stac_fastapi/types/search.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.search
+    options:
+      show_source: true

--- a/docs/src/api/stac_fastapi/types/stac.md
+++ b/docs/src/api/stac_fastapi/types/stac.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.types.stac
+    options:
+      show_source: true

--- a/stac_fastapi/api/setup.py
+++ b/stac_fastapi/api/setup.py
@@ -22,7 +22,14 @@ extra_reqs = {
     "benchmark": [
         "pytest-benchmark",
     ],
-    "docs": ["mkdocs", "mkdocs-material", "pdocs"],
+    "docs": [
+        "black>=23.10.1",
+        "mkdocs>=1.4.3",
+        "mkdocs-jupyter>=0.24.5",
+        "mkdocs-material[imaging]>=9.5",
+        "griffe-inherited-docstrings>=1.0.0",
+        "mkdocstrings[python]>=0.25.1",
+    ],
 }
 
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -138,12 +138,8 @@ class StacApi:
                 return ext
         return None
 
-    def register_landing_page(self):
-        """Register landing page (GET /).
-
-        Returns:
-            None
-        """
+    def register_landing_page(self) -> None:
+        """Register landing page (GET /)."""
         self.router.add_api_route(
             name="Landing Page",
             path="/",
@@ -165,12 +161,8 @@ class StacApi:
             endpoint=create_async_endpoint(self.client.landing_page, EmptyRequest),
         )
 
-    def register_conformance_classes(self):
-        """Register conformance classes (GET /conformance).
-
-        Returns:
-            None
-        """
+    def register_conformance_classes(self) -> None:
+        """Register conformance classes (GET /conformance)."""
         self.router.add_api_route(
             name="Conformance Classes",
             path="/conformance",
@@ -192,12 +184,8 @@ class StacApi:
             endpoint=create_async_endpoint(self.client.conformance, EmptyRequest),
         )
 
-    def register_get_item(self):
-        """Register get item endpoint (GET /collections/{collection_id}/items/{item_id}).
-
-        Returns:
-            None
-        """
+    def register_get_item(self) -> None:
+        """Register get item endpoint (GET /collections/{collection_id}/items/{item_id})."""  # noqa: E501
         self.router.add_api_route(
             name="Get Item",
             path="/collections/{collection_id}/items/{item_id}",
@@ -219,12 +207,8 @@ class StacApi:
             ),
         )
 
-    def register_post_search(self):
-        """Register search endpoint (POST /search).
-
-        Returns:
-            None
-        """
+    def register_post_search(self) -> None:
+        """Register search endpoint (POST /search)."""
         self.router.add_api_route(
             name="Search",
             path="/search",
@@ -248,12 +232,8 @@ class StacApi:
             ),
         )
 
-    def register_get_search(self):
-        """Register search endpoint (GET /search).
-
-        Returns:
-            None
-        """
+    def register_get_search(self) -> None:
+        """Register search endpoint (GET /search)."""
         self.router.add_api_route(
             name="Search",
             path="/search",
@@ -277,12 +257,8 @@ class StacApi:
             ),
         )
 
-    def register_get_collections(self):
-        """Register get collections endpoint (GET /collections).
-
-        Returns:
-            None
-        """
+    def register_get_collections(self) -> None:
+        """Register get collections endpoint (GET /collections)."""
         self.router.add_api_route(
             name="Get Collections",
             path="/collections",
@@ -306,12 +282,8 @@ class StacApi:
             ),
         )
 
-    def register_get_collection(self):
-        """Register get collection endpoint (GET /collection/{collection_id}).
-
-        Returns:
-            None
-        """
+    def register_get_collection(self) -> None:
+        """Register get collection endpoint (GET /collection/{collection_id})."""
         self.router.add_api_route(
             name="Get Collection",
             path="/collections/{collection_id}",
@@ -335,12 +307,8 @@ class StacApi:
             ),
         )
 
-    def register_get_item_collection(self):
-        """Register get item collection endpoint (GET /collection/{collection_id}/items).
-
-        Returns:
-            None
-        """
+    def register_get_item_collection(self) -> None:
+        """Register get item collection endpoint (GET /collection/{collection_id}/items)."""  # noqa: E501
         self.router.add_api_route(
             name="Get ItemCollection",
             path="/collections/{collection_id}/items",
@@ -364,7 +332,7 @@ class StacApi:
             ),
         )
 
-    def register_core(self):
+    def register_core(self) -> None:
         """Register core STAC endpoints.
 
             GET /
@@ -378,8 +346,6 @@ class StacApi:
 
         Injects application logic (StacApi.client) into the API layer.
 
-        Returns:
-            None
         """
         self.register_landing_page()
         self.register_conformance_classes()
@@ -390,7 +356,7 @@ class StacApi:
         self.register_get_collection()
         self.register_get_item_collection()
 
-    def add_health_check(self):
+    def add_health_check(self) -> None:
         """Add a health check."""
         mgmt_router = APIRouter(prefix=self.app.state.router_prefix)
 
@@ -407,24 +373,20 @@ class StacApi:
         """Add custom dependencies to routes.
 
         Args:
-            scopes: list of scopes. Each scope should be a dict with a `path`
-                and `method` property.
-            dependencies: list of [FastAPI
-                dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/)
+            scopes: list of Scope.
+                Each scope should be a dict with a `path` and `method` property.
+            dependencies: list of fastapi.Depends
+                [FastAPI dependencies](https://fastapi.tiangolo.com/tutorial/dependencies/)
                 to apply to each scope.
 
-        Returns:
-            None
         """
         return add_route_dependencies(self.app.router.routes, scopes, dependencies)
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         """Post-init hook.
 
         Responsible for setting up the application upon instantiation of the class.
 
-        Returns:
-            None
         """
         # inject settings
         self.client.extensions = self.extensions

--- a/stac_fastapi/extensions/setup.py
+++ b/stac_fastapi/extensions/setup.py
@@ -19,7 +19,14 @@ extra_reqs = {
         "pre-commit",
         "requests",
     ],
-    "docs": ["mkdocs", "mkdocs-material", "pdocs"],
+    "docs": [
+        "black>=23.10.1",
+        "mkdocs>=1.4.3",
+        "mkdocs-jupyter>=0.24.5",
+        "mkdocs-material[imaging]>=9.5",
+        "griffe-inherited-docstrings>=1.0.0",
+        "mkdocstrings[python]>=0.25.1",
+    ],
 }
 
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/pagination/offset_pagination.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/pagination/offset_pagination.py
@@ -1,4 +1,4 @@
-"""Pagination API extension."""
+"""Offset Pagination API extension."""
 
 from typing import List, Optional
 

--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -21,7 +21,14 @@ extra_reqs = {
         "pre-commit",
         "requests",
     ],
-    "docs": ["mkdocs", "mkdocs-material", "pdocs"],
+    "docs": [
+        "black>=23.10.1",
+        "mkdocs>=1.4.3",
+        "mkdocs-jupyter>=0.24.5",
+        "mkdocs-material[imaging]>=9.5",
+        "griffe-inherited-docstrings>=1.0.0",
+        "mkdocstrings[python]>=0.25.1",
+    ],
 }
 
 


### PR DESCRIPTION
switching to mkdocstring will enable better API documentation but also to create `inventories` for submodule (e.g stac-fastapi-pgstac)