### PR TITLE
Fix: resolve links to handle absolute links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Prevent resolve_links from mangling absolute URLs in STAC items. The function now checks if an href is already absolute (starts with http:// or https://) before applying the proxy path and base_url. This fixes a regression in v6.3.1 that affected any backend or custom implementation that returns STAC items containing external or absolute URLs (such as license links, external documentation, or custom asset endpoints).
+- Prevent resolve_links from mangling absolute URLs in STAC items. The function now checks if an href is already absolute (starts with http:// or https://) before applying the proxy path and base_url. This fixes a regression in v6.3.1 that affected any backend or custom implementation that returns STAC items containing external or absolute URLs (such as license links, external documentation, or custom asset endpoints). ([#940](https://github.com/stac-utils/stac-fastapi/pull/940))
 
 ## [6.3.1] - 2026-06-25
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent resolve_links from mangling absolute URLs in STAC items. The function now checks if an href is already absolute (starts with http:// or https://) before applying the proxy path and base_url. This fixes a regression in v6.3.1 that affected any backend or custom implementation that returns STAC items containing external or absolute URLs (such as license links, external documentation, or custom asset endpoints).
+
 ## [6.3.1] - 2026-06-25
 
 ### Fixed

--- a/stac_fastapi/types/stac_fastapi/types/links.py
+++ b/stac_fastapi/types/stac_fastapi/types/links.py
@@ -19,12 +19,27 @@ def filter_links(links: list[dict]) -> list[dict]:
 
 
 def resolve_links(links: list, base_url: str) -> list[dict]:
-    """Convert relative links to absolute links."""
+    """Convert relative links to absolute links while preserving existing absolute URLs.
+
+    This function processes links and applies the base_url and proxy path to relative URLs
+    However, it explicitly preserves absolute URLs (starting with http:// or https://) to
+    prevent mangling of external links stored in STAC items (e.g., license URLs, external
+    documentation links).
+    """
     filtered_links = filter_links(links)
     path = urlsplit(base_url).path.rstrip("/")
     for link in filtered_links:
-        href = link["href"].lstrip("/")
-        link.update({"href": urljoin(base_url, f"{path}/{href}")})
+        href = str(link.get("href", ""))
+
+        # Do not mangle URLs that are already absolute
+        if href.startswith(("http://", "https://")):
+            continue
+
+        # Remove leading slash to prevent urljoin from replacing the entire path
+        href = href.lstrip("/")
+        # Construct the full path with proxy path preserved
+        full_path = f"{path}/{href}" if path else href
+        link.update({"href": urljoin(base_url, full_path)})
     return filtered_links
 
 

--- a/stac_fastapi/types/tests/test_links.py
+++ b/stac_fastapi/types/tests/test_links.py
@@ -1,0 +1,148 @@
+"""Tests for link resolution functionality."""
+
+from stac_fastapi.types.links import resolve_links
+
+
+def test_resolve_links_with_absolute_and_relative_urls():
+    """Test that resolve_links correctly handles a mix of absolute and relative URLs.
+
+    This test ensures that the v6.3.1 regression is fixed: absolute URLs in STAC items
+    should not be mangled by prepending the proxy path and base_url.
+    """
+    base_url = "http://api.stac.io/api/v1/"
+
+    incoming_links = [
+        {
+            "rel": "child",
+            "href": "/collections/sentinel-2",
+            "type": "application/geo+json",
+        },
+        {
+            "rel": "license",
+            "href": "https://example.com/license.pdf",
+            "type": "application/pdf",
+        },
+    ]
+
+    resolved = resolve_links(incoming_links, base_url)
+
+    # 1. Check the relative link (Should have the proxy path APPLIED and PRESERVED)
+    child_link = next(link for link in resolved if link["rel"] == "child")
+    assert child_link["href"] == "http://api.stac.io/api/v1/collections/sentinel-2"
+
+    # 2. Check the absolute link (Should be completely untouched)
+    license_link = next(link for link in resolved if link["rel"] == "license")
+    assert license_link["href"] == "https://example.com/license.pdf"
+
+    # 3. Ensure no double-protocol mangling occurred
+    assert "http://api.stac.io/api/v1/https://" not in license_link["href"]
+
+
+def test_resolve_links_preserves_http_urls():
+    """Test that HTTP (not HTTPS) absolute URLs are also preserved."""
+    base_url = "https://api.stac.io/v1/"
+
+    incoming_links = [
+        {
+            "rel": "alternate",
+            "href": "http://example.com/data",
+            "type": "application/json",
+        },
+    ]
+
+    resolved = resolve_links(incoming_links, base_url)
+    assert resolved[0]["href"] == "http://example.com/data"
+
+
+def test_resolve_links_handles_relative_urls_without_leading_slash():
+    """Test that relative URLs without leading slashes are properly resolved."""
+    base_url = "http://api.stac.io/api/v1/"
+
+    incoming_links = [
+        {
+            "rel": "documentation",
+            "href": "docs/readme.md",
+            "type": "text/markdown",
+        },
+    ]
+
+    resolved = resolve_links(incoming_links, base_url)
+    assert resolved[0]["href"] == "http://api.stac.io/api/v1/docs/readme.md"
+
+
+def test_resolve_links_with_proxy_path():
+    """Test that proxy paths are correctly applied to relative URLs."""
+    base_url = "http://api.stac.io/stac/v1/"
+
+    incoming_links = [
+        {
+            "rel": "child",
+            "href": "/catalogs/sentinel",
+            "type": "application/json",
+        },
+    ]
+
+    resolved = resolve_links(incoming_links, base_url)
+    # The proxy path (/stac/v1) should be successfully retained
+    assert resolved[0]["href"] == "http://api.stac.io/stac/v1/catalogs/sentinel"
+
+
+def test_resolve_links_filters_inferred_links():
+    """Test that inferred links (self, item, parent, etc.) are filtered out."""
+    base_url = "http://api.stac.io/v1/"
+
+    incoming_links = [
+        {
+            "rel": "self",
+            "href": "/collections/sentinel-2",
+            "type": "application/json",
+        },
+        {
+            "rel": "custom",
+            "href": "https://example.com/custom",
+            "type": "application/json",
+        },
+    ]
+
+    resolved = resolve_links(incoming_links, base_url)
+
+    # Only the custom link should be in the result
+    assert len(resolved) == 1
+    assert resolved[0]["rel"] == "custom"
+
+
+def test_resolve_links_empty_href():
+    """Test that links with missing or empty href are handled gracefully."""
+    base_url = "http://api.stac.io/v1/"
+
+    incoming_links = [
+        {
+            "rel": "custom",
+            "href": "",
+            "type": "application/json",
+        },
+    ]
+
+    resolved = resolve_links(incoming_links, base_url)
+
+    # Should handle empty href without crashing
+    assert len(resolved) == 1
+    assert resolved[0]["href"] == "http://api.stac.io/v1/"
+
+
+def test_resolve_links_missing_href():
+    """Test that links with missing href key are handled gracefully."""
+    base_url = "http://api.stac.io/v1/"
+
+    incoming_links = [
+        {
+            "rel": "custom",
+            "type": "application/json",
+        },
+    ]
+
+    resolved = resolve_links(incoming_links, base_url)
+
+    # Should handle missing href without crashing, defaulting to base_url
+    assert len(resolved) == 1
+    assert resolved[0]["href"] == "http://api.stac.io/v1/"

--- a/uv.lock
+++ b/uv.lock
@@ -2193,7 +2193,7 @@ wheels = [
 
 [[package]]
 name = "stac-fastapi"
-version = "6.3.0"
+version = "6.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "stac-fastapi-api" },


### PR DESCRIPTION
**Related Issue(s):**

- None

**Description:**

- Prevents resolve_links from mangling absolute URLs in STAC items. The function now checks if an href is already absolute (starts with http:// or https://) before applying the proxy path and base_url. This fixes a regression in v6.3.1 that affected any backend or custom implementation that returns STAC items containing external or absolute URLs (such as license links, external documentation, or custom asset endpoints).

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
