### PR TITLE
fix: fix assign to type instead of annotation in add_route_dependencies

### DIFF
--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -373,7 +373,7 @@ class StacApi:
         self.app.include_router(mgmt_router, tags=["Liveliness/Readiness"])
 
     def add_route_dependencies(
-        self, scopes: List[Scope], dependencies=List[Depends]
+        self, scopes: List[Scope], dependencies: List[Depends]
     ) -> None:
         """Add custom dependencies to routes.
 

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -88,7 +88,7 @@ class Scope(TypedDict, total=False):
 
 
 def add_route_dependencies(
-    routes: List[BaseRoute], scopes: List[Scope], dependencies=List[params.Depends]
+    routes: List[BaseRoute], scopes: List[Scope], dependencies: List[params.Depends]
 ) -> None:
     """Add dependencies to routes.
 


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Description:**

- fix two instance where a method parameter is assigned to a type rather than being annotated with it

**PR Checklist:**

- [X] `pre-commit` hooks pass locally
- [X] Tests pass (run `make test`)
- [X] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
