### PR TITLE
fix: add back SortConformanceClasses enum values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- add back `SortConformanceClasses.{COLLECTIONS|ITEMS|SEARCH}` enum values to avoid breaking change and add deprecation warning for them
+
 ## [6.4.0] - 2026-07-21
 
 ### Added 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
 ]
 
 [tool.ruff]
-target-version = "py39" # minimum supported version
+target-version = "py311" # minimum supported version
 line-length = 90
 
 [tool.ruff.lint]

--- a/stac_fastapi/extensions/stac_fastapi/extensions/sort/sort.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/sort/sort.py
@@ -1,6 +1,7 @@
 """Sort extension."""
 
-from enum import StrEnum
+import warnings
+from enum import EnumMeta, StrEnum
 from typing import Any
 
 import attr
@@ -50,7 +51,67 @@ class SortablesSchema(BaseModel):
     }
 
 
-class SortConformanceClasses(StrEnum):
+class _DeprecatedMemberMeta(EnumMeta):
+    def __getattr__(cls, name: str):
+        match name:
+            case "COLLECTIONS":
+                warnings.warn(
+                    "'COLLECTIONS' will be removed in a future version, "
+                    "use 'COLLECTION_SEARCH_SORT' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return cls.COLLECTION_SEARCH_SORT
+            case "ITEMS":
+                warnings.warn(
+                    "'ITEMS' will be removed in a future version, "
+                    "use 'FEATURES_SORT' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return cls.FEATURES_SORT
+            case "SEARCH":
+                warnings.warn(
+                    "'SEARCH' will be removed in a future version, "
+                    "use 'ITEM_SEARCH_SORT' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return cls.ITEM_SEARCH_SORT
+
+        raise AttributeError(f"'{cls.__name__}' has no attribute '{name}'")
+
+    def __getitem__(cls, name: str):
+        match name:
+            case "COLLECTIONS":
+                warnings.warn(
+                    "'COLLECTIONS' will be removed in a future version, "
+                    "use 'COLLECTION_SEARCH_SORT' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return cls.COLLECTION_SEARCH_SORT
+            case "ITEMS":
+                warnings.warn(
+                    "'ITEMS' will be removed in a future version, "
+                    "use 'FEATURES_SORT' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return cls.FEATURES_SORT
+            case "SEARCH":
+                warnings.warn(
+                    "'SEARCH' will be removed in a future version, "
+                    "use 'ITEM_SEARCH_SORT' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return cls.ITEM_SEARCH_SORT
+
+        return super().__getitem__(name)
+
+
+class SortConformanceClasses(StrEnum, metaclass=_DeprecatedMemberMeta):
     """Conformance classes for the Sort v1.1.0 extension.
 
     See https://github.com/stac-api-extensions/sort

--- a/stac_fastapi/extensions/stac_fastapi/extensions/sort/sort.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/sort/sort.py
@@ -52,6 +52,8 @@ class SortablesSchema(BaseModel):
 
 
 class _DeprecatedMemberMeta(EnumMeta):
+    """TODO: Remove this metaclass in 7.0.0."""
+
     def __getattr__(cls, name: str):
         match name:
             case "COLLECTIONS":

--- a/stac_fastapi/extensions/tests/test_sort.py
+++ b/stac_fastapi/extensions/tests/test_sort.py
@@ -90,6 +90,42 @@ def test_sort_conformance_classes():
         == "https://api.stacspec.org/v1.1.0/collection-search#sortables"
     )
 
+    with pytest.warns(DeprecationWarning):
+        assert (
+            SortConformanceClasses.COLLECTIONS
+            == "https://api.stacspec.org/v1.1.0/collection-search#sort"
+        )
+
+    with pytest.warns(DeprecationWarning):
+        assert (
+            SortConformanceClasses["COLLECTIONS"]
+            == "https://api.stacspec.org/v1.1.0/collection-search#sort"
+        )
+
+    with pytest.warns(DeprecationWarning):
+        assert (
+            SortConformanceClasses.ITEMS
+            == "https://api.stacspec.org/v1.1.0/ogcapi-features#sort"
+        )
+
+    with pytest.warns(DeprecationWarning):
+        assert (
+            SortConformanceClasses["ITEMS"]
+            == "https://api.stacspec.org/v1.1.0/ogcapi-features#sort"
+        )
+
+    with pytest.warns(DeprecationWarning):
+        assert (
+            SortConformanceClasses.SEARCH
+            == "https://api.stacspec.org/v1.1.0/item-search#sort"
+        )
+
+    with pytest.warns(DeprecationWarning):
+        assert (
+            SortConformanceClasses["SEARCH"]
+            == "https://api.stacspec.org/v1.1.0/item-search#sort"
+        )
+
 
 def test_sort_extension_defaults():
     """Test the default instantiation of the SortExtension."""

--- a/uv.lock
+++ b/uv.lock
@@ -2171,7 +2171,7 @@ wheels = [
 
 [[package]]
 name = "stac-fastapi"
-version = "6.3.2"
+version = "6.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "stac-fastapi-api" },


### PR DESCRIPTION
@jonhealy1 I didn't realize that https://github.com/stac-utils/stac-fastapi/pull/945 had breaking changes. For now this PR will address the changes and add deprecation notice 

we can remove this in 7.0