### PR TITLE
use internally defined JSONResponse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - avoid future deprecation for pydantic.Field and use `json_schema_extra` instead of `openapi_examples`
+- use `orjson` based JSONResponse when available
 
 ## [5.2.0] - 2025-04-18
 

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -12,7 +12,7 @@ from stac_pydantic.api.collections import Collections
 from stac_pydantic.shared import MimeTypes
 from stac_pydantic.version import STAC_VERSION
 from starlette.middleware import Middleware
-from starlette.responses import JSONResponse, Response
+from starlette.responses import Response
 
 from stac_fastapi.api.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from stac_fastapi.api.middleware import CORSMiddleware, ProxyHeaderMiddleware
@@ -23,6 +23,7 @@ from stac_fastapi.api.models import (
     GeoJSONResponse,
     ItemCollectionUri,
     ItemUri,
+    JSONResponse,
 )
 from stac_fastapi.api.openapi import update_openapi
 from stac_fastapi.api.routes import (

--- a/stac_fastapi/api/stac_fastapi/api/errors.py
+++ b/stac_fastapi/api/stac_fastapi/api/errors.py
@@ -8,8 +8,8 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError, ResponseValidationError
 from starlette import status
 from starlette.requests import Request
-from starlette.responses import JSONResponse
 
+from stac_fastapi.api.models import JSONResponse
 from stac_fastapi.types.errors import (
     ConflictError,
     DatabaseError,

--- a/stac_fastapi/api/stac_fastapi/api/openapi.py
+++ b/stac_fastapi/api/stac_fastapi/api/openapi.py
@@ -2,7 +2,7 @@
 
 from fastapi import FastAPI
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response
+from starlette.responses import Response
 from starlette.routing import Route, request_response
 
 
@@ -22,7 +22,7 @@ def update_openapi(app: FastAPI) -> FastAPI:
     # Create a patched endpoint function that modifies the content type of the response
     async def patched_openapi_endpoint(req: Request) -> Response:
         # Get the response from the old endpoint function
-        response: JSONResponse = await old_endpoint(req)
+        response = await old_endpoint(req)
         # Update the content type header in place
         response.headers["content-type"] = "application/vnd.oai.openapi+json;version=3.0"
         # Return the updated response

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/transaction.py
@@ -7,10 +7,10 @@ import attr
 from fastapi import APIRouter, Body, FastAPI
 from stac_pydantic import Collection, Item, ItemCollection
 from stac_pydantic.shared import MimeTypes
-from starlette.responses import JSONResponse, Response
+from starlette.responses import Response
 from typing_extensions import Annotated
 
-from stac_fastapi.api.models import CollectionUri, ItemUri
+from stac_fastapi.api.models import CollectionUri, ItemUri, JSONResponse
 from stac_fastapi.api.routes import create_async_endpoint
 from stac_fastapi.types.config import ApiSettings
 from stac_fastapi.types.core import AsyncBaseTransactionsClient, BaseTransactionsClient


### PR DESCRIPTION
in `stac_fastapi.api.models` we define `JSONResponse` based on the availability of `orjson`. This PR change all JSONResponse imports (from starlette.responses) to use it instead.