### PR TITLE
feat: add route_dependencies attribute to transaction extensions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 - Add tests for the `sort` extension ([#906](https://github.com/stac-utils/stac-fastapi/pull/906))
 - Add tests for the `fields` extension ([#902](https://github.com/stac-utils/stac-fastapi/pull/902))
 - Simply add a list of present stac-fastapi extensions to the Readme ([#898](https://github.com/stac-utils/stac-fastapi/pull/898))
-- Add `route_dependencies` argument to `transactions` extension to make it easy to apply auth dependencies to all transactions routes ([#885](https://github.com/stac-utils/stac-fastapi/pull/885))
+- Add `route_dependencies` argument to `transactions` and `bulk_transactions` extensions to make it easy to apply auth dependencies to all transactions routes ([#885](https://github.com/stac-utils/stac-fastapi/pull/885))
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Add tests for the `sort` extension ([#906](https://github.com/stac-utils/stac-fastapi/pull/906))
 - Add tests for the `fields` extension ([#902](https://github.com/stac-utils/stac-fastapi/pull/902))
 - Simply add a list of present stac-fastapi extensions to the Readme ([#898](https://github.com/stac-utils/stac-fastapi/pull/898))
+- Add `route_dependencies` argument to `transactions` extension to make it easy to apply auth dependencies to all transactions routes ([#885](https://github.com/stac-utils/stac-fastapi/pull/885))
 
 ### Changed
 

--- a/stac_fastapi/api/tests/test_api.py
+++ b/stac_fastapi/api/tests/test_api.py
@@ -40,9 +40,9 @@ class TestRouteDependencies:
             for route in routes:
                 print(route)
                 response = getattr(client, route["method"].lower())(route["path"])
-                assert response.status_code == 401, (
-                    "Unauthenticated requests should be rejected"
-                )
+                assert (
+                    response.status_code == 401
+                ), "Unauthenticated requests should be rejected"
                 assert response.json() == {"detail": "Not authenticated"}
 
                 path = route["path"].format(
@@ -55,9 +55,9 @@ class TestRouteDependencies:
                     content=route["payload"],
                     headers={"content-type": "application/json"},
                 )
-                assert 200 <= response.status_code < 300, (
-                    "Authenticated requests should be accepted"
-                )
+                assert (
+                    200 <= response.status_code < 300
+                ), "Authenticated requests should be accepted"
                 assert response.json() == "dummy response"
 
     @staticmethod
@@ -74,9 +74,9 @@ class TestRouteDependencies:
                     headers={"content-type": "application/json"},
                 )
 
-                assert 200 <= response.status_code < 300, (
-                    "Unauthenticated requests should be accepted"
-                )
+                assert (
+                    200 <= response.status_code < 300
+                ), "Unauthenticated requests should be accepted"
                 assert response.json() == "dummy response"
 
     def test_openapi_content_type(self):

--- a/stac_fastapi/api/tests/test_api.py
+++ b/stac_fastapi/api/tests/test_api.py
@@ -39,9 +39,9 @@ class TestRouteDependencies:
         with TestClient(api.app) as client:
             for route in routes:
                 response = getattr(client, route["method"].lower())(route["path"])
-                assert response.status_code == 401, (
-                    "Unauthenticated requests should be rejected"
-                )
+                assert (
+                    response.status_code == 401
+                ), "Unauthenticated requests should be rejected"
                 assert response.json() == {"detail": "Not authenticated"}
 
                 path = route["path"].format(
@@ -54,9 +54,9 @@ class TestRouteDependencies:
                     content=route["payload"],
                     headers={"content-type": "application/json"},
                 )
-                assert 200 <= response.status_code < 300, (
-                    "Authenticated requests should be accepted"
-                )
+                assert (
+                    200 <= response.status_code < 300
+                ), "Authenticated requests should be accepted"
                 assert response.json() == "dummy response"
 
     @staticmethod
@@ -73,9 +73,9 @@ class TestRouteDependencies:
                     headers={"content-type": "application/json"},
                 )
 
-                assert 200 <= response.status_code < 300, (
-                    "Unauthenticated requests should be accepted"
-                )
+                assert (
+                    200 <= response.status_code < 300
+                ), "Unauthenticated requests should be accepted"
                 assert response.json() == "dummy response"
 
     def test_openapi_content_type(self):

--- a/stac_fastapi/api/tests/test_api.py
+++ b/stac_fastapi/api/tests/test_api.py
@@ -38,11 +38,10 @@ class TestRouteDependencies:
     def _assert_dependency_applied(api, routes):
         with TestClient(api.app) as client:
             for route in routes:
-                print(route)
                 response = getattr(client, route["method"].lower())(route["path"])
-                assert (
-                    response.status_code == 401
-                ), "Unauthenticated requests should be rejected"
+                assert response.status_code == 401, (
+                    "Unauthenticated requests should be rejected"
+                )
                 assert response.json() == {"detail": "Not authenticated"}
 
                 path = route["path"].format(
@@ -55,9 +54,9 @@ class TestRouteDependencies:
                     content=route["payload"],
                     headers={"content-type": "application/json"},
                 )
-                assert (
-                    200 <= response.status_code < 300
-                ), "Authenticated requests should be accepted"
+                assert 200 <= response.status_code < 300, (
+                    "Authenticated requests should be accepted"
+                )
                 assert response.json() == "dummy response"
 
     @staticmethod
@@ -74,9 +73,9 @@ class TestRouteDependencies:
                     headers={"content-type": "application/json"},
                 )
 
-                assert (
-                    200 <= response.status_code < 300
-                ), "Unauthenticated requests should be accepted"
+                assert 200 <= response.status_code < 300, (
+                    "Unauthenticated requests should be accepted"
+                )
                 assert response.json() == "dummy response"
 
     def test_openapi_content_type(self):

--- a/stac_fastapi/api/tests/test_api.py
+++ b/stac_fastapi/api/tests/test_api.py
@@ -38,6 +38,7 @@ class TestRouteDependencies:
     def _assert_dependency_applied(api, routes):
         with TestClient(api.app) as client:
             for route in routes:
+                print(route)
                 response = getattr(client, route["method"].lower())(route["path"])
                 assert response.status_code == 401, (
                     "Unauthenticated requests should be rejected"
@@ -69,11 +70,12 @@ class TestRouteDependencies:
                 response = client.request(
                     method=route["method"].lower(),
                     url=path,
-                    content=route["payload"],
+                    content=route.get("payload"),
                     headers={"content-type": "application/json"},
                 )
+
                 assert 200 <= response.status_code < 300, (
-                    "Authenticated requests should be accepted"
+                    "Unauthenticated requests should be accepted"
                 )
                 assert response.json() == "dummy response"
 
@@ -85,6 +87,53 @@ class TestRouteDependencies:
                 response.headers["content-type"]
                 == "application/vnd.oai.openapi+json;version=3.0"
             )
+
+    def test_build_api_with_transaction_dependencies(self, collection, item):
+        settings = config.ApiSettings()
+        dependencies = [Depends(must_be_bob)]
+        api = self._build_api(
+            extensions=[
+                TransactionExtension(
+                    client=DummyTransactionsClient(),
+                    settings=settings,
+                    route_dependencies=dependencies,
+                )
+            ]
+        )
+        self._assert_dependency_applied(
+            api,
+            [
+                {"path": "/collections", "method": "POST", "payload": collection},
+                {
+                    "path": "/collections/{collectionId}",
+                    "method": "PUT",
+                    "payload": collection,
+                },
+                {
+                    "path": "/collections/{collectionId}",
+                    "method": "DELETE",
+                    "payload": collection,
+                },
+                {
+                    "path": "/collections/{collectionId}/items",
+                    "method": "POST",
+                    "payload": item,
+                },
+                {
+                    "path": "/collections/{collectionId}/items/{itemId}",
+                    "method": "PUT",
+                    "payload": item,
+                },
+                {
+                    "path": "/collections/{collectionId}/items/{itemId}",
+                    "method": "DELETE",
+                    "payload": item,
+                },
+            ],
+        )
+        self._assert_dependency_not_applied(
+            api, [{"path": "/collections/{collectionId}", "method": "GET"}]
+        )
 
     def test_build_api_with_route_dependencies(self, collection, item):
         routes = [
@@ -400,6 +449,7 @@ class TestRouteDependencies:
 
 
 class DummyCoreClient(core.BaseCoreClient):
+<<<<<<< HEAD
     def all_collections(self, *args, **kwargs): ...
 
     def get_collection(self, *args, **kwargs): ...
@@ -411,6 +461,25 @@ class DummyCoreClient(core.BaseCoreClient):
     def post_search(self, *args, **kwargs): ...
 
     def item_collection(self, *args, **kwargs): ...
+=======
+    def all_collections(self, *args, **kwargs):
+        return "dummy response"
+
+    def get_collection(self, *args, **kwargs):
+        return "dummy response"
+
+    def get_item(self, *args, **kwargs):
+        return "dummy response"
+
+    def get_search(self, *args, **kwargs):
+        return "dummy response"
+
+    def post_search(self, *args, **kwargs):
+        return "dummy response"
+
+    def item_collection(self, *args, **kwargs):
+        return "dummy response"
+>>>>>>> 94418b3 (feat: add route_dependencies attribute to transaction extensions)
 
 
 class DummyTransactionsClient(BaseTransactionsClient):

--- a/stac_fastapi/api/tests/test_api.py
+++ b/stac_fastapi/api/tests/test_api.py
@@ -39,9 +39,9 @@ class TestRouteDependencies:
         with TestClient(api.app) as client:
             for route in routes:
                 response = getattr(client, route["method"].lower())(route["path"])
-                assert (
-                    response.status_code == 401
-                ), "Unauthenticated requests should be rejected"
+                assert response.status_code == 401, (
+                    "Unauthenticated requests should be rejected"
+                )
                 assert response.json() == {"detail": "Not authenticated"}
 
                 path = route["path"].format(
@@ -54,9 +54,9 @@ class TestRouteDependencies:
                     content=route["payload"],
                     headers={"content-type": "application/json"},
                 )
-                assert (
-                    200 <= response.status_code < 300
-                ), "Authenticated requests should be accepted"
+                assert 200 <= response.status_code < 300, (
+                    "Authenticated requests should be accepted"
+                )
                 assert response.json() == "dummy response"
 
     @staticmethod
@@ -73,9 +73,9 @@ class TestRouteDependencies:
                     headers={"content-type": "application/json"},
                 )
 
-                assert (
-                    200 <= response.status_code < 300
-                ), "Unauthenticated requests should be accepted"
+                assert 200 <= response.status_code < 300, (
+                    "Unauthenticated requests should be accepted"
+                )
                 assert response.json() == "dummy response"
 
     def test_openapi_content_type(self):
@@ -448,19 +448,6 @@ class TestRouteDependencies:
 
 
 class DummyCoreClient(core.BaseCoreClient):
-<<<<<<< HEAD
-    def all_collections(self, *args, **kwargs): ...
-
-    def get_collection(self, *args, **kwargs): ...
-
-    def get_item(self, *args, **kwargs): ...
-
-    def get_search(self, *args, **kwargs): ...
-
-    def post_search(self, *args, **kwargs): ...
-
-    def item_collection(self, *args, **kwargs): ...
-=======
     def all_collections(self, *args, **kwargs):
         return "dummy response"
 
@@ -478,7 +465,6 @@ class DummyCoreClient(core.BaseCoreClient):
 
     def item_collection(self, *args, **kwargs):
         return "dummy response"
->>>>>>> 94418b3 (feat: add route_dependencies attribute to transaction extensions)
 
 
 class DummyTransactionsClient(BaseTransactionsClient):

--- a/stac_fastapi/extensions/stac_fastapi/extensions/bulk_transactions/bulk_transactions.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/bulk_transactions/bulk_transactions.py
@@ -2,10 +2,11 @@
 
 import abc
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import attr
 from fastapi import APIRouter, FastAPI
+from fastapi.params import Depends
 from pydantic import BaseModel
 
 from stac_fastapi.api.models import create_request_model
@@ -113,6 +114,7 @@ class BulkTransactionExtension(ApiExtension):
     client: Union[AsyncBaseBulkTransactionsClient, BaseBulkTransactionsClient] = attr.ib()
     conformance_classes: List[str] = attr.ib(default=list())
     schema_href: Optional[str] = attr.ib(default=None)
+    route_dependencies: Optional[Sequence[Depends]] = attr.ib(default=None)
 
     def register(self, app: FastAPI) -> None:
         """Register the extension with a FastAPI application.
@@ -136,5 +138,6 @@ class BulkTransactionExtension(ApiExtension):
             endpoint=create_async_endpoint(
                 self.client.bulk_item_insert, items_request_model
             ),
+            dependencies=self.route_dependencies,
         )
         app.include_router(router, tags=["Bulk Transaction Extension"])

--- a/stac_fastapi/extensions/stac_fastapi/extensions/transaction/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/transaction/transaction.py
@@ -1,7 +1,7 @@
 """Transaction extension."""
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Sequence, Type, Union
 
 import attr
 from fastapi import APIRouter, Body, FastAPI

--- a/stac_fastapi/extensions/stac_fastapi/extensions/transaction/transaction.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/transaction/transaction.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 import attr
 from fastapi import APIRouter, Body, FastAPI
+from fastapi.params import Depends
 from pydantic import TypeAdapter
 from stac_pydantic import Collection, Item, ItemCollection
 from stac_pydantic.shared import MimeTypes
@@ -187,6 +188,7 @@ class TransactionExtension(ApiExtension):
     schema_href: Optional[str] = attr.ib(default=None)
     router: APIRouter = attr.ib(factory=APIRouter)
     response_class: Type[Response] = attr.ib(default=JSONResponse)
+    route_dependencies: Optional[Sequence[Depends]] = attr.ib(default=None)
 
     def register_create_item(self):
         """Register create item endpoint (POST /collections/{collection_id}/items)."""
@@ -208,6 +210,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=create_async_endpoint(self.client.create_item, PostItem),
+            dependencies=self.route_dependencies,
         )
 
     def register_update_item(self):
@@ -230,6 +233,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["PUT"],
             endpoint=create_async_endpoint(self.client.update_item, PutItem),
+            dependencies=self.route_dependencies,
         )
 
     def register_patch_item(self):
@@ -271,6 +275,7 @@ class TransactionExtension(ApiExtension):
                 self.client.patch_item,
                 PatchItem,
             ),
+            dependencies=self.route_dependencies,
         )
 
     def register_delete_item(self):
@@ -293,6 +298,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["DELETE"],
             endpoint=create_async_endpoint(self.client.delete_item, ItemUri),
+            dependencies=self.route_dependencies,
         )
 
     def register_create_collection(self):
@@ -315,6 +321,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["POST"],
             endpoint=create_async_endpoint(self.client.create_collection, Collection),
+            dependencies=self.route_dependencies,
         )
 
     def register_update_collection(self):
@@ -336,6 +343,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["PUT"],
             endpoint=create_async_endpoint(self.client.update_collection, PutCollection),
+            dependencies=self.route_dependencies,
         )
 
     def register_patch_collection(self):
@@ -376,6 +384,7 @@ class TransactionExtension(ApiExtension):
                 self.client.patch_collection,
                 PatchCollection,
             ),
+            dependencies=self.route_dependencies,
         )
 
     def register_delete_collection(self):
@@ -397,6 +406,7 @@ class TransactionExtension(ApiExtension):
             response_model_exclude_none=True,
             methods=["DELETE"],
             endpoint=create_async_endpoint(self.client.delete_collection, CollectionUri),
+            dependencies=self.route_dependencies,
         )
 
     def register(self, app: FastAPI) -> None:

--- a/stac_fastapi/extensions/tests/test_bulk_transactions.py
+++ b/stac_fastapi/extensions/tests/test_bulk_transactions.py
@@ -4,6 +4,7 @@ from typing import Iterator
 from unittest.mock import Mock
 
 import pytest
+from fastapi import Depends, HTTPException, security, status
 from starlette.testclient import TestClient
 
 from stac_fastapi.api.app import StacApi
@@ -63,15 +64,18 @@ def test_bulk_transaction_extension_customization():
     mock_client = Mock(spec=AsyncBaseBulkTransactionsClient)
     custom_conformance = ["https://example.com/bulk-spec"]
     custom_schema = "https://example.com/bulk-schema.json"
+    custom_dependencies = [Depends(must_be_bob)]
 
     ext = BulkTransactionExtension(
         client=mock_client,
         conformance_classes=custom_conformance,
         schema_href=custom_schema,
+        route_dependencies=custom_dependencies,
     )
 
     assert ext.conformance_classes == custom_conformance
     assert ext.schema_href == custom_schema
+    assert ext.route_dependencies == custom_dependencies
 
 
 # --- INTEGRATION TESTS ---
@@ -183,3 +187,53 @@ def test_bulk_item_invalid_method(client: TestClient, item: dict) -> None:
     response = client.post("/collections/a-collection/bulk_items", json=payload)
 
     assert response.status_code == 400
+
+
+def test_bulk_item_insert_with_route_dependencies(item: dict) -> None:
+    """Test route dependencies are applied to the bulk transactions route."""
+    settings = ApiSettings()
+    api = StacApi(
+        settings=settings,
+        client=DummyCoreClient(),
+        extensions=[
+            BulkTransactionExtension(
+                client=DummyBulkTransactionsClient(),
+                route_dependencies=[Depends(must_be_bob)],
+            ),
+        ],
+    )
+    payload = {
+        "items": {item["id"]: item},
+        "method": "insert",
+    }
+
+    with TestClient(api.app) as client:
+        unauthenticated_response = client.post(
+            "/collections/a-collection/bulk_items", json=payload
+        )
+        assert unauthenticated_response.status_code == 401
+        assert unauthenticated_response.json() == {"detail": "Not authenticated"}
+
+        authenticated_response = client.post(
+            "/collections/a-collection/bulk_items",
+            json=payload,
+            auth=("bob", "dobbs"),
+        )
+        assert authenticated_response.is_success, authenticated_response.text
+        assert (
+            authenticated_response.json() == "Successfully processed 1 items via insert."
+        )
+
+
+def must_be_bob(
+    credentials: security.HTTPBasicCredentials = Depends(security.HTTPBasic()),
+) -> bool:
+    """Require HTTP basic auth for user bob."""
+    if credentials.username == "bob":
+        return True
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="You're not Bob",
+        headers={"WWW-Authenticate": "Basic"},
+    )


### PR DESCRIPTION
resolves #884

**Related Issue(s):**

- #884 

**Description:**

This adds a new argument to the `TransactionExtension` and `BulkTransactionExtension` that makes it simple to add a dependency to all routes affected by the transactions extensions. It is possible that we would want to build off of the existing `add_route_dependencies` pathway instead of doing this within the extension, see #884 for some discussion around that point.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
