### PR TITLE
Added optional prometheus metrics endpoint.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@
 
 ### Added 
 
+- Optional Prometheus metrics (`stac-fastapi-api[metrics]`) with STAC operation labels at `/_mgmt/metrics`
 - Advice on creating custom extensions ([#944](https://github.com/stac-utils/stac-fastapi/pull/944))
 - Log warning when default API title, description, landing ID, or version are used to encourage proper API configuration ([#943](https://github.com/stac-utils/stac-fastapi/issues/943))
 - Added sortables support to Sort extension for discovering available sort fields via dedicated endpoints (`/sortables`, `/collections/{id}/sortables`, `/collections-sortables`) ([#945](https://github.com/stac-utils/stac-fastapi/issues/945))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- Optional Prometheus metrics (`stac-fastapi-api[metrics]`) with STAC operation labels at `/_mgmt/metrics`, enabled via `StacApi(add_metrics=True)` ([#958](https://github.com/stac-utils/stac-fastapi/pull/958))
 
 ## [6.4.1] - 2026-07-22
 
@@ -17,7 +20,6 @@
 
 ### Added 
 
-- Optional Prometheus metrics (`stac-fastapi-api[metrics]`) with STAC operation labels at `/_mgmt/metrics`
 - Advice on creating custom extensions ([#944](https://github.com/stac-utils/stac-fastapi/pull/944))
 - Log warning when default API title, description, landing ID, or version are used to encourage proper API configuration ([#943](https://github.com/stac-utils/stac-fastapi/issues/943))
 - Added sortables support to Sort extension for discovering available sort fields via dedicated endpoints (`/sortables`, `/collections/{id}/sortables`, `/collections-sortables`) ([#945](https://github.com/stac-utils/stac-fastapi/issues/945))

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
           - app: api/stac_fastapi/api/app.md
           - config: api/stac_fastapi/api/config.md
           - errors: api/stac_fastapi/api/errors.md
+          - metrics: api/stac_fastapi/api/metrics.md
           - middleware: api/stac_fastapi/api/middleware.md
           - models: api/stac_fastapi/api/models.md
           - openapi: api/stac_fastapi/api/openapi.md

--- a/docs/src/api/stac_fastapi/api/index.md
+++ b/docs/src/api/stac_fastapi/api/index.md
@@ -7,6 +7,7 @@ Api submodule.
 * [stac_fastapi.api.app](app.md)
 * [stac_fastapi.api.config](config.md)
 * [stac_fastapi.api.errors](errors.md)
+* [stac_fastapi.api.metrics](metrics.md)
 * [stac_fastapi.api.middleware](middleware.md)
 * [stac_fastapi.api.models](models.md)
 * [stac_fastapi.api.openapi](openapi.md)

--- a/docs/src/api/stac_fastapi/api/metrics.md
+++ b/docs/src/api/stac_fastapi/api/metrics.md
@@ -1,0 +1,3 @@
+::: stac_fastapi.api.metrics
+    options:
+      show_source: true

--- a/docs/src/tips-and-tricks.md
+++ b/docs/src/tips-and-tricks.md
@@ -184,10 +184,22 @@ api = StacApi(
 
 ## Prometheus metrics
 
-Install the optional dependency to expose metrics at `{router_prefix}/_mgmt/metrics` with low-cardinality STAC `operation` labels (`search`, `get_item`, …):
+Install the optional dependency and enable metrics on `StacApi` to expose
+`{router_prefix}/_mgmt/metrics` with low-cardinality STAC `operation` labels
+(`search`, `get_item`, …):
 
 ```bash
 pip install "stac-fastapi-api[metrics]"
+```
+
+```python
+from stac_fastapi.api.app import StacApi
+
+api = StacApi(
+    settings=settings,
+    client=client,
+    add_metrics=True,
+)
 ```
 
 `/_mgmt/*` routes (ping, health, metrics) are excluded from instrumentation.

--- a/docs/src/tips-and-tricks.md
+++ b/docs/src/tips-and-tricks.md
@@ -181,3 +181,24 @@ api = StacApi(
     ]
 )
 ```
+
+## Prometheus metrics
+
+Install the optional dependency to expose metrics at `{router_prefix}/_mgmt/metrics` with low-cardinality STAC `operation` labels (`search`, `get_item`, …):
+
+```bash
+pip install "stac-fastapi-api[metrics]"
+```
+
+`/_mgmt/*` routes (ping, health, metrics) are excluded from instrumentation.
+
+Unmatched `/catalogs*` paths fall back to `operation="catalog"`. Backends with extra routes (for example multi-tenant catalogs) should register explicit labels with `register_operations` before or at app construction:
+
+```python
+from stac_fastapi.api.metrics import register_operations
+
+register_operations({
+    ("GET", "/viewer"): "viewer",
+    ("GET", "/catalogs/{catalog_id}/collections"): "list_collections",
+})
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
     "pre-commit",
     "httpx2",
     "requests",
-    "prometheus-fastapi-instrumentator>=8,<9",
+    "prometheus-fastapi-instrumentator>=8",
 ]
 docs = [
     "black>=23.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pre-commit",
     "httpx2",
     "requests",
+    "prometheus-fastapi-instrumentator>=8,<9",
 ]
 docs = [
     "black>=23.10.1",

--- a/stac_fastapi/api/pyproject.toml
+++ b/stac_fastapi/api/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 metrics = [
-    "prometheus-fastapi-instrumentator>=8,<9",
+    "prometheus-fastapi-instrumentator>=8",
 ]
 
 [dependency-groups]

--- a/stac_fastapi/api/pyproject.toml
+++ b/stac_fastapi/api/pyproject.toml
@@ -35,6 +35,11 @@ dependencies = [
     "stac-fastapi.types~=6.4",
 ]
 
+[project.optional-dependencies]
+metrics = [
+    "prometheus-fastapi-instrumentator>=8,<9",
+]
+
 [dependency-groups]
 dev = [
     "httpx",

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -41,16 +41,6 @@ from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest
 
 
-def add_metrics(app: FastAPI) -> None:
-    """Expose Prometheus metrics when the optional metrics extra is installed."""
-    try:
-        from stac_fastapi.api.metrics import instrument_app
-    except ImportError:
-        return
-
-    instrument_app(app)
-
-
 @attr.s
 class StacApi:
     """StacApi factory.
@@ -84,6 +74,10 @@ class StacApi:
         health_check:
             A Callable which return application's `health` information.
             Defaults to `def health: return {"status": "UP"}`
+        add_metrics:
+            When ``True``, instrument the app and expose Prometheus metrics at
+            ``{router_prefix}/_mgmt/metrics``. Requires
+            ``stac-fastapi-api[metrics]`` to be installed.
 
     """
 
@@ -152,6 +146,7 @@ class StacApi:
     health_check: Callable[[], dict] | Callable[[], Awaitable[dict]] = attr.ib(
         default=lambda: {"status": "UP"}
     )
+    add_metrics: bool = attr.ib(default=False)
 
     def get_extension(self, extension: type[ApiExtension]) -> ApiExtension | None:
         """Get an extension.
@@ -487,7 +482,10 @@ class StacApi:
         for middleware in self.middlewares:
             self.app.user_middleware.insert(0, middleware)
 
-        add_metrics(self.app)
+        if self.add_metrics:
+            from stac_fastapi.api.metrics import instrument_app
+
+            instrument_app(self.app)
 
         # customize route dependencies
         for scopes, dependencies in self.route_dependencies:

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -485,7 +485,10 @@ class StacApi:
         if self.add_metrics:
             from stac_fastapi.api.metrics import instrument_app
 
-            instrument_app(self.app)
+            instrument_app(
+                self.app,
+                endpoint=f"{self.app.state.router_prefix}/_mgmt/metrics",
+            )
 
         # customize route dependencies
         for scopes, dependencies in self.route_dependencies:

--- a/stac_fastapi/api/stac_fastapi/api/app.py
+++ b/stac_fastapi/api/stac_fastapi/api/app.py
@@ -41,6 +41,16 @@ from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.search import BaseSearchGetRequest, BaseSearchPostRequest
 
 
+def add_metrics(app: FastAPI) -> None:
+    """Expose Prometheus metrics when the optional metrics extra is installed."""
+    try:
+        from stac_fastapi.api.metrics import instrument_app
+    except ImportError:
+        return
+
+    instrument_app(app)
+
+
 @attr.s
 class StacApi:
     """StacApi factory.
@@ -476,6 +486,8 @@ class StacApi:
 
         for middleware in self.middlewares:
             self.app.user_middleware.insert(0, middleware)
+
+        add_metrics(self.app)
 
         # customize route dependencies
         for scopes, dependencies in self.route_dependencies:

--- a/stac_fastapi/api/stac_fastapi/api/metrics.py
+++ b/stac_fastapi/api/stac_fastapi/api/metrics.py
@@ -103,13 +103,7 @@ def record_stac_metrics(info: Info) -> None:
     LATENCY.labels(operation, info.method).observe(info.modified_duration)
 
 
-def metrics_endpoint(app: FastAPI) -> str:
-    """Return the Prometheus scrape path under ``/_mgmt``."""
-    prefix = getattr(app.state, "router_prefix", "") or ""
-    return f"{prefix}/_mgmt/metrics".replace("//", "/")
-
-
-def instrument_app(app: FastAPI, endpoint: str | None = None) -> None:
+def instrument_app(app: FastAPI, endpoint: str) -> None:
     """Instrument a FastAPI app and expose Prometheus metrics.
 
     Must be called during app construction (e.g. from ``StacApi``), before any
@@ -124,8 +118,6 @@ def instrument_app(app: FastAPI, endpoint: str | None = None) -> None:
             "`stac-fastapi-api[metrics]`. Install with: "
             "pip install 'stac-fastapi-api[metrics]'"
         )
-
-    endpoint = endpoint or metrics_endpoint(app)
 
     (
         Instrumentator(

--- a/stac_fastapi/api/stac_fastapi/api/metrics.py
+++ b/stac_fastapi/api/stac_fastapi/api/metrics.py
@@ -2,14 +2,37 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from prometheus_client import REGISTRY, Counter, Histogram
-from prometheus_fastapi_instrumentator import Instrumentator
-from prometheus_fastapi_instrumentator.metrics import Info
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
+
+try:
+    from prometheus_client import REGISTRY, Counter, Histogram
+    from prometheus_fastapi_instrumentator import Instrumentator
+    from prometheus_fastapi_instrumentator.metrics import Info
+
+    REQUESTS: Any = Counter(
+        "http_requests_total",
+        "Total HTTP requests by STAC operation.",
+        labelnames=("operation", "method", "status"),
+        registry=REGISTRY,
+    )
+    LATENCY: Any = Histogram(
+        "http_request_duration_seconds",
+        "HTTP request latency by STAC operation.",
+        labelnames=("operation", "method"),
+        buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, float("inf")),
+        registry=REGISTRY,
+    )
+except ImportError:  # pragma: no cover
+    REGISTRY = None  # type: ignore
+    Counter = None  # type: ignore
+    Histogram = None  # type: ignore
+    Instrumentator = None  # type: ignore
+    Info = None  # type: ignore
+    REQUESTS = None
+    LATENCY = None
 
 OPERATIONS: dict[tuple[str, str], str] = {
     ("GET", "/"): "landing",
@@ -69,21 +92,6 @@ def resolve_operation(method: str, route: str | None, router_prefix: str = "") -
     return "unknown"
 
 
-REQUESTS = Counter(
-    "http_requests_total",
-    "Total HTTP requests by STAC operation.",
-    labelnames=("operation", "method", "status"),
-    registry=REGISTRY,
-)
-LATENCY = Histogram(
-    "http_request_duration_seconds",
-    "HTTP request latency by STAC operation.",
-    labelnames=("operation", "method"),
-    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, float("inf")),
-    registry=REGISTRY,
-)
-
-
 def record_stac_metrics(info: Info) -> None:
     """Record request count and latency using STAC operation labels."""
     route = info.request.scope.get("route")
@@ -106,7 +114,17 @@ def instrument_app(app: FastAPI, endpoint: str | None = None) -> None:
 
     Must be called during app construction (e.g. from ``StacApi``), before any
     requests. Adding middleware after the app has started is not supported.
+
+    Raises:
+        ImportError: If ``stac-fastapi-api[metrics]`` is not installed.
     """
+    if Instrumentator is None:
+        raise ImportError(
+            "Prometheus metrics require the optional dependency "
+            "`stac-fastapi-api[metrics]`. Install with: "
+            "pip install 'stac-fastapi-api[metrics]'"
+        )
+
     endpoint = endpoint or metrics_endpoint(app)
 
     (

--- a/stac_fastapi/api/stac_fastapi/api/metrics.py
+++ b/stac_fastapi/api/stac_fastapi/api/metrics.py
@@ -1,0 +1,147 @@
+"""Prometheus metrics with low-cardinality STAC operation labels."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from prometheus_client import REGISTRY, Counter, Histogram
+from prometheus_fastapi_instrumentator import Instrumentator
+from prometheus_fastapi_instrumentator.metrics import Info
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+OPERATIONS: dict[tuple[str, str], str] = {
+    ("GET", "/"): "landing",
+    ("GET", "/conformance"): "conformance",
+    ("GET", "/collections"): "list_collections",
+    ("GET", "/collections/{collection_id}"): "get_collection",
+    ("GET", "/collections/{collection_id}/items"): "list_items",
+    ("GET", "/collections/{collection_id}/items/{item_id}"): "get_item",
+    ("GET", "/search"): "search",
+    ("POST", "/search"): "search",
+    ("POST", "/collections"): "create_collection",
+    ("PUT", "/collections/{collection_id}"): "edit_collection",
+    ("PATCH", "/collections/{collection_id}"): "edit_collection",
+    ("DELETE", "/collections/{collection_id}"): "delete_collection",
+    ("POST", "/collections/{collection_id}/items"): "create_item",
+    ("PUT", "/collections/{collection_id}/items/{item_id}"): "edit_item",
+    ("PATCH", "/collections/{collection_id}/items/{item_id}"): "edit_item",
+    ("DELETE", "/collections/{collection_id}/items/{item_id}"): "delete_item",
+    ("POST", "/collections/{collection_id}/bulk_items"): "bulk",
+    ("GET", "/queryables"): "queryables",
+    ("GET", "/collections/{collection_id}/queryables"): "queryables",
+    ("GET", "/aggregations"): "aggregations",
+    ("POST", "/aggregations"): "aggregations",
+    ("GET", "/collections/{collection_id}/aggregations"): "aggregations",
+    ("POST", "/collections/{collection_id}/aggregations"): "aggregations",
+    ("GET", "/aggregate"): "aggregate",
+    ("POST", "/aggregate"): "aggregate",
+    ("GET", "/collections/{collection_id}/aggregate"): "aggregate",
+    ("POST", "/collections/{collection_id}/aggregate"): "aggregate",
+}
+
+
+def register_operations(mapping: dict[tuple[str, str], str]) -> None:
+    """Register or override operation labels for route templates."""
+    OPERATIONS.update(mapping)
+
+
+def resolve_operation(method: str, route: str | None, router_prefix: str = "") -> str:
+    """Map a request method and route template to a STAC operation label."""
+    if not route or route == "none":
+        return "unknown"
+
+    path = route
+    prefix = (router_prefix or "").rstrip("/")
+    if prefix and path.startswith(prefix):
+        path = path[len(prefix) :] or "/"
+
+    operation = OPERATIONS.get((method.upper(), path))
+    if operation:
+        return operation
+
+    if path.startswith("/catalogs"):
+        return "catalog"
+    if "bulk" in path:
+        return "bulk"
+
+    return "unknown"
+
+
+def _metric_or_none(factory):
+    try:
+        return factory()
+    except ValueError as exc:
+        if "Duplicated timeseries in CollectorRegistry" not in str(exc):
+            raise
+        return None
+
+
+REQUESTS = _metric_or_none(
+    lambda: Counter(
+        "http_requests_total",
+        "Total HTTP requests by STAC operation.",
+        labelnames=("operation", "method", "status"),
+        registry=REGISTRY,
+    )
+)
+LATENCY = _metric_or_none(
+    lambda: Histogram(
+        "http_request_duration_seconds",
+        "HTTP request latency by STAC operation.",
+        labelnames=("operation", "method"),
+        buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, float("inf")),
+        registry=REGISTRY,
+    )
+)
+
+
+def record_stac_metrics(info: Info) -> None:
+    """Record request count and latency using STAC operation labels."""
+    route = info.request.scope.get("route")
+    route_path = getattr(route, "path", None)
+    router_prefix = getattr(info.request.app.state, "router_prefix", "") or ""
+    operation = resolve_operation(info.method, route_path, router_prefix)
+
+    if REQUESTS is not None:
+        REQUESTS.labels(operation, info.method, info.modified_status).inc()
+    if LATENCY is not None:
+        LATENCY.labels(operation, info.method).observe(info.modified_duration)
+
+
+def metrics_endpoint(app: FastAPI) -> str:
+    """Return the Prometheus scrape path under ``/_mgmt``."""
+    prefix = getattr(app.state, "router_prefix", "") or ""
+    return f"{prefix}/_mgmt/metrics".replace("//", "/")
+
+
+def instrument_app(app: FastAPI, endpoint: str | None = None) -> None:
+    """Instrument a FastAPI app and expose Prometheus metrics.
+
+    Must be called during app construction (e.g. from ``StacApi``), before any
+    requests. Adding middleware after the app has started is not supported.
+    """
+    if getattr(app.state, "stac_metrics_instrumented", False):
+        return
+
+    if app.middleware_stack is not None:
+        raise RuntimeError(
+            "Cannot instrument metrics after the application has started. "
+            "Call instrument_app during app construction (before any requests), "
+            "not after startup."
+        )
+
+    endpoint = endpoint or metrics_endpoint(app)
+
+    (
+        Instrumentator(
+            should_group_status_codes=True,
+            should_ignore_untemplated=True,
+            excluded_handlers=[".*/_mgmt/.*"],
+        )
+        .add(record_stac_metrics)
+        .instrument(app)
+        .expose(app, endpoint=endpoint, include_in_schema=False)
+    )
+    app.state.stac_metrics_instrumented = True

--- a/stac_fastapi/api/stac_fastapi/api/metrics.py
+++ b/stac_fastapi/api/stac_fastapi/api/metrics.py
@@ -69,31 +69,18 @@ def resolve_operation(method: str, route: str | None, router_prefix: str = "") -
     return "unknown"
 
 
-def _metric_or_none(factory):
-    try:
-        return factory()
-    except ValueError as exc:
-        if "Duplicated timeseries in CollectorRegistry" not in str(exc):
-            raise
-        return None
-
-
-REQUESTS = _metric_or_none(
-    lambda: Counter(
-        "http_requests_total",
-        "Total HTTP requests by STAC operation.",
-        labelnames=("operation", "method", "status"),
-        registry=REGISTRY,
-    )
+REQUESTS = Counter(
+    "http_requests_total",
+    "Total HTTP requests by STAC operation.",
+    labelnames=("operation", "method", "status"),
+    registry=REGISTRY,
 )
-LATENCY = _metric_or_none(
-    lambda: Histogram(
-        "http_request_duration_seconds",
-        "HTTP request latency by STAC operation.",
-        labelnames=("operation", "method"),
-        buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, float("inf")),
-        registry=REGISTRY,
-    )
+LATENCY = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request latency by STAC operation.",
+    labelnames=("operation", "method"),
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, float("inf")),
+    registry=REGISTRY,
 )
 
 
@@ -104,10 +91,8 @@ def record_stac_metrics(info: Info) -> None:
     router_prefix = getattr(info.request.app.state, "router_prefix", "") or ""
     operation = resolve_operation(info.method, route_path, router_prefix)
 
-    if REQUESTS is not None:
-        REQUESTS.labels(operation, info.method, info.modified_status).inc()
-    if LATENCY is not None:
-        LATENCY.labels(operation, info.method).observe(info.modified_duration)
+    REQUESTS.labels(operation, info.method, info.modified_status).inc()
+    LATENCY.labels(operation, info.method).observe(info.modified_duration)
 
 
 def metrics_endpoint(app: FastAPI) -> str:
@@ -122,16 +107,6 @@ def instrument_app(app: FastAPI, endpoint: str | None = None) -> None:
     Must be called during app construction (e.g. from ``StacApi``), before any
     requests. Adding middleware after the app has started is not supported.
     """
-    if getattr(app.state, "stac_metrics_instrumented", False):
-        return
-
-    if app.middleware_stack is not None:
-        raise RuntimeError(
-            "Cannot instrument metrics after the application has started. "
-            "Call instrument_app during app construction (before any requests), "
-            "not after startup."
-        )
-
     endpoint = endpoint or metrics_endpoint(app)
 
     (
@@ -144,4 +119,3 @@ def instrument_app(app: FastAPI, endpoint: str | None = None) -> None:
         .instrument(app)
         .expose(app, endpoint=endpoint, include_in_schema=False)
     )
-    app.state.stac_metrics_instrumented = True

--- a/stac_fastapi/api/tests/test_metrics.py
+++ b/stac_fastapi/api/tests/test_metrics.py
@@ -5,16 +5,10 @@ from fastapi.testclient import TestClient
 from stac_fastapi.api import app
 from stac_fastapi.api.metrics import (
     OPERATIONS,
-    metrics_endpoint,
     register_operations,
     resolve_operation,
 )
 from stac_fastapi.types.config import ApiSettings
-
-
-class _App:
-    def __init__(self, router_prefix: str = ""):
-        self.state = type("S", (), {"router_prefix": router_prefix})()
 
 
 @pytest.mark.parametrize(
@@ -32,14 +26,6 @@ class _App:
 )
 def test_resolve_operation(method, route, router_prefix, expected):
     assert resolve_operation(method, route, router_prefix) == expected
-
-
-@pytest.mark.parametrize(
-    ("router_prefix", "expected"),
-    [("", "/_mgmt/metrics"), ("/api", "/api/_mgmt/metrics")],
-)
-def test_metrics_endpoint(router_prefix, expected):
-    assert metrics_endpoint(_App(router_prefix)) == expected
 
 
 def test_register_operations():
@@ -107,4 +93,4 @@ def test_instrument_app_requires_metrics_extra(monkeypatch):
     monkeypatch.setattr(metrics, "Instrumentator", None)
 
     with pytest.raises(ImportError, match=r"stac-fastapi-api\[metrics\]"):
-        metrics.instrument_app(FastAPI())
+        metrics.instrument_app(FastAPI(), endpoint="/_mgmt/metrics")

--- a/stac_fastapi/api/tests/test_metrics.py
+++ b/stac_fastapi/api/tests/test_metrics.py
@@ -1,0 +1,96 @@
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from stac_fastapi.api import app
+from stac_fastapi.api.metrics import (
+    OPERATIONS,
+    instrument_app,
+    metrics_endpoint,
+    register_operations,
+    resolve_operation,
+)
+from stac_fastapi.types.config import ApiSettings
+
+
+class _App:
+    def __init__(self, router_prefix: str = ""):
+        self.state = type("S", (), {"router_prefix": router_prefix})()
+
+
+@pytest.mark.parametrize(
+    ("method", "route", "router_prefix", "expected"),
+    [
+        ("GET", "/search", "", "search"),
+        ("GET", "/collections/{collection_id}/items/{item_id}", "", "get_item"),
+        ("POST", "/collections/{collection_id}/bulk_items", "", "bulk"),
+        ("GET", "/aggregations", "", "aggregations"),
+        ("GET", "/_mgmt/health", "", "unknown"),
+        ("GET", "/catalogs/root", "", "catalog"),
+        ("GET", "/api/search", "/api", "search"),
+        ("GET", "none", "", "unknown"),
+    ],
+)
+def test_resolve_operation(method, route, router_prefix, expected):
+    assert resolve_operation(method, route, router_prefix) == expected
+
+
+@pytest.mark.parametrize(
+    ("router_prefix", "expected"),
+    [("", "/_mgmt/metrics"), ("/api", "/api/_mgmt/metrics")],
+)
+def test_metrics_endpoint(router_prefix, expected):
+    assert metrics_endpoint(_App(router_prefix)) == expected
+
+
+def test_register_operations():
+    key = ("GET", "/custom/viewer")
+    previous = OPERATIONS.pop(key, None)
+    try:
+        register_operations({key: "viewer"})
+        assert resolve_operation("GET", "/custom/viewer") == "viewer"
+    finally:
+        if previous is None:
+            OPERATIONS.pop(key, None)
+        else:
+            OPERATIONS[key] = previous
+
+
+def test_metrics_operation_labels(TestCoreClient):
+    test_app = app.StacApi(
+        settings=ApiSettings(),
+        client=TestCoreClient(),
+    )
+
+    with TestClient(test_app.app) as client:
+        assert client.get("/search", params={"limit": 1}).status_code == 200
+        assert client.get("/collections/c/items/item-a").status_code == 200
+        assert client.get("/collections/c/items/item-b").status_code == 200
+        body = client.get("/_mgmt/metrics").text
+
+    assert 'operation="search"' in body
+    assert 'operation="get_item"' in body
+    assert "item-a" not in body
+    assert "item-b" not in body
+
+
+def test_metrics_router_prefix(TestCoreClient):
+    test_app = app.StacApi(
+        settings=ApiSettings(),
+        client=TestCoreClient(),
+        router=APIRouter(prefix="/api"),
+    )
+
+    with TestClient(test_app.app) as client:
+        assert client.get("/_mgmt/metrics").status_code == 404
+        resp = client.get("/api/_mgmt/metrics")
+        assert resp.status_code == 200
+        assert "http_requests_total" in resp.text
+
+
+def test_instrument_app_rejects_post_startup():
+    fastapi_app = FastAPI()
+    fastapi_app.middleware_stack = object()
+
+    with pytest.raises(RuntimeError, match="after the application has started"):
+        instrument_app(fastapi_app)

--- a/stac_fastapi/api/tests/test_metrics.py
+++ b/stac_fastapi/api/tests/test_metrics.py
@@ -1,11 +1,10 @@
 import pytest
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter
 from fastapi.testclient import TestClient
 
 from stac_fastapi.api import app
 from stac_fastapi.api.metrics import (
     OPERATIONS,
-    instrument_app,
     metrics_endpoint,
     register_operations,
     resolve_operation,
@@ -60,6 +59,7 @@ def test_metrics_operation_labels(TestCoreClient):
     test_app = app.StacApi(
         settings=ApiSettings(),
         client=TestCoreClient(),
+        add_metrics=True,
     )
 
     with TestClient(test_app.app) as client:
@@ -79,6 +79,7 @@ def test_metrics_router_prefix(TestCoreClient):
         settings=ApiSettings(),
         client=TestCoreClient(),
         router=APIRouter(prefix="/api"),
+        add_metrics=True,
     )
 
     with TestClient(test_app.app) as client:
@@ -88,9 +89,11 @@ def test_metrics_router_prefix(TestCoreClient):
         assert "http_requests_total" in resp.text
 
 
-def test_instrument_app_rejects_post_startup():
-    fastapi_app = FastAPI()
-    fastapi_app.middleware_stack = object()
+def test_metrics_disabled_by_default(TestCoreClient):
+    test_app = app.StacApi(
+        settings=ApiSettings(),
+        client=TestCoreClient(),
+    )
 
-    with pytest.raises(RuntimeError, match="after the application has started"):
-        instrument_app(fastapi_app)
+    with TestClient(test_app.app) as client:
+        assert client.get("/_mgmt/metrics").status_code == 404

--- a/stac_fastapi/api/tests/test_metrics.py
+++ b/stac_fastapi/api/tests/test_metrics.py
@@ -97,3 +97,14 @@ def test_metrics_disabled_by_default(TestCoreClient):
 
     with TestClient(test_app.app) as client:
         assert client.get("/_mgmt/metrics").status_code == 404
+
+
+def test_instrument_app_requires_metrics_extra(monkeypatch):
+    from fastapi import FastAPI
+
+    import stac_fastapi.api.metrics as metrics
+
+    monkeypatch.setattr(metrics, "Instrumentator", None)
+
+    with pytest.raises(ImportError, match=r"stac-fastapi-api\[metrics\]"):
+        metrics.instrument_app(FastAPI())

--- a/uv.lock
+++ b/uv.lock
@@ -1522,6 +1522,28 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "prometheus-fastapi-instrumentator"
+version = "8.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prometheus-client" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/e9/2065686d1dfa62296fdc158b6e8fd25b0cb3dca09b0632cabeb5ae81fe4d/prometheus_fastapi_instrumentator-8.0.2.tar.gz", hash = "sha256:3c252e748151768a7aefd66824a04a870144f71de48a67aed211749a9ca2a548", size = 21342, upload-time = "2026-06-23T09:39:31.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/c7/fa2b3f469a2e6001b829e0d6bc8680755349aa1329a87bf48731e9d5d30a/prometheus_fastapi_instrumentator-8.0.2-py3-none-any.whl", hash = "sha256:746002ec1e2c58b93f61444e1d104de959a9463a6a3f1c8909ac3757e16c3866", size = 20549, upload-time = "2026-06-23T09:39:32.616Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -2183,6 +2205,7 @@ dependencies = [
 dev = [
     { name = "httpx2" },
     { name = "pre-commit" },
+    { name = "prometheus-fastapi-instrumentator" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
@@ -2209,6 +2232,7 @@ requires-dist = [
 dev = [
     { name = "httpx2" },
     { name = "pre-commit" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=8,<9" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
@@ -2232,6 +2256,11 @@ dependencies = [
     { name = "stac-fastapi-types" },
 ]
 
+[package.optional-dependencies]
+metrics = [
+    { name = "prometheus-fastapi-instrumentator" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
@@ -2244,8 +2273,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "brotli-asgi" },
+    { name = "prometheus-fastapi-instrumentator", marker = "extra == 'metrics'", specifier = ">=8,<9" },
     { name = "stac-fastapi-types", editable = "stac_fastapi/types" },
 ]
+provides-extras = ["metrics"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -2232,7 +2232,7 @@ requires-dist = [
 dev = [
     { name = "httpx2" },
     { name = "pre-commit" },
-    { name = "prometheus-fastapi-instrumentator", specifier = ">=8,<9" },
+    { name = "prometheus-fastapi-instrumentator", specifier = ">=8" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
@@ -2273,7 +2273,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "brotli-asgi" },
-    { name = "prometheus-fastapi-instrumentator", marker = "extra == 'metrics'", specifier = ">=8,<9" },
+    { name = "prometheus-fastapi-instrumentator", marker = "extra == 'metrics'", specifier = ">=8" },
     { name = "stac-fastapi-types", editable = "stac_fastapi/types" },
 ]
 provides-extras = ["metrics"]


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stac-fastapi-pgstac/pull/398

**Description:**

- Optional Prometheus metrics via `stac-fastapi-api[metrics]`, exposed at `{router_prefix}/_mgmt/metrics` when the extra is installed (same opt-in pattern as [sfeos](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch)).
- Uses low-cardinality STAC `operation` labels (`search`, `get_item`, …) instead of default path-based labels, per the approach discussed in https://github.com/developmentseed/eoAPI/issues/193#issuecomment-4353287562.
- Backends can map custom routes with `register_operations`.

Concretely, things to discuss if this is desired:

- Without `[metrics]`, app still starts and no metrics route is registered
- With `[metrics]`, `/_mgmt/metrics` returns series labeled by `operation`
- Item/collection IDs do not appear in label values
- With a router prefix, metrics are at `{prefix}/_mgmt/metrics`

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
