### PR TITLE
Improve documentation how to run tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@
 **PR Checklist:**
 
 - [ ] `pre-commit` hooks pass locally
-- [ ] Tests pass (run `make test`)
+- [ ] Tests pass (run `make install test`)
 - [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
 - [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- improved documentation how to run tests ([#851](https://github.com/stac-utils/stac-fastapi/pull/851))
+
 ## [6.0.0] - 2025-06-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -78,16 +78,13 @@ Other backends may be available from other sources, search [PyPI](https://pypi.o
 Install the packages in editable mode:
 
 ```shell
-python -m pip install \
-  -e 'stac_fastapi/types[dev]' \
-  -e 'stac_fastapi/api[dev]' \
-  -e 'stac_fastapi/extensions[dev]'
+make install
 ```
 
-To run the tests:
+To run the tests (after the packages have been installed):
 
 ```shell
-python -m pytest
+make test
 ```
 
 ## Releasing


### PR DESCRIPTION
**Related Issue(s):**

Running only "make test" after a git checkout, like advised in the GitHub pull request template, does not work:
```
ERROR collecting stac_fastapi/extensions/tests/test_transaction.py __________________________________________________________________________________________
ImportError while importing test module '/home/xxx/projects/stac/stac-fastapi/stac_fastapi/extensions/tests/test_transaction.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
stac_fastapi/extensions/tests/test_transaction.py:13: in <module>
    from stac_fastapi.extensions.core.transaction.request import (
E   ModuleNotFoundError: No module named 'stac_fastapi.extensions.core.transaction.request'; 'stac_fastapi.extensions.core.transaction' is not a package
```

**Description:**

It is not obvious for newcomers that `make install` must be called before `make test`. This PR fixes it in README and GitHub pull request template.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
