### PR TITLE
remove: deprecated sort conformace classes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Changed output from `string` to `dict` object (`BulkTransaction`) for bulk transaction `bulk_item_insert` methods. 
 - Removed `app_host`, `app_port`, and `reload` attributes from `ApiSettings`.
+- Removed deprecated `SortConformanceClasses` enum aliases (`COLLECTIONS`, `ITEMS`, `SEARCH`). Use `COLLECTION_SEARCH_SORT`, `FEATURES_SORT`, and `ITEM_SEARCH_SORT` instead.
 
 ## [6.6.0] - 2026-08-31
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,10 @@
 
 - Changed output from `string` to `dict` object (`BulkTransaction`) for bulk transaction `bulk_item_insert` methods. 
 - Removed `app_host`, `app_port`, and `reload` attributes from `ApiSettings`.
-- Removed deprecated `SortConformanceClasses` enum aliases (`COLLECTIONS`, `ITEMS`, `SEARCH`). Use `COLLECTION_SEARCH_SORT`, `FEATURES_SORT`, and `ITEM_SEARCH_SORT` instead.
+
+### Removed
+
+- Removed deprecated `SortConformanceClasses` enum aliases (`COLLECTIONS`, `ITEMS`, `SEARCH`). Use `COLLECTION_SEARCH_SORT`, `FEATURES_SORT`, and `ITEM_SEARCH_SORT` instead. ([#979](https://github.com/stac-utils/stac-fastapi/pull/979))
 
 ## [6.6.0] - 2026-08-31
 

--- a/stac_fastapi/extensions/stac_fastapi/extensions/sort/sort.py
+++ b/stac_fastapi/extensions/stac_fastapi/extensions/sort/sort.py
@@ -1,7 +1,6 @@
 """Sort extension."""
 
-import warnings
-from enum import EnumMeta, StrEnum
+from enum import StrEnum
 from typing import Any
 
 import attr
@@ -51,69 +50,7 @@ class SortablesSchema(BaseModel):
     }
 
 
-class _DeprecatedMemberMeta(EnumMeta):
-    """TODO: Remove this metaclass in 7.0.0."""
-
-    def __getattr__(cls, name: str):
-        match name:
-            case "COLLECTIONS":
-                warnings.warn(
-                    "'COLLECTIONS' will be removed in a future version, "
-                    "use 'COLLECTION_SEARCH_SORT' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return cls.COLLECTION_SEARCH_SORT
-            case "ITEMS":
-                warnings.warn(
-                    "'ITEMS' will be removed in a future version, "
-                    "use 'FEATURES_SORT' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return cls.FEATURES_SORT
-            case "SEARCH":
-                warnings.warn(
-                    "'SEARCH' will be removed in a future version, "
-                    "use 'ITEM_SEARCH_SORT' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return cls.ITEM_SEARCH_SORT
-
-        raise AttributeError(f"'{cls.__name__}' has no attribute '{name}'")
-
-    def __getitem__(cls, name: str):
-        match name:
-            case "COLLECTIONS":
-                warnings.warn(
-                    "'COLLECTIONS' will be removed in a future version, "
-                    "use 'COLLECTION_SEARCH_SORT' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return cls.COLLECTION_SEARCH_SORT
-            case "ITEMS":
-                warnings.warn(
-                    "'ITEMS' will be removed in a future version, "
-                    "use 'FEATURES_SORT' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return cls.FEATURES_SORT
-            case "SEARCH":
-                warnings.warn(
-                    "'SEARCH' will be removed in a future version, "
-                    "use 'ITEM_SEARCH_SORT' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return cls.ITEM_SEARCH_SORT
-
-        return super().__getitem__(name)
-
-
-class SortConformanceClasses(StrEnum, metaclass=_DeprecatedMemberMeta):
+class SortConformanceClasses(StrEnum):
     """Conformance classes for the Sort v1.1.0 extension.
 
     See https://github.com/stac-api-extensions/sort

--- a/stac_fastapi/extensions/tests/test_sort.py
+++ b/stac_fastapi/extensions/tests/test_sort.py
@@ -90,42 +90,6 @@ def test_sort_conformance_classes():
         == "https://api.stacspec.org/v1.1.0/collection-search#sortables"
     )
 
-    with pytest.warns(DeprecationWarning):
-        assert (
-            SortConformanceClasses.COLLECTIONS
-            == "https://api.stacspec.org/v1.1.0/collection-search#sort"
-        )
-
-    with pytest.warns(DeprecationWarning):
-        assert (
-            SortConformanceClasses["COLLECTIONS"]
-            == "https://api.stacspec.org/v1.1.0/collection-search#sort"
-        )
-
-    with pytest.warns(DeprecationWarning):
-        assert (
-            SortConformanceClasses.ITEMS
-            == "https://api.stacspec.org/v1.1.0/ogcapi-features#sort"
-        )
-
-    with pytest.warns(DeprecationWarning):
-        assert (
-            SortConformanceClasses["ITEMS"]
-            == "https://api.stacspec.org/v1.1.0/ogcapi-features#sort"
-        )
-
-    with pytest.warns(DeprecationWarning):
-        assert (
-            SortConformanceClasses.SEARCH
-            == "https://api.stacspec.org/v1.1.0/item-search#sort"
-        )
-
-    with pytest.warns(DeprecationWarning):
-        assert (
-            SortConformanceClasses["SEARCH"]
-            == "https://api.stacspec.org/v1.1.0/item-search#sort"
-        )
-
 
 def test_sort_extension_defaults():
     """Test the default instantiation of the SortExtension."""


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

- Removed deprecated `SortConformanceClasses` enum aliases (`COLLECTIONS`, `ITEMS`, `SEARCH`). Use `COLLECTION_SEARCH_SORT`, `FEATURES_SORT`, and `ITEM_SEARCH_SORT` instead. 

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `make test`)
- [x] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
