### PR TITLE
avoid future deprecation for pydantic.Field and use `json_schema_extra` instead of `openapi_examples`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- avoid future deprecation for pydantic.Field and use `json_schema_extra` instead of `openapi_examples`
+
 ## [5.2.0] - 2025-04-18
 
 ### Fixed

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
@@ -40,21 +40,32 @@ class BaseCollectionSearchPostRequest(BaseModel):
     bbox: Optional[BBox] = Field(
         default=None,
         description="Only return items intersecting this bounding box. Mutually exclusive with **intersects**.",  # noqa: E501
-        openapi_examples={
-            "user-provided": {"value": None},
-            "Montreal": {"value": "-73.896103,45.364690,-73.413734,45.674283"},
+        json_schema_extra={
+            "examples": [
+                # user-provided
+                None,
+                # Montreal
+                "-73.896103,45.364690,-73.413734,45.674283",
+            ],
         },
     )
     datetime: Optional[str] = Field(
         default=None,
         description="""Only return items that have a temporal property that intersects this value.\n
 Either a date-time or an interval, open or closed. Date and time expressions adhere to RFC 3339. Open intervals are expressed using double-dots.""",  # noqa: E501
-        openapi_examples={
-            "user-provided": {"value": None},
-            "datetime": {"value": "2018-02-12T23:20:50Z"},
-            "closed-interval": {"value": "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"},
-            "open-interval-from": {"value": "2018-02-12T00:00:00Z/.."},
-            "open-interval-to": {"value": "../2018-03-18T12:31:12Z"},
+        json_schema_extra={
+            "examples": [
+                # user-provided
+                None,
+                # single datetime
+                "2018-02-12T23:20:50Z",
+                # closed inverval
+                "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z",
+                # open interval FROM
+                "2018-02-12T00:00:00Z/..",
+                # open interval TO
+                "../2018-03-18T12:31:12Z",
+            ],
         },
     )
     limit: Optional[Limit] = Field(

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/filter/request.py
@@ -51,13 +51,15 @@ class FilterExtensionPostRequest(BaseModel):
     """Filter extension POST request model."""
 
     filter_expr: Optional[Dict[str, Any]] = Field(
-        default=None,
+        None,
         alias="filter",
         description="A CQL filter expression for filtering items.",
-        openapi_examples={
-            "user-provided": {"value": None},
-            "landsat8-item": {
-                "value": {
+        json_schema_extra={
+            "examples": [
+                # user-provided
+                None,
+                # landsat8-item
+                {
                     "op": "and",
                     "args": [
                         {
@@ -73,16 +75,16 @@ class FilterExtensionPostRequest(BaseModel):
                         },
                     ],
                 },
-            },
+            ],
         },
     )
     filter_crs: Optional[str] = Field(
+        None,
         alias="filter-crs",
-        default=None,
         description="The coordinate reference system (CRS) used by spatial literals in the 'filter' value. Default is `http://www.opengis.net/def/crs/OGC/1.3/CRS84`",  # noqa: E501
     )
     filter_lang: Optional[Literal["cql-json", "cql2-json"]] = Field(
+        "cql2-json",
         alias="filter-lang",
-        default="cql2-json",
         description="The CQL filter encoding that the 'filter' value uses.",
     )

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/query/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/query/request.py
@@ -32,8 +32,12 @@ class QueryExtensionPostRequest(BaseModel):
     query: Optional[Dict[str, Dict[str, Any]]] = Field(
         None,
         description="Allows additional filtering based on the properties of Item objects",  # noqa: E501
-        openapi_examples={
-            "user-provided": {"value": None},
-            "cloudy": {"value": '{"eo:cloud_cover": {"gte": 95}}'},
+        json_schema_extra={
+            "examples": [
+                # user-provided
+                None,
+                # cloudy
+                '{"eo:cloud_cover": {"gte": 95}}',
+            ],
         },
     )

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/sort/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/sort/request.py
@@ -40,15 +40,17 @@ class SortExtensionPostRequest(BaseModel):
     sortby: Optional[List[PostSortModel]] = Field(
         None,
         description="An array of property (field) names, and direction in form of '{'field': '<property_name>', 'direction':'<direction>'}'",  # noqa: E501
-        openapi_examples={
-            "user-provided": {"value": None},
-            "creation-time": {
-                "value": [
+        json_schema_extra={
+            "examples": [
+                # user-provided
+                None,
+                # creation-time
+                [
                     {
                         "field": "properties.created",
                         "direction": "asc",
                     }
                 ],
-            },
+            ],
         },
     )


### PR DESCRIPTION
closes #818 

Sadly Pydantic.Field `json_schema_extra.examples` does not support `named` examples as FastAPI Params do 😭 