### PR TITLE
Support fastapi >= 0.137

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - fix mypy type errors in transaction extension for Python 3.14 compatibility (mypy 1.20.0) ([#895](https://github.com/stac-utils/stac-fastapi/pull/895))
+- fix `add_route_dependencies` to support FastAPI >= 0.137 by recursively unwrapping `_IncludedRouter` objects
 
 ## [6.2.1] - 2026-02-10
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@
 ### Fixed
 
 - fix mypy type errors in transaction extension for Python 3.14 compatibility (mypy 1.20.0) ([#895](https://github.com/stac-utils/stac-fastapi/pull/895))
-- fix `add_route_dependencies` to support FastAPI >= 0.137 by recursively unwrapping `_IncludedRouter` objects
+- fix `add_route_dependencies` to support FastAPI >= 0.137 by recursively unwrapping `_IncludedRouter` objects ([#929](https://github.com/stac-utils/stac-fastapi/pull/929))
 
 ## [6.2.1] - 2026-02-10
 

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -83,6 +83,45 @@ class Scope(TypedDict, total=False):
     type: Optional[str]
 
 
+def _is_endpoint_route(route: BaseRoute) -> bool:
+    """Check if route is a standard endpoint (not a mount or sub-router)."""
+    return (
+        hasattr(route, "path") and hasattr(route, "methods") and route.methods is not None
+    )
+
+
+def _apply_dependencies_to_route(
+    route: BaseRoute, scopes: List[Scope], dependencies: List[params.Depends]
+) -> None:
+    """Apply dependencies to a single route matching the given scopes."""
+    for scope in scopes:
+        _scope = copy.deepcopy(scope)
+
+        if scope["path"] == "*":
+            _scope["path"] = route.path  # type: ignore
+
+        if scope["method"] == "*":
+            _scope["method"] = list(route.methods)[0]  # type: ignore
+
+        match, _ = route.matches({"type": "http", **_scope})
+        if match != Match.FULL:
+            continue
+
+        if not hasattr(route, "dependant"):
+            continue
+
+        for depends in dependencies[::-1]:
+            route.dependant.dependencies.insert(
+                0,
+                get_parameterless_sub_dependant(
+                    depends=depends,
+                    path=route.path_format,  # type: ignore
+                ),
+            )
+
+        route.dependencies.extend(dependencies)  # type: ignore
+
+
 def add_route_dependencies(
     routes: List[BaseRoute], scopes: List[Scope], dependencies: List[params.Depends]
 ) -> None:
@@ -97,62 +136,18 @@ def add_route_dependencies(
         None
     """
     for route in routes:
-        # 1. Safely recurse into FastAPI >= 0.137 _IncludedRouters
         if hasattr(route, "original_router"):
             add_route_dependencies(route.original_router.routes, scopes, dependencies)
             continue
-            
-        # 2. Recurse into Mounts or older Starlette sub-routers
+
         if hasattr(route, "routes") and route.routes:
             add_route_dependencies(route.routes, scopes, dependencies)
             continue
-            
-        # 3. Skip anything that isn't a standard endpoint
-        if not hasattr(route, "path") or not hasattr(route, "methods") or not route.methods:
+
+        if not _is_endpoint_route(route):
             continue
 
-        for scope in scopes:
-            _scope = copy.deepcopy(scope)
-            
-            if scope["path"] == "*":
-                # NOTE: ignore type, because BaseRoute has no "path" attribute
-                # but APIRoute does.
-                _scope["path"] = route.path  # type: ignore
-
-            # NOTE: ignore type, because BaseRoute has no "method" attribute
-            # but APIRoute does.
-            if scope["method"] == "*":
-                _scope["method"] = list(route.methods)[0]  # type: ignore
-
-            match, _ = route.matches({"type": "http", **_scope})
-            if match != Match.FULL:
-                continue
-
-            # Ignore paths without dependants, e.g. /api, /api.html, /docs/oauth2-redirect
-            if not hasattr(route, "dependant"):
-                continue
-
-            # Mimicking how APIRoute handles dependencies:
-            # https://github.com/tiangolo/fastapi/blob/1760da0efa55585c19835d81afa8ca386036c325/fastapi/routing.py#L408-L412
-            for depends in dependencies[::-1]:
-                route.dependant.dependencies.insert(
-                    0,
-                    get_parameterless_sub_dependant(
-                        # NOTE: ignore type, because BaseRoute has no "path_format"
-                        # attribute but APIRoute does.
-                        depends=depends,
-                        path=route.path_format,  # type: ignore
-                    ),
-                )
-
-            # Register dependencies directly on route so that they aren't ignored if
-            # the routes are later associated with an app (e.g.
-            # app.include_router(router))
-            # https://github.com/tiangolo/fastapi/blob/58ab733f19846b4875c5b79bfb1f4d1cb7f4823f/fastapi/applications.py#L337-L360
-            # https://github.com/tiangolo/fastapi/blob/58ab733f19846b4875c5b79bfb1f4d1cb7f4823f/fastapi/routing.py#L677-L678
-            # NOTE: ignore type, because BaseRoute has no "dependencies" attribute
-            # but APIRoute does.
-            route.dependencies.extend(dependencies)  # type: ignore
+        _apply_dependencies_to_route(route, scopes, dependencies)
 
 
 def add_direct_response(app: FastAPI) -> None:

--- a/stac_fastapi/api/stac_fastapi/api/routes.py
+++ b/stac_fastapi/api/stac_fastapi/api/routes.py
@@ -96,9 +96,24 @@ def add_route_dependencies(
     Returns:
         None
     """
-    for scope in scopes:
-        _scope = copy.deepcopy(scope)
-        for route in routes:
+    for route in routes:
+        # 1. Safely recurse into FastAPI >= 0.137 _IncludedRouters
+        if hasattr(route, "original_router"):
+            add_route_dependencies(route.original_router.routes, scopes, dependencies)
+            continue
+            
+        # 2. Recurse into Mounts or older Starlette sub-routers
+        if hasattr(route, "routes") and route.routes:
+            add_route_dependencies(route.routes, scopes, dependencies)
+            continue
+            
+        # 3. Skip anything that isn't a standard endpoint
+        if not hasattr(route, "path") or not hasattr(route, "methods") or not route.methods:
+            continue
+
+        for scope in scopes:
+            _scope = copy.deepcopy(scope)
+            
             if scope["path"] == "*":
                 # NOTE: ignore type, because BaseRoute has no "path" attribute
                 # but APIRoute does.

--- a/uv.lock
+++ b/uv.lock
@@ -2297,7 +2297,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=23.2.0" },
-    { name = "fastapi", specifier = ">0.137.0" },
+    { name = "fastapi", specifier = ">=0.109.0" },
     { name = "iso8601", specifier = ">=1.0.2,<2.2.0" },
     { name = "pydantic-settings", specifier = ">=2" },
     { name = "stac-pydantic", specifier = ">=3.3.0,<4.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.138.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -646,9 +646,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
 ]
 
 [[package]]
@@ -2297,7 +2297,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=23.2.0" },
-    { name = "fastapi", specifier = ">=0.109.0" },
+    { name = "fastapi", specifier = ">0.137.0" },
     { name = "iso8601", specifier = ">=1.0.2,<2.2.0" },
     { name = "pydantic-settings", specifier = ">=2" },
     { name = "stac-pydantic", specifier = ">=3.3.0,<4.0" },


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/779
- https://github.com/stac-utils/stac-fastapi-pgstac/pull/389

**Description:**

- fix `add_route_dependencies` to support FastAPI >= 0.137 by recursively unwrapping `_IncludedRouter` objects 

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
