### PR TITLE
log warning for default title, description

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Log warning when default API title, description, landing ID, or version are used to encourage proper API configuration ([#943](https://github.com/stac-utils/stac-fastapi/issues/943))
+
 ## [6.3.2] - 2026-06-27
 
 ### Fixed

--- a/stac_fastapi/types/stac_fastapi/types/config.py
+++ b/stac_fastapi/types/stac_fastapi/types/config.py
@@ -1,9 +1,12 @@
 """stac_fastapi.types.config module."""
 
+import logging
 from typing import Self
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class ApiSettings(BaseSettings):
@@ -43,10 +46,28 @@ class ApiSettings(BaseSettings):
 
     @model_validator(mode="after")
     def check_incompatible_options(self) -> Self:
-        """Check for incompatible options."""
+        """Check for incompatible options and warn about default values."""
         if self.enable_response_models and self.enable_direct_response:
             raise ValueError(
                 "`enable_reponse_models` and `enable_direct_response` options are incompatible"  # noqa: E501
+            )
+
+        defaults_used = []
+        if self.stac_fastapi_title == "stac-fastapi":
+            defaults_used.append("stac_fastapi_title")
+        if self.stac_fastapi_description == "stac-fastapi":
+            defaults_used.append("stac_fastapi_description")
+        if self.stac_fastapi_landing_id == "stac-fastapi":
+            defaults_used.append("stac_fastapi_landing_id")
+        if self.stac_fastapi_version == "0.1":
+            defaults_used.append("stac_fastapi_version")
+
+        if defaults_used:
+            logger.warning(
+                "Using default values for %s. This may impact API discoverability. "
+                "Please configure these values via environment variables or settings. "
+                "See https://stac-utils.github.io/stac-fastapi/tips-and-tricks/#set-api-title-description-and-version",  # noqa: E501
+                ", ".join(defaults_used),
             )
 
         return self

--- a/stac_fastapi/types/tests/test_config.py
+++ b/stac_fastapi/types/tests/test_config.py
@@ -1,5 +1,7 @@
 """test config classes."""
 
+import logging
+
 import pytest
 from pydantic import ValidationError
 
@@ -27,3 +29,43 @@ def test_incompatible_options():
             enable_response_models=True,
             enable_direct_response=True,
         )
+
+
+def test_default_values_warning(caplog):
+    """test that a warning is logged when using default values."""
+    with caplog.at_level(logging.WARNING):
+        ApiSettings()
+
+    assert "Using default values for" in caplog.text
+    assert "stac_fastapi_title" in caplog.text
+    assert "stac_fastapi_description" in caplog.text
+    assert "stac_fastapi_landing_id" in caplog.text
+    assert "stac_fastapi_version" in caplog.text
+
+
+def test_custom_values_no_warning(caplog):
+    """test that no warning is logged when using custom values."""
+    with caplog.at_level(logging.WARNING):
+        ApiSettings(
+            stac_fastapi_title="My API",
+            stac_fastapi_description="My API Description",
+            stac_fastapi_landing_id="my-api",
+            stac_fastapi_version="1.0.0",
+        )
+
+    assert "Using default values for" not in caplog.text
+
+
+def test_partial_custom_values_warning(caplog):
+    """test that a warning is logged only for remaining default values."""
+    with caplog.at_level(logging.WARNING):
+        ApiSettings(
+            stac_fastapi_title="My API",
+            stac_fastapi_description="My API Description",
+        )
+
+    assert "Using default values for" in caplog.text
+    assert "stac_fastapi_landing_id" in caplog.text
+    assert "stac_fastapi_version" in caplog.text
+    assert "stac_fastapi_title" not in caplog.text
+    assert "stac_fastapi_description" not in caplog.text


### PR DESCRIPTION
**Related Issue(s):**

- #932 

**Description:**

- Log warning when default API title, description, landing ID, or version are used to encourage proper API configuration 

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
