### PR TITLE
Revert "feat: remove port/host/reload settings (#964)"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,6 @@
 
 ### Changed
 
-- Removed `app_host`, `app_port`, and `reload` attributes from `ApiSettings`.
 - Removed explicit error handler for uncaught exceptions, improving security by preventing sensitive information from being exposed in error responses. ([#966](https://github.com/stac-utils/stac-fastapi/pull/966))
 
 ## [6.5.0] - 2026-08-03

--- a/stac_fastapi/types/stac_fastapi/types/config.py
+++ b/stac_fastapi/types/stac_fastapi/types/config.py
@@ -28,6 +28,10 @@ class ApiSettings(BaseSettings):
     stac_fastapi_version: str = "0.1"
     stac_fastapi_landing_id: str = "stac-fastapi"
 
+    app_host: str = "0.0.0.0"
+    app_port: int = 8000
+    reload: bool = True
+
     # Enable Pydantic validation for output Response
     enable_response_models: bool = False
 


### PR DESCRIPTION
This reverts commit df6d822aaa13920e6ea54ccb34617ec0b47474d0.

**Related Issue(s):**

- #964 

**Description:**

Revert changes that were merged prematurely. These changes will be merged for v7.0.0.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
