### PR TITLE
Fix FastAPI 0.119.0+ compatibility by updating imports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - fixed typing of base_model and mixins parameters ([#852](https://github.com/stac-utils/stac-fastapi/pull/852))
+- fixed FastAPI 0.119.0+ compatibility by updating `request_response` import from starlette to fastapi and removing upper version constraint ([#856](https://github.com/stac-utils/stac-fastapi/issues/856))
 
 ### Changed 
 

--- a/stac_fastapi/api/stac_fastapi/api/openapi.py
+++ b/stac_fastapi/api/stac_fastapi/api/openapi.py
@@ -1,9 +1,10 @@
 """openapi."""
 
 from fastapi import FastAPI
+from fastapi.routing import request_response
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.routing import Route, request_response
+from starlette.routing import Route
 
 
 def update_openapi(app: FastAPI) -> FastAPI:

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -8,12 +8,12 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional, Type, TypedDi
 from fastapi import Depends, FastAPI, params
 from fastapi.datastructures import DefaultPlaceholder
 from fastapi.dependencies.utils import get_dependant, get_parameterless_sub_dependant
-from fastapi.routing import APIRoute
+from fastapi.routing import APIRoute, request_response
 from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.routing import BaseRoute, Match, request_response
+from starlette.routing import BaseRoute, Match
 from starlette.status import HTTP_204_NO_CONTENT
 
 from stac_fastapi.api.models import APIRequest

--- a/stac_fastapi/types/pyproject.toml
+++ b/stac_fastapi/types/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "fastapi>=0.109.0,<0.118.0",
+  "fastapi>=0.109.0",
   "attrs>=23.2.0",
   "pydantic-settings>=2",
   "stac_pydantic>=3.3.0,<4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2973,7 +2973,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=23.2.0" },
-    { name = "fastapi", specifier = ">=0.109.0,<0.118.0" },
+    { name = "fastapi", specifier = ">=0.109.0" },
     { name = "iso8601", specifier = ">=1.0.2,<2.2.0" },
     { name = "pydantic-settings", specifier = ">=2" },
     { name = "stac-pydantic", specifier = ">=3.3.0,<4.0" },


### PR DESCRIPTION
Change request_response import from starlette.routing to fastapi.routing in both routes.py and openapi.py to use FastAPI's enhanced version with AsyncExitStack support for dependencies with yield.

Remove upper version constraint on FastAPI (<0.118.0) to allow users to upgrade to FastAPI 0.119.0 and later versions.

In FastAPI 0.119.0, request_response is no longer a re-export from Starlette but a custom implementation with additional functionality for proper dependency lifecycle management.

Fixes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi/issues/856

**Description:**

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
