### PR TITLE
feat: improve security by not returning uncaught exceptions to end-users

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Removed explicit error handler for uncaught exceptions, improving security by preventing sensitive information from being exposed in error responses. ([#966](https://github.com/stac-utils/stac-fastapi/pull/966))
+
 ## [6.5.0] - 2026-08-03
 
 ### Added

--- a/stac_fastapi/api/stac_fastapi/api/errors.py
+++ b/stac_fastapi/api/stac_fastapi/api/errors.py
@@ -27,7 +27,6 @@ DEFAULT_STATUS_CODES = {
     ConflictError: status.HTTP_409_CONFLICT,
     ForeignKeyError: status.HTTP_424_FAILED_DEPENDENCY,
     DatabaseError: status.HTTP_424_FAILED_DEPENDENCY,
-    Exception: status.HTTP_500_INTERNAL_SERVER_ERROR,
     InvalidQueryParameter: status.HTTP_400_BAD_REQUEST,
     ResponseValidationError: status.HTTP_500_INTERNAL_SERVER_ERROR,
 }


### PR DESCRIPTION
**Description:**
By having an exception handler for the Python base `Exception`, all uncaught exception messages will be returned to the end-user. For security purposes, it is better to show a generic error message for uncaught exceptions as these might contain sensitive information. On the other hand, error handling for validating and processing user input can be improved in the application itself, eg. by explicitly raising an `HTTPException` with code `400` when parsing of a filter string fails.

This PR proposes to remove the exception handler for the `Exception` type, as a result end-users will get a generic `HTTP 500` response without detail of the underlying exception raised.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
