### PR TITLE
fix: avoid urljoin issue

### DIFF
--- a/stac_fastapi/api/tests/test_app_prefix.py
+++ b/stac_fastapi/api/tests/test_app_prefix.py
@@ -88,7 +88,7 @@ def test_api_prefix(TestCoreClient, prefix):
             assert resp.status_code == 200
 
 
-@pytest.mark.parametrize("prefix", ["", "/a_prefix"])
+@pytest.mark.parametrize("prefix", ["", "/stac", "/v1/stac"])
 def test_async_api_prefix(AsyncTestCoreClient, prefix):
     api_settings = ApiSettings(
         openapi_url=f"{prefix}/api",
@@ -104,7 +104,6 @@ def test_async_api_prefix(AsyncTestCoreClient, prefix):
     with TestClient(api.app, base_url="http://stac.io") as client:
         landing = client.get(f"{prefix}/")
         assert landing.status_code == 200, landing.json()
-
         service_doc = client.get(f"{prefix}/api.html")
         assert service_doc.status_code == 200, service_doc.text
 
@@ -152,9 +151,12 @@ def test_async_api_prefix(AsyncTestCoreClient, prefix):
 
 
 @pytest.mark.parametrize("prefix", ["", "/a_prefix"])
-def test_api_prefix_with_root_path(TestCoreClient, prefix):
+@pytest.mark.parametrize("root_path", ["", "/api/v1"])
+def test_api_prefix_with_root_path(TestCoreClient, root_path, prefix):
     api_settings = ApiSettings(
-        openapi_url=f"{prefix}/api", docs_url=f"{prefix}/api.html", root_path="/api/v1"
+        openapi_url=f"{prefix}/api",
+        docs_url=f"{prefix}/api.html",
+        root_path=root_path,
     )
 
     api = StacApi(
@@ -163,8 +165,8 @@ def test_api_prefix_with_root_path(TestCoreClient, prefix):
         router=APIRouter(prefix=prefix),
     )
 
-    prefix = "/api/v1" + prefix
-    with TestClient(api.app, base_url="http://stac.io", root_path="/api/v1") as client:
+    prefix = root_path + prefix
+    with TestClient(api.app, base_url="http://stac.io", root_path=root_path) as client:
         landing = client.get(f"{prefix}/")
         assert landing.status_code == 200, landing.json()
 

--- a/stac_fastapi/types/stac_fastapi/types/core.py
+++ b/stac_fastapi/types/stac_fastapi/types/core.py
@@ -2,7 +2,7 @@
 
 import abc
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 import attr
 from fastapi import Request
@@ -47,6 +47,7 @@ class LandingPageMixin(abc.ABC):
         conformance_classes: list[str],
         extension_schemas: list[str],
     ) -> stac.LandingPage:
+        path = urlsplit(base_url).path.rstrip("/")
         landing_page = stac.LandingPage(
             type="Catalog",
             id=self.landing_page_id,
@@ -71,26 +72,26 @@ class LandingPageMixin(abc.ABC):
                     "rel": Relations.data.value,
                     "type": MimeTypes.json.value,
                     "title": "Collections available for this Catalog",
-                    "href": urljoin(base_url, "collections"),
+                    "href": urljoin(base_url, f"{path}/collections"),
                 },
                 {
                     "rel": Relations.conformance.value,
                     "type": MimeTypes.json.value,
                     "title": "STAC/OGC conformance classes implemented by this server",
-                    "href": urljoin(base_url, "conformance"),
+                    "href": urljoin(base_url, f"{path}/conformance"),
                 },
                 {
                     "rel": Relations.search.value,
                     "type": MimeTypes.geojson.value,
                     "title": "STAC search [GET]",
-                    "href": urljoin(base_url, "search"),
+                    "href": urljoin(base_url, f"{path}/search"),
                     "method": "GET",
                 },
                 {
                     "rel": Relations.search.value,
                     "type": MimeTypes.geojson.value,
                     "title": "STAC search [POST]",
-                    "href": urljoin(base_url, "search"),
+                    "href": urljoin(base_url, f"{path}/search"),
                     "method": "POST",
                 },
             ],
@@ -155,6 +156,8 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
             extension_schemas=[],
         )
 
+        path = urlsplit(base_url).path.rstrip("/")
+
         # Add Queryables link
         if self.extension_is_enabled("FilterExtension") or self.extension_is_enabled(
             "SearchFilterExtension"
@@ -164,7 +167,7 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
                     "rel": Relations.queryables.value,
                     "type": MimeTypes.jsonschema.value,
                     "title": "Queryables available for this Catalog",
-                    "href": urljoin(base_url, "queryables"),
+                    "href": urljoin(base_url, f"{path}/queryables"),
                 }
             )
 
@@ -176,13 +179,13 @@ class BaseCoreClient(LandingPageMixin, abc.ABC):
                         "rel": "aggregate",
                         "type": "application/json",
                         "title": "Aggregate",
-                        "href": urljoin(base_url, "aggregate"),
+                        "href": urljoin(base_url, f"{path}/aggregate"),
                     },
                     {
                         "rel": "aggregations",
                         "type": "application/json",
                         "title": "Aggregations",
-                        "href": urljoin(base_url, "aggregations"),
+                        "href": urljoin(base_url, f"{path}/aggregations"),
                     },
                 ]
             )
@@ -364,6 +367,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
             conformance_classes=self.conformance_classes(),
             extension_schemas=[],
         )
+        path = urlsplit(base_url).path.rstrip("/")
 
         # Add Queryables link
         if self.extension_is_enabled("FilterExtension") or self.extension_is_enabled(
@@ -374,7 +378,7 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
                     "rel": Relations.queryables.value,
                     "type": MimeTypes.jsonschema.value,
                     "title": "Queryables available for this Catalog",
-                    "href": urljoin(base_url, "queryables"),
+                    "href": urljoin(base_url, f"{path}/queryables"),
                     "method": "GET",
                 }
             )
@@ -387,13 +391,13 @@ class AsyncBaseCoreClient(LandingPageMixin, abc.ABC):
                         "rel": "aggregate",
                         "type": "application/json",
                         "title": "Aggregate",
-                        "href": urljoin(base_url, "aggregate"),
+                        "href": urljoin(base_url, f"{path}/aggregate"),
                     },
                     {
                         "rel": "aggregations",
                         "type": "application/json",
                         "title": "Aggregations",
-                        "href": urljoin(base_url, "aggregations"),
+                        "href": urljoin(base_url, f"{path}/aggregations"),
                     },
                 ]
             )

--- a/stac_fastapi/types/stac_fastapi/types/links.py
+++ b/stac_fastapi/types/stac_fastapi/types/links.py
@@ -1,7 +1,7 @@
 """Link helpers."""
 
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 import attr
 from stac_pydantic.links import Relations
@@ -21,8 +21,10 @@ def filter_links(links: list[dict]) -> list[dict]:
 def resolve_links(links: list, base_url: str) -> list[dict]:
     """Convert relative links to absolute links."""
     filtered_links = filter_links(links)
+    path = urlsplit(base_url).path.rstrip("/")
     for link in filtered_links:
-        link.update({"href": urljoin(base_url, link["href"])})
+        href = link["href"].lstrip("/")
+        link.update({"href": urljoin(base_url, f"{path}/{href}")})
     return filtered_links
 
 
@@ -44,10 +46,11 @@ class CollectionLinks(BaseLinks):
 
     def self(self) -> dict[str, Any]:
         """Create the `self` link."""
+        path = urlsplit(self.base_url).path.rstrip("/")
         return dict(
             rel=Relations.self,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"{path}/collections/{self.collection_id}"),
         )
 
     def parent(self) -> dict[str, Any]:
@@ -56,10 +59,11 @@ class CollectionLinks(BaseLinks):
 
     def items(self) -> dict[str, Any]:
         """Create the `items` link."""
+        path = urlsplit(self.base_url).path.rstrip("/")
         return dict(
             rel="items",
             type=MimeTypes.geojson,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}/items"),
+            href=urljoin(self.base_url, f"{path}/collections/{self.collection_id}/items"),
         )
 
     def create_links(self) -> list[dict[str, Any]]:
@@ -75,29 +79,32 @@ class ItemLinks(BaseLinks):
 
     def self(self) -> dict[str, Any]:
         """Create the `self` link."""
+        path = urlsplit(self.base_url).path.rstrip("/")
         return dict(
             rel=Relations.self,
             type=MimeTypes.geojson,
             href=urljoin(
                 self.base_url,
-                f"collections/{self.collection_id}/items/{self.item_id}",
+                f"{path}/collections/{self.collection_id}/items/{self.item_id}",
             ),
         )
 
     def parent(self) -> dict[str, Any]:
         """Create the `parent` link."""
+        path = urlsplit(self.base_url).path.rstrip("/")
         return dict(
             rel=Relations.parent,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"{path}/collections/{self.collection_id}"),
         )
 
     def collection(self) -> dict[str, Any]:
         """Create the `collection` link."""
+        path = urlsplit(self.base_url).path.rstrip("/")
         return dict(
             rel=Relations.collection,
             type=MimeTypes.json,
-            href=urljoin(self.base_url, f"collections/{self.collection_id}"),
+            href=urljoin(self.base_url, f"{path}/collections/{self.collection_id}"),
         )
 
     def create_links(self) -> list[dict[str, Any]]:


### PR DESCRIPTION
Because we always add `/` at the end of the base url in 

https://github.com/stac-utils/stac-fastapi/blob/8ca103aca17d32cc65f7387043c3d78dbe372a05/stac_fastapi/types/stac_fastapi/types/requests.py#L12

```python
# when base url doesn't end with a slash, the last part of the base url is replaced by the relative url
urljoin("http://stac.io/stac", "collection")
'http://stac.io/collection'

urljoin("http://stac.io/stac/", "collection")
'http://stac.io/stac/collection'
```

There is only one place where the issue could happen in https://github.com/stac-utils/stac-fastapi/blob/8ca103aca17d32cc65f7387043c3d78dbe372a05/stac_fastapi/types/stac_fastapi/types/links.py#L21-L26

but I don't see any use of this method.



Anyway, better be safe than sorry so I decided to apply the same `fix` everywhere.