### PR TITLE
fix: remove deprecated CORSMiddleware

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
 
 - Removed `app_host`, `app_port`, and `reload` attributes from `ApiSettings`. ([#973](https://github.com/stac-utils/stac-fastapi/pull/973))
 - Removed deprecated `stac_fastapi.extensions.core` namespace. Import extensions directly from `stac_fastapi.extensions` instead. ([#978](https://github.com/stac-utils/stac-fastapi/pull/978))
+- Removed `CORSMiddleware` subclass from `stac_fastapi.api.middleware`. Use `starlette.middleware.cors.CORSMiddleware` instead.
 
 ### Removed
 

--- a/docs/src/tips-and-tricks.md
+++ b/docs/src/tips-and-tricks.md
@@ -18,7 +18,8 @@ By default the `StacApi` class will enable 3 Middlewares (`BrotliMiddleware`, `C
 from starlette.middleware import Middleware
 
 from stac_fastapi.api.app import StacApi
-from stac_fastapi.api.middleware import CORSMiddleware
+from starlette.middleware.cors import CORSMiddleware
+
 
 api = StacApi(
     ...

--- a/stac_fastapi/api/stac_fastapi/api/middleware.py
+++ b/stac_fastapi/api/stac_fastapi/api/middleware.py
@@ -2,56 +2,9 @@
 
 import contextlib
 import re
-import typing
-import warnings
 from http.client import HTTP_PORT, HTTPS_PORT
 
-from starlette.middleware.cors import CORSMiddleware as _CORSMiddleware
 from starlette.types import ASGIApp, Receive, Scope, Send
-
-
-class CORSMiddleware(_CORSMiddleware):
-    """Subclass of Starlette's standard CORS middleware with default values set to those
-    recommended by the STAC API spec.
-
-    https://github.com/radiantearth/stac-api-spec/blob/914cf8108302e2ec734340080a45aaae4859bb63/implementation.md#cors
-    """
-
-    def __init__(
-        self,
-        app: ASGIApp,
-        allow_origins: typing.Sequence[str] = ("*",),
-        allow_methods: typing.Sequence[str] = (
-            "OPTIONS",
-            "POST",
-            "GET",
-        ),
-        allow_headers: typing.Sequence[str] = ("Content-Type",),
-        allow_credentials: bool = False,
-        allow_origin_regex: str | None = None,
-        expose_headers: typing.Sequence[str] = (),
-        max_age: int = 600,
-        **kwargs: typing.Any,
-    ) -> None:
-        """Create CORS middleware."""
-        warnings.warn(
-            """stac_fastapi.api.middleware.CORSMiddleware is deprecated and
-            will be removed in a future release.
-            Please use starlette.middleware.cors.CORSMiddleware instead.""",
-            DeprecationWarning,
-        )
-        super().__init__(
-            app,
-            allow_origins=allow_origins,
-            allow_methods=allow_methods,
-            allow_headers=allow_headers,
-            allow_credentials=allow_credentials,
-            allow_origin_regex=allow_origin_regex,
-            expose_headers=expose_headers,
-            max_age=max_age,
-            **kwargs,
-        )
-
 
 _PROTO_HEADER_REGEX = re.compile(r"proto=(?P<proto>http(s)?)")
 _HOST_HEADER_REGEX = re.compile(r"host=(?P<host>[\w.-]+)(:(?P<port>\d{1,5}))?")


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
