### PR TITLE
fix extension free-text advanced GET-q query not split by comma

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- fix `q` query parameter parsing of advanced free-text search on GET request
+
 ## [6.0.0] - 2025-06-19
 
 ### Changed

--- a/stac_fastapi/extensions/stac_fastapi/extensions/core/free_text/request.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/core/free_text/request.py
@@ -48,7 +48,7 @@ class FreeTextAdvancedExtensionGetRequest(APIRequest):
     """Free-text Extension GET request model."""
 
     q: Annotated[
-        Optional[str],
+        Optional[List[str]],
         Query(
             description="Parameter to perform free-text queries against STAC metadata",
             openapi_examples={
@@ -56,7 +56,7 @@ class FreeTextAdvancedExtensionGetRequest(APIRequest):
                 "Coastal": {"value": "ocean,coast"},
             },
         ),
-    ] = attr.ib(default=None)
+    ] = attr.ib(default=None, converter=_ft_converter)
 
 
 class FreeTextAdvancedExtensionPostRequest(BaseModel):


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Description:**

Unlike its *basic* counterpart, the `q` parameter of *advanced* free-text extension was passed as is (plain string) to the downstream client. This lead to invalid searches.

![image](https://github.com/user-attachments/assets/c99da431-c258-4c8e-bd36-ea0de87179e8)

This PR fixes this by applying the same transform, which leads to the expected behavior.

![image](https://github.com/user-attachments/assets/a6f8765e-d395-4be4-8e39-528f856f4d10)


>[!NOTE]
> Both "test_search_free_text_advanced" tests fail currently, but it doesn't seem to make much sense that the literal inputs are returned as is in `response.json() == "+ocean,-coast"`, given that the client expects `q: List[str]` (https://github.com/stac-utils/stac-fastapi-pgstac/blob/d33b0f3d1d509e16fe0dfc765dc47aea6613aac8/stac_fastapi/pgstac/core.py#L57). Should those tests be adjusted?

```python
stac_fastapi/extensions/tests/test_free_text.py:302: AssertionError
======================================================================================================================================= short test summary info =======================================================================================================================================
FAILED stac_fastapi/extensions/tests/test_free_text.py::test_search_free_text_search_advanced - AssertionError: assert ['+ocean', '-coast'] == '+ocean,-coast'
FAILED stac_fastapi/extensions/tests/test_free_text.py::test_search_free_text_advanced_complete - AssertionError: assert ['ocean', 'coast'] == 'ocean,coast'
```


**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
