### PR TITLE
Fix import for latest stac_pydantic version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
 
 - add `py.typed` to package distributions ([#842](https://github.com/stac-utils/stac-fastapi/pull/842))
 - update/fix type informations ([#842](https://github.com/stac-utils/stac-fastapi/pull/842))
-- updated import of `SearchDatetime` to add support to `stac_pydantic` v3.3.0 ([#844](https://github.com/stac-utils/stac-fastapi/pull/844))
+- pin `stac_pydantic` to `>=3.3.0` for the correct import path of `stac_pydantic.shared.SearchDatetime` ([#844](https://github.com/stac-utils/stac-fastapi/pull/844))
 
 ## [5.2.1] - 2025-04-18
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - add `py.typed` to package distributions ([#842](https://github.com/stac-utils/stac-fastapi/pull/842))
 - update/fix type informations ([#842](https://github.com/stac-utils/stac-fastapi/pull/842))
+- updated import of `SearchDatetime` to add support to `stac_pydantic` v3.3.0 ([#844](https://github.com/stac-utils/stac-fastapi/pull/844))
 
 ## [5.2.1] - 2025-04-18
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
@@ -6,8 +6,15 @@ from typing import List, Optional, Tuple, cast
 import attr
 from fastapi import Query
 from pydantic import BaseModel, Field, PrivateAttr, ValidationInfo, field_validator
-from stac_pydantic.api.search import SearchDatetime
 from stac_pydantic.shared import BBox
+
+try:
+    # the import path changed recently in stac_pydantic v3.3.0
+    # to make sure both older and newer versions are supported, we try both paths
+    from stac_pydantic.shared import SearchDatetime
+except ImportError:
+    from stac_pydantic.api.search import SearchDatetime
+
 from typing_extensions import Annotated
 
 from stac_fastapi.types.search import (

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/collection_search/request.py
@@ -6,15 +6,7 @@ from typing import List, Optional, Tuple, cast
 import attr
 from fastapi import Query
 from pydantic import BaseModel, Field, PrivateAttr, ValidationInfo, field_validator
-from stac_pydantic.shared import BBox
-
-try:
-    # the import path changed recently in stac_pydantic v3.3.0
-    # to make sure both older and newer versions are supported, we try both paths
-    from stac_pydantic.shared import SearchDatetime
-except ImportError:
-    from stac_pydantic.api.search import SearchDatetime
-
+from stac_pydantic.shared import BBox, SearchDatetime
 from typing_extensions import Annotated
 
 from stac_fastapi.types.search import (

--- a/stac_fastapi/types/setup.py
+++ b/stac_fastapi/types/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     "fastapi>=0.109.0",
     "attrs>=23.2.0",
     "pydantic-settings>=2",
-    "stac_pydantic>=3.1.3,<4.0",
+    "stac_pydantic>=3.3.0,<4.0",
     "iso8601>=1.0.2,<2.2.0",
 ]
 


### PR DESCRIPTION
**Related Issue(s):**

- none, I created a PR directly

**Description:**

The latest release of [stac_pydantic](https://github.com/stac-utils/stac-pydantic) moved `SearchDatetime` from `stac_pydantic.api.search` to `stac_pydantic.shared`

As a consequence, using both the latest version of `stac-fastapi` and `stac_pydantic` raises an `ImportError`:

```
  File "/Users/lukasbindreiter/Documents/tilebox/stac-fastapi-tilebox/.venv/lib/python3.13/site-packages/stac_fastapi/extensions/core/collection_search/__init__.py", line 3, in <module>
    from .collection_search import (
    ...<3 lines>...
    )
  File "/Users/lukasbindreiter/Documents/tilebox/stac-fastapi-tilebox/.venv/lib/python3.13/site-packages/stac_fastapi/extensions/core/collection_search/collection_search.py", line 16, in <module>
    from .client import AsyncBaseCollectionSearchClient, BaseCollectionSearchClient
  File "/Users/lukasbindreiter/Documents/tilebox/stac-fastapi-tilebox/.venv/lib/python3.13/site-packages/stac_fastapi/extensions/core/collection_search/client.py", line 9, in <module>
    from .request import BaseCollectionSearchPostRequest
  File "/Users/lukasbindreiter/Documents/tilebox/stac-fastapi-tilebox/.venv/lib/python3.13/site-packages/stac_fastapi/extensions/core/collection_search/request.py", line 9, in <module>
    from stac_pydantic.api.search import SearchDatetime
ImportError: cannot import name 'SearchDatetime' from 'stac_pydantic.api.search' (/Users/lukasbindreiter/Documents/tilebox/stac-fastapi-t^CINFO:     Stopping reloader process [31239]c_pydantic/api/search.py)
```

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
